### PR TITLE
Feat/rate limiting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,3 +38,6 @@ RUST_LOG=info
 # Allowed CORS origins (comma-separated). Use * to allow all origins (local dev only).
 # Example: ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
 ALLOWED_ORIGINS=*
+
+# Per-IP rate limit (requests per minute). Exceeding this returns 429 with Retry-After.
+RATE_LIMIT_PER_MINUTE=60

--- a/.env.example
+++ b/.env.example
@@ -11,9 +11,12 @@ DATABASE_URL=postgres://<USER>:<PASSWORD>@db:5432/soroban_pulse
 DB_MAX_CONNECTIONS=10
 DB_MIN_CONNECTIONS=1
 
-# Soroban RPC endpoint URL
+# Soroban RPC endpoint URL — must be a valid HTTPS URL in production
 # Format: https://<domain> or http://<ip>:<port>
 STELLAR_RPC_URL=https://soroban-testnet.stellar.org
+
+# Allow HTTP or loopback/private RPC URLs (local dev only — never set in production)
+# ALLOW_INSECURE_RPC=true
 
 # Ledger sequence number to start indexing from (0 = latest)
 # Format: integer (e.g., 0, 123456)

--- a/.env.example
+++ b/.env.example
@@ -1,6 +1,11 @@
-# PostgreSQL connection string
-# Format: postgres://<username>:<password>@<host>:<port>/<database_name>
-DATABASE_URL=postgres://<USER>:<PASSWORD>@<HOST>:<PORT>/<DATABASE_NAME>
+# PostgreSQL credentials (used by both the db service and the app's DATABASE_URL)
+POSTGRES_USER=<USER>
+POSTGRES_PASSWORD=<PASSWORD>
+POSTGRES_DB=soroban_pulse
+
+# PostgreSQL connection string — must match the credentials above
+# Format: postgres://<POSTGRES_USER>:<POSTGRES_PASSWORD>@db:5432/<POSTGRES_DB>
+DATABASE_URL=postgres://<USER>:<PASSWORD>@db:5432/soroban_pulse
 
 # PostgreSQL connection pool sizing
 DB_MAX_CONNECTIONS=10

--- a/.env.example
+++ b/.env.example
@@ -31,3 +31,7 @@ RUST_LOG=info
 # If left unset, authentication is bypassed entirely.
 # Format: string (e.g., your-super-secret-key-123)
 # API_KEY=
+
+# Allowed CORS origins (comma-separated). Use * to allow all origins (local dev only).
+# Example: ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
+ALLOWED_ORIGINS=*

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 /target
+.env
+docker-compose.override.yml

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,4 @@ tower-http = { version = "0.5", features = ["trace", "cors"] }
 axum-extra = { version = "0.9", features = ["typed-header"] }
 anyhow = "1.0.102"
 url = "2"
+tower-governor = { version = "0.8", features = ["axum"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,4 @@ tower = { version = "0.4", features = ["util"] }
 tower-http = { version = "0.5", features = ["trace", "cors"] }
 axum-extra = { version = "0.9", features = ["typed-header"] }
 anyhow = "1.0.102"
+url = "2"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,9 +2,9 @@ services:
   db:
     image: postgres:16-alpine
     environment:
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: password
-      POSTGRES_DB: soroban_pulse
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
     ports:
       - "5432:5432"
     volumes:
@@ -15,11 +15,11 @@ services:
     depends_on:
       - db
     environment:
-      DATABASE_URL: postgres://postgres:password@db:5432/soroban_pulse
-      STELLAR_RPC_URL: https://soroban-testnet.stellar.org
-      START_LEDGER: 0
-      PORT: 3000
-      RUST_LOG: info
+      DATABASE_URL: ${DATABASE_URL}
+      STELLAR_RPC_URL: ${STELLAR_RPC_URL}
+      START_LEDGER: ${START_LEDGER}
+      PORT: ${PORT}
+      RUST_LOG: ${RUST_LOG}
     ports:
       - "3000:3000"
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -14,6 +14,7 @@ pub struct Config {
     pub db_min_connections: u32,
     pub behind_proxy: bool,
     pub allowed_origins: Vec<String>,
+    pub rate_limit_per_minute: u32,
 }
 
 fn validate_rpc_url(raw: &str) -> String {
@@ -102,6 +103,10 @@ impl Config {
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
                 .collect(),
+            rate_limit_per_minute: env::var("RATE_LIMIT_PER_MINUTE")
+                .unwrap_or_else(|_| "60".to_string())
+                .parse()
+                .expect("RATE_LIMIT_PER_MINUTE must be a positive integer"),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use std::env;
+use url::Url;
 
 #[derive(Clone, Debug)]
 pub struct Config {
@@ -15,6 +16,57 @@ pub struct Config {
     pub allowed_origins: Vec<String>,
 }
 
+fn validate_rpc_url(raw: &str) -> String {
+    let url = Url::parse(raw)
+        .unwrap_or_else(|e| panic!("STELLAR_RPC_URL is not a valid URL: {e}"));
+
+    let allow_insecure = env::var("ALLOW_INSECURE_RPC")
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "y"))
+        .unwrap_or(false);
+
+    match url.scheme() {
+        "https" => {}
+        "http" if allow_insecure => {}
+        "http" => panic!(
+            "STELLAR_RPC_URL uses http — set ALLOW_INSECURE_RPC=true to permit insecure connections"
+        ),
+        scheme => panic!("STELLAR_RPC_URL has disallowed scheme '{scheme}' — only https is permitted"),
+    }
+
+    if !allow_insecure {
+        let host = url.host_str().unwrap_or("");
+        let is_loopback = host == "localhost"
+            || host == "127.0.0.1"
+            || host == "::1"
+            || host.ends_with(".local");
+        let is_private = {
+            // Reject RFC-1918 / link-local ranges by prefix
+            host.starts_with("10.")
+                || host.starts_with("192.168.")
+                || host.starts_with("169.254.")
+                || (host.starts_with("172.") && {
+                    host.split('.')
+                        .nth(1)
+                        .and_then(|o| o.parse::<u8>().ok())
+                        .map(|o| (16..=31).contains(&o))
+                        .unwrap_or(false)
+                })
+        };
+        if is_loopback || is_private {
+            panic!(
+                "STELLAR_RPC_URL points to a non-routable host '{host}' — \
+                 set ALLOW_INSECURE_RPC=true to allow this in development"
+            );
+        }
+    }
+
+    // Return URL without credentials
+    let mut safe = url.clone();
+    let _ = safe.set_username("");
+    let _ = safe.set_password(None);
+    safe.to_string()
+}
+
 impl Config {
     pub fn from_env() -> Self {
         let behind_proxy = env::var("BEHIND_PROXY")
@@ -27,8 +79,10 @@ impl Config {
 
         Self {
             database_url: env::var("DATABASE_URL").expect("DATABASE_URL must be set"),
-            stellar_rpc_url: env::var("STELLAR_RPC_URL")
-                .unwrap_or_else(|_| "https://soroban-testnet.stellar.org".to_string()),
+            stellar_rpc_url: validate_rpc_url(
+                &env::var("STELLAR_RPC_URL")
+                    .unwrap_or_else(|_| "https://soroban-testnet.stellar.org".to_string()),
+            ),
             start_ledger,
             start_ledger_fallback,
             port,

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@ pub struct Config {
     pub db_max_connections: u32,
     pub db_min_connections: u32,
     pub behind_proxy: bool,
+    pub allowed_origins: Vec<String>,
 }
 
 impl Config {
@@ -41,6 +42,12 @@ impl Config {
                 .parse()
                 .expect("DB_MIN_CONNECTIONS must be a number"),
             behind_proxy,
+            allowed_origins: env::var("ALLOWED_ORIGINS")
+                .unwrap_or_else(|_| "*".to_string())
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect(),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,31 +53,23 @@ async fn main() {
 
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     info!("Allowed CORS origins: {:?}", config.allowed_origins);
-    let router = routes::create_router(pool, config.api_key, &config.allowed_origins);
+    info!("Rate limit: {} requests/minute per IP", config.rate_limit_per_minute);
+    let router = routes::create_router(pool, config.api_key, &config.allowed_origins, config.rate_limit_per_minute);
 
     info!("Soroban Pulse listening on {}", addr);
 
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
 
-    if config.behind_proxy {
-        info!("Running behind proxy — trusting X-Forwarded-For");
-        axum::serve(
-            listener,
-            router.into_make_service_with_connect_info::<SocketAddr>(),
-        )
-        .with_graceful_shutdown(async move {
-            let _ = shutdown_rx_axum.changed().await;
-        })
-        .await
-        .unwrap();
-    } else {
-        axum::serve(listener, router)
-            .with_graceful_shutdown(async move {
-                let _ = shutdown_rx_axum.changed().await;
-            })
-            .await
-            .unwrap();
-    }
+    // GovernorLayer requires connect_info to extract peer IP — always use it.
+    axum::serve(
+        listener,
+        router.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(async move {
+        let _ = shutdown_rx_axum.changed().await;
+    })
+    .await
+    .unwrap();
 
     let _ = indexer_handle.await;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ async fn main() {
     db::run_migrations(&pool).await;
 
     info!("Migrations applied successfully");
+    info!("Soroban RPC URL: {}", config.stellar_rpc_url);
 
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
     let mut shutdown_rx_axum = shutdown_rx.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -51,7 +51,8 @@ async fn main() {
     });
 
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
-    let router = routes::create_router(pool, config.api_key);
+    info!("Allowed CORS origins: {:?}", config.allowed_origins);
+    let router = routes::create_router(pool, config.api_key, &config.allowed_origins);
 
     info!("Soroban Pulse listening on {}", addr);
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,22 +1,55 @@
-use axum::{routing::get, Router};
-use http::{HeaderValue, Method};
+use axum::{response::IntoResponse, routing::get, Json, Router};
+use http::{HeaderValue, Method, StatusCode};
+use serde_json::json;
 use sqlx::PgPool;
 use std::sync::Arc;
+use tower_governor::{governor::GovernorConfigBuilder, GovernorLayer};
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
 use crate::{handlers, middleware};
 
-pub fn create_router(pool: PgPool, api_key: Option<String>, allowed_origins: &[String]) -> Router {
+pub fn create_router(
+    pool: PgPool,
+    api_key: Option<String>,
+    allowed_origins: &[String],
+    rate_limit_per_minute: u32,
+) -> Router {
     let cors = build_cors(allowed_origins);
-
     let auth_state = Arc::new(middleware::AuthState { api_key });
 
-    Router::new()
-        .route("/health", get(handlers::health))
+    // Replenish one token every (60 / rate_limit_per_minute) seconds.
+    // burst_size = rate_limit_per_minute so a fresh client can use the full quota at once.
+    let period_secs = 60u64.div_ceil(rate_limit_per_minute as u64);
+    let governor_conf = Arc::new(
+        GovernorConfigBuilder::default()
+            .per_second(period_secs)
+            .burst_size(rate_limit_per_minute)
+            .use_headers()
+            .error_handler(|_| {
+                (
+                    StatusCode::TOO_MANY_REQUESTS,
+                    Json(json!({ "error": "rate limit exceeded" })),
+                )
+                    .into_response()
+            })
+            .finish()
+            .expect("invalid rate limit configuration"),
+    );
+
+    // Rate-limited API routes
+    let api = Router::new()
         .route("/events", get(handlers::get_events))
         .route("/events/:contract_id", get(handlers::get_events_by_contract))
         .route("/events/tx/:tx_hash", get(handlers::get_events_by_tx))
-        .layer(axum::middleware::from_fn_with_state(auth_state, middleware::auth_middleware))
+        .layer(GovernorLayer::new(governor_conf));
+
+    Router::new()
+        .route("/health", get(handlers::health))
+        .merge(api)
+        .layer(axum::middleware::from_fn_with_state(
+            auth_state,
+            middleware::auth_middleware,
+        ))
         .layer(cors)
         .layer(TraceLayer::new_for_http())
         .with_state(pool)

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,11 +1,14 @@
 use axum::{routing::get, Router};
+use http::{HeaderValue, Method};
 use sqlx::PgPool;
 use std::sync::Arc;
 use tower_http::{cors::CorsLayer, trace::TraceLayer};
 
 use crate::{handlers, middleware};
 
-pub fn create_router(pool: PgPool, api_key: Option<String>) -> Router {
+pub fn create_router(pool: PgPool, api_key: Option<String>, allowed_origins: &[String]) -> Router {
+    let cors = build_cors(allowed_origins);
+
     let auth_state = Arc::new(middleware::AuthState { api_key });
 
     Router::new()
@@ -14,7 +17,27 @@ pub fn create_router(pool: PgPool, api_key: Option<String>) -> Router {
         .route("/events/:contract_id", get(handlers::get_events_by_contract))
         .route("/events/tx/:tx_hash", get(handlers::get_events_by_tx))
         .layer(axum::middleware::from_fn_with_state(auth_state, middleware::auth_middleware))
-        .layer(CorsLayer::permissive())
+        .layer(cors)
         .layer(TraceLayer::new_for_http())
         .with_state(pool)
+}
+
+fn build_cors(allowed_origins: &[String]) -> CorsLayer {
+    let methods = [Method::GET];
+
+    if allowed_origins.iter().any(|o| o == "*") {
+        return CorsLayer::new()
+            .allow_origin(tower_http::cors::Any)
+            .allow_methods(methods);
+    }
+
+    let origins: Vec<HeaderValue> = allowed_origins
+        .iter()
+        .filter_map(|o| o.parse().ok())
+        .collect();
+
+    CorsLayer::new()
+        .allow_origin(origins)
+        .allow_methods(methods)
+        .vary([http::header::ORIGIN])
 }


### PR DESCRIPTION
### Without rate limiting, a single client could exhaust the DB connection pool via unlimited requests.

Changes:
- routes.rs — applies GovernorLayer to /events* routes only; /health is exempt. Returns 429 {"error": "rate limit exceeded"} with Retry-After on 
breach
- config.rs — adds rate_limit_per_minute (default: 60)
- main.rs — logs rate limit at startup; always uses into_make_service_with_connect_info (required for peer IP extraction)
- Cargo.toml — adds tower-governor = { version = "0.8", features = ["axum"] }
- .env.example — documents RATE_LIMIT_PER_MINUTE

Closes #6 

