### PR TITLE
Fix/restrictive cors

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
-# PostgreSQL connection string
-# Format: postgres://<username>:<password>@<host>:<port>/<database_name>
-DATABASE_URL=postgres://<USER>:<PASSWORD>@<HOST>:<PORT>/<DATABASE_NAME>
+# PostgreSQL credentials (used by both the db service and the app's DATABASE_URL)
+POSTGRES_USER=<USER>
+POSTGRES_PASSWORD=<PASSWORD>
+POSTGRES_DB=soroban_pulse
+
+# PostgreSQL connection string — must match the credentials above
+# Format: postgres://<POSTGRES_USER>:<POSTGRES_PASSWORD>@db:5432/<POSTGRES_DB>
+DATABASE_URL=postgres://<USER>:<PASSWORD>@db:5432/soroban_pulse
 
 # PostgreSQL connection pool sizing
 DB_MAX_CONNECTIONS=10

--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,7 @@ RUST_LOG=info
 # If left unset, authentication is bypassed entirely.
 # Format: string (e.g., your-super-secret-key-123)
 # API_KEY=
+
+# Allowed CORS origins (comma-separated). Use * to allow all origins (local dev only).
+# Example: ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
+ALLOWED_ORIGINS=*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.env
+docker-compose.override.yml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ services:
   db:
     image: postgres:16-alpine
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: soroban_pulse
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - "5432:5432"
     volumes:
@@ -15,11 +15,11 @@ services:
     depends_on:
       - db
     environment:
-      DATABASE_URL: postgres://postgres:password@db:5432/soroban_pulse
-      STELLAR_RPC_URL: https://soroban-testnet.stellar.org
-      START_LEDGER: 0
-      PORT: 3000
-      RUST_LOG: info
+      DATABASE_URL: ${DATABASE_URL}
+      STELLAR_RPC_URL: ${STELLAR_RPC_URL}
+      START_LEDGER: ${START_LEDGER}
+      PORT: ${PORT}
+      RUST_LOG: ${RUST_LOG}
     ports:
       - "3000:3000"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub db_max_connections: u32,
     pub db_min_connections: u32,
     pub behind_proxy: bool,
+    pub allowed_origins: Vec<String>,
 }
 
 impl Config {
@@ -41,6 +42,12 @@ impl Config {
                 .parse()
                 .expect("DB_MIN_CONNECTIONS must be a number"),
             behind_proxy,
+            allowed_origins: env::var("ALLOWED_ORIGINS")
+                .unwrap_or_else(|_| "*".to_string())
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,8 @@ async fn main() {
     });
 
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
-    let router = routes::create_router(pool, config.api_key);
+    info!("Allowed CORS origins: {:?}", config.allowed_origins);
+    let router = routes::create_router(pool, config.api_key, &config.allowed_origins);
 
     info!("Soroban Pulse listening on {}", addr);
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,11 +1,14 @@
 use axum::{routing::get, Router};
+use http::{HeaderValue, Method};
 use sqlx::PgPool;
 use std::sync::Arc;
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
 use crate::{handlers, middleware};
 
-pub fn create_router(pool: PgPool, api_key: Option<String>) -> Router {
+pub fn create_router(pool: PgPool, api_key: Option<String>, allowed_origins: &[String]) -> Router {
+    let cors = build_cors(allowed_origins);
+
     let auth_state = Arc::new(middleware::AuthState { api_key });
 
     Router::new()
@@ -14,7 +17,27 @@ pub fn create_router(pool: PgPool, api_key: Option<String>) -> Router {
         .route("/events/:contract_id", get(handlers::get_events_by_contract))
         .route("/events/tx/:tx_hash", get(handlers::get_events_by_tx))
         .layer(axum::middleware::from_fn_with_state(auth_state, middleware::auth_middleware))
-        .layer(CorsLayer::permissive())
+        .layer(cors)
         .layer(TraceLayer::new_for_http())
         .with_state(pool)
+}
+
+fn build_cors(allowed_origins: &[String]) -> CorsLayer {
+    let methods = [Method::GET];
+
+    if allowed_origins.iter().any(|o| o == "*") {
+        return CorsLayer::new()
+            .allow_origin(tower_http::cors::Any)
+            .allow_methods(methods);
+    }
+
+    let origins: Vec<HeaderValue> = allowed_origins
+        .iter()
+        .filter_map(|o| o.parse().ok())
+        .collect();
+
+    CorsLayer::new()
+        .allow_origin(origins)
+        .allow_methods(methods)
+        .vary([http::header::ORIGIN])
 }


### PR DESCRIPTION
CorsLayer::permissive() allowed all origins, methods, and headers. This replaces it with an explicit configuration.

Changes:
- routes.rs — builds CorsLayer from ALLOWED_ORIGINS; methods restricted to GET; Vary: Origin set for multi-origin configs
- config.rs — parses ALLOWED_ORIGINS (comma-separated) into Vec<String>
- main.rs — logs allowed origins at startup
- .env.example — documents ALLOWED_ORIGINS

Behavior:
- Unlisted origins receive a CORS error
- ALLOWED_ORIGINS=* restores open access for local dev (default if unset)

Closes #3