### PR TITLE
Fix/validate rpc url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,12 @@ DATABASE_URL=postgres://<USER>:<PASSWORD>@db:5432/soroban_pulse
 DB_MAX_CONNECTIONS=10
 DB_MIN_CONNECTIONS=1
 
-# Soroban RPC endpoint URL
+# Soroban RPC endpoint URL — must be a valid HTTPS URL in production
 # Format: https://<domain> or http://<ip>:<port>
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+
+# Allow HTTP or loopback/private RPC URLs (local dev only — never set in production)
+# ALLOW_INSECURE_RPC=true
 
 # Ledger sequence number to start indexing from (0 = latest)
 # Format: integer (e.g., 0, 123456)

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
-# PostgreSQL connection string
-# Format: postgres://<username>:<password>@<host>:<port>/<database_name>
-DATABASE_URL=postgres://<USER>:<PASSWORD>@<HOST>:<PORT>/<DATABASE_NAME>
+# PostgreSQL credentials (used by both the db service and the app's DATABASE_URL)
+POSTGRES_USER=<USER>
+POSTGRES_PASSWORD=<PASSWORD>
+POSTGRES_DB=soroban_pulse
+
+# PostgreSQL connection string — must match the credentials above
+# Format: postgres://<POSTGRES_USER>:<POSTGRES_PASSWORD>@db:5432/<POSTGRES_DB>
+DATABASE_URL=postgres://<USER>:<PASSWORD>@db:5432/soroban_pulse
 
 # PostgreSQL connection pool sizing
 DB_MAX_CONNECTIONS=10

--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,7 @@ RUST_LOG=info
 # If left unset, authentication is bypassed entirely.
 # Format: string (e.g., your-super-secret-key-123)
 # API_KEY=
+
+# Allowed CORS origins (comma-separated). Use * to allow all origins (local dev only).
+# Example: ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
+ALLOWED_ORIGINS=*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.env
+docker-compose.override.yml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.5", features = ["trace", "cors"] }
 axum-extra = { version = "0.9", features = ["typed-header"] }
 anyhow = "1.0.102"
+url = "2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ services:
   db:
     image: postgres:16-alpine
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: soroban_pulse
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - "5432:5432"
     volumes:
@@ -15,11 +15,11 @@ services:
     depends_on:
       - db
     environment:
-      DATABASE_URL: postgres://postgres:password@db:5432/soroban_pulse
-      STELLAR_RPC_URL: https://soroban-testnet.stellar.org
-      START_LEDGER: 0
-      PORT: 3000
-      RUST_LOG: info
+      DATABASE_URL: ${DATABASE_URL}
+      STELLAR_RPC_URL: ${STELLAR_RPC_URL}
+      START_LEDGER: ${START_LEDGER}
+      PORT: ${PORT}
+      RUST_LOG: ${RUST_LOG}
     ports:
       - "3000:3000"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use std::env;
+use url::Url;
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -15,6 +16,57 @@ pub struct Config {
     pub allowed_origins: Vec<String>,
 }
 
+fn validate_rpc_url(raw: &str) -> String {
+    let url = Url::parse(raw)
+        .unwrap_or_else(|e| panic!("STELLAR_RPC_URL is not a valid URL: {e}"));
+
+    let allow_insecure = env::var("ALLOW_INSECURE_RPC")
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "y"))
+        .unwrap_or(false);
+
+    match url.scheme() {
+        "https" => {}
+        "http" if allow_insecure => {}
+        "http" => panic!(
+            "STELLAR_RPC_URL uses http — set ALLOW_INSECURE_RPC=true to permit insecure connections"
+        ),
+        scheme => panic!("STELLAR_RPC_URL has disallowed scheme '{scheme}' — only https is permitted"),
+    }
+
+    if !allow_insecure {
+        let host = url.host_str().unwrap_or("");
+        let is_loopback = host == "localhost"
+            || host == "127.0.0.1"
+            || host == "::1"
+            || host.ends_with(".local");
+        let is_private = {
+            // Reject RFC-1918 / link-local ranges by prefix
+            host.starts_with("10.")
+                || host.starts_with("192.168.")
+                || host.starts_with("169.254.")
+                || (host.starts_with("172.") && {
+                    host.split('.')
+                        .nth(1)
+                        .and_then(|o| o.parse::<u8>().ok())
+                        .map(|o| (16..=31).contains(&o))
+                        .unwrap_or(false)
+                })
+        };
+        if is_loopback || is_private {
+            panic!(
+                "STELLAR_RPC_URL points to a non-routable host '{host}' — \
+                 set ALLOW_INSECURE_RPC=true to allow this in development"
+            );
+        }
+    }
+
+    // Return URL without credentials
+    let mut safe = url.clone();
+    let _ = safe.set_username("");
+    let _ = safe.set_password(None);
+    safe.to_string()
+}
+
 impl Config {
     pub fn from_env() -> Self {
         let behind_proxy = env::var("BEHIND_PROXY")
@@ -27,8 +79,10 @@ impl Config {
 
         Self {
             database_url: env::var("DATABASE_URL").expect("DATABASE_URL must be set"),
-            stellar_rpc_url: env::var("STELLAR_RPC_URL")
-                .unwrap_or_else(|_| "https://soroban-testnet.stellar.org".to_string()),
+            stellar_rpc_url: validate_rpc_url(
+                &env::var("STELLAR_RPC_URL")
+                    .unwrap_or_else(|_| "https://soroban-testnet.stellar.org".to_string()),
+            ),
             start_ledger,
             start_ledger_fallback,
             port,

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub db_max_connections: u32,
     pub db_min_connections: u32,
     pub behind_proxy: bool,
+    pub allowed_origins: Vec<String>,
 }
 
 impl Config {
@@ -41,6 +42,12 @@ impl Config {
                 .parse()
                 .expect("DB_MIN_CONNECTIONS must be a number"),
             behind_proxy,
+            allowed_origins: env::var("ALLOWED_ORIGINS")
+                .unwrap_or_else(|_| "*".to_string())
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ async fn main() {
     db::run_migrations(&pool).await;
 
     info!("Migrations applied successfully");
+    info!("Soroban RPC URL: {}", config.stellar_rpc_url);
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let mut shutdown_rx_axum = shutdown_rx.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,8 @@ async fn main() {
     });
 
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
-    let router = routes::create_router(pool, config.api_key);
+    info!("Allowed CORS origins: {:?}", config.allowed_origins);
+    let router = routes::create_router(pool, config.api_key, &config.allowed_origins);
 
     info!("Soroban Pulse listening on {}", addr);
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,11 +1,14 @@
 use axum::{routing::get, Router};
+use http::{HeaderValue, Method};
 use sqlx::PgPool;
 use std::sync::Arc;
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
 use crate::{handlers, middleware};
 
-pub fn create_router(pool: PgPool, api_key: Option<String>) -> Router {
+pub fn create_router(pool: PgPool, api_key: Option<String>, allowed_origins: &[String]) -> Router {
+    let cors = build_cors(allowed_origins);
+
     let auth_state = Arc::new(middleware::AuthState { api_key });
 
     Router::new()
@@ -14,7 +17,27 @@ pub fn create_router(pool: PgPool, api_key: Option<String>) -> Router {
         .route("/events/:contract_id", get(handlers::get_events_by_contract))
         .route("/events/tx/:tx_hash", get(handlers::get_events_by_tx))
         .layer(axum::middleware::from_fn_with_state(auth_state, middleware::auth_middleware))
-        .layer(CorsLayer::permissive())
+        .layer(cors)
         .layer(TraceLayer::new_for_http())
         .with_state(pool)
+}
+
+fn build_cors(allowed_origins: &[String]) -> CorsLayer {
+    let methods = [Method::GET];
+
+    if allowed_origins.iter().any(|o| o == "*") {
+        return CorsLayer::new()
+            .allow_origin(tower_http::cors::Any)
+            .allow_methods(methods);
+    }
+
+    let origins: Vec<HeaderValue> = allowed_origins
+        .iter()
+        .filter_map(|o| o.parse().ok())
+        .collect();
+
+    CorsLayer::new()
+        .allow_origin(origins)
+        .allow_methods(methods)
+        .vary([http::header::ORIGIN])
 }


### PR DESCRIPTION

### config.rs accepted any string for STELLAR_RPC_URL, enabling SSRF via file://, http://internal-service, etc.

Changes:
- config.rs — validate_rpc_url() rejects invalid URLs, non-https schemes, and loopback/private hosts; strips credentials before storing
- main.rs — logs the validated RPC URL at startup
- Cargo.toml — adds url = "2"
- .env.example — documents ALLOW_INSECURE_RPC escape hatch for local dev

Behavior:
- STELLAR_RPC_URL=not-a-url → clean panic with descriptive message
- STELLAR_RPC_URL=http://... → panics unless ALLOW_INSECURE_RPC=true
- STELLAR_RPC_URL=https://... → validated, logged, accepted

Closes #5
