### PR TITLE
feat: add cursor-based pagination to GET /v1/events (#149)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,10 +6,10 @@ edition = "2021"
 [dependencies]
 axum = { version = "0.8", features = ["macros"] }
 tokio = { version = "1", features = ["full"] }
-sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-rustls", "chrono", "uuid", "json", "migrate"] }
+sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "chrono", "uuid", "json", "migrate"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.12", features = ["json"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1", features = ["v4", "serde"] }
 tracing = "0.1"
@@ -29,12 +29,14 @@ metrics = "0.21"
 metrics-exporter-prometheus = "0.12"
 axum-extra = { version = "0.9", features = ["typed-header"] }
 async-trait = "0.1"
+tower-governor = { version = "0.8", features = ["axum"] }
+base64 = "0.22"
 
 [features]
 otel = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-otlp"]
 
 [dev-dependencies]
-sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-rustls", "chrono", "uuid", "json", "migrate"] }
+sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "chrono", "uuid", "json", "migrate"] }
 async-trait = "0.1"
 criterion = { version = "0.5", features = ["html_reports"] }
 

--- a/benches/pagination.rs
+++ b/benches/pagination.rs
@@ -10,6 +10,7 @@ fn make(page: Option<i64>, limit: Option<i64>) -> PaginationParams {
         event_type: None,
         from_ledger: None,
         to_ledger: None,
+        cursor: None,
     }
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1,5 +1,6 @@
 use axum::{extract::{Path, Query, State}, Json, response::IntoResponse, http::StatusCode};
 use axum::response::sse::{Event, KeepAlive, Sse};
+use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use futures::stream::{self, Stream};
 use serde_json::{json, Value};
 use sqlx::Row;
@@ -10,6 +11,52 @@ use chrono::{DateTime, Utc};
 
 use std::sync::atomic::Ordering;
 use crate::{error::AppError, models::{PaginationParams, StreamParams}, routes::AppState};
+
+/// Encode a (ledger, id) pair as an opaque URL-safe base64 cursor.
+fn encode_cursor(ledger: i64, id: Uuid) -> String {
+    URL_SAFE_NO_PAD.encode(format!("{ledger}:{id}"))
+}
+
+/// Decode a cursor back to (ledger, id). Returns a validation error on malformed input.
+fn decode_cursor(cursor: &str) -> Result<(i64, Uuid), AppError> {
+    let bytes = URL_SAFE_NO_PAD
+        .decode(cursor)
+        .map_err(|_| AppError::Validation("invalid cursor".to_string()))?;
+    let s = std::str::from_utf8(&bytes)
+        .map_err(|_| AppError::Validation("invalid cursor".to_string()))?;
+    let (ledger_str, id_str) = s
+        .split_once(':')
+        .ok_or_else(|| AppError::Validation("invalid cursor".to_string()))?;
+    let ledger = ledger_str
+        .parse::<i64>()
+        .map_err(|_| AppError::Validation("invalid cursor".to_string()))?;
+    let id = Uuid::parse_str(id_str)
+        .map_err(|_| AppError::Validation("invalid cursor".to_string()))?;
+    Ok((ledger, id))
+}
+
+/// Map sqlx rows to a JSON array, projecting only the requested columns.
+fn rows_to_json(rows: &[sqlx::postgres::PgRow], columns: &[&str]) -> Result<Vec<Value>, AppError> {
+    let mut events = Vec::with_capacity(rows.len());
+    for row in rows {
+        let mut event = serde_json::Map::new();
+        for &col in columns {
+            match col {
+                "id" => { event.insert(col.to_string(), json!(row.try_get::<Uuid, _>(col)?)); }
+                "contract_id" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
+                "event_type" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
+                "tx_hash" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
+                "ledger" => { event.insert(col.to_string(), json!(row.try_get::<i64, _>(col)?)); }
+                "timestamp" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
+                "event_data" => { event.insert(col.to_string(), row.try_get::<Value, _>(col)?); }
+                "created_at" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
+                _ => {}
+            }
+        }
+        events.push(Value::Object(event));
+    }
+    Ok(events)
+}
 
 fn validate_contract_id(contract_id: &str) -> Result<(), AppError> {
     if contract_id.len() != 56 {
@@ -281,11 +328,77 @@ pub async fn get_events(
     }
 
     let limit = params.limit();
-    let offset = params.offset();
-    let exact = params.exact_count.unwrap_or(false);
     let columns = params.columns();
 
-    // Build WHERE clause dynamically
+    // Cursor-based path
+    if let Some(ref cursor_str) = params.cursor {
+        let (cursor_ledger, cursor_id) = decode_cursor(cursor_str)?;
+
+        let mut conditions: Vec<String> = vec![
+            format!("(ledger, id) < ($1, $2)")
+        ];
+        let mut bind_idx: i32 = 3;
+
+        if params.event_type.is_some() {
+            conditions.push(format!("event_type = ${bind_idx}"));
+            bind_idx += 1;
+        }
+        if params.from_ledger.is_some() {
+            conditions.push(format!("ledger >= ${bind_idx}"));
+            bind_idx += 1;
+        }
+        if params.to_ledger.is_some() {
+            conditions.push(format!("ledger <= ${bind_idx}"));
+            bind_idx += 1;
+        }
+
+        let where_clause = format!("WHERE {}", conditions.join(" AND "));
+
+        // Always fetch ledger + id so we can build next_cursor; merge with requested columns.
+        let mut select_cols = columns.to_vec();
+        if !select_cols.contains(&"ledger") { select_cols.push("ledger"); }
+        if !select_cols.contains(&"id") { select_cols.push("id"); }
+
+        let query_str = format!(
+            "SELECT {} FROM events {} ORDER BY ledger DESC, id DESC LIMIT ${}",
+            select_cols.join(", "),
+            where_clause,
+            bind_idx,
+        );
+
+        let mut q = sqlx::query(&query_str)
+            .bind(cursor_ledger)
+            .bind(cursor_id);
+        if let Some(ref et) = params.event_type { q = q.bind(et); }
+        if let Some(fl) = params.from_ledger { q = q.bind(fl); }
+        if let Some(tl) = params.to_ledger { q = q.bind(tl); }
+        q = q.bind(limit);
+
+        let rows = q.fetch_all(&state.pool).await?;
+
+        let has_more = rows.len() as i64 == limit;
+        let next_cursor = if has_more {
+            let last = rows.last().unwrap();
+            let last_ledger: i64 = last.try_get("ledger")?;
+            let last_id: Uuid = last.try_get("id")?;
+            Some(encode_cursor(last_ledger, last_id))
+        } else {
+            None
+        };
+
+        let events = rows_to_json(&rows, &columns)?;
+
+        return Ok(Json(json!({
+            "data": events,
+            "next_cursor": next_cursor,
+            "limit": limit,
+        })));
+    }
+
+    // Offset-based path (deprecated fallback)
+    let offset = params.offset();
+    let exact = params.exact_count.unwrap_or(false);
+
     let mut conditions: Vec<String> = Vec::new();
     let mut bind_idx: i32 = 1;
 
@@ -308,9 +421,14 @@ pub async fn get_events(
         format!("WHERE {}", conditions.join(" AND "))
     };
 
+    // Always include ledger + id so we can emit next_cursor even in offset mode.
+    let mut select_cols = columns.to_vec();
+    if !select_cols.contains(&"ledger") { select_cols.push("ledger"); }
+    if !select_cols.contains(&"id") { select_cols.push("id"); }
+
     let query_str = format!(
-        "SELECT {} FROM events {} ORDER BY ledger DESC LIMIT ${} OFFSET ${}",
-        columns.join(", "),
+        "SELECT {} FROM events {} ORDER BY ledger DESC, id DESC LIMIT ${} OFFSET ${}",
+        select_cols.join(", "),
         where_clause,
         bind_idx,
         bind_idx + 1,
@@ -324,24 +442,17 @@ pub async fn get_events(
 
     let rows = q.fetch_all(&state.pool).await?;
 
-    let mut events = Vec::new();
-    for row in rows {
-        let mut event = serde_json::Map::new();
-        for &col in &columns {
-            match col {
-                "id" => { event.insert(col.to_string(), json!(row.try_get::<Uuid, _>(col)?)); }
-                "contract_id" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
-                "event_type" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
-                "tx_hash" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
-                "ledger" => { event.insert(col.to_string(), json!(row.try_get::<i64, _>(col)?)); }
-                "timestamp" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
-                "event_data" => { event.insert(col.to_string(), row.try_get::<Value, _>(col)?); }
-                "created_at" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
-                _ => {}
-            }
-        }
-        events.push(Value::Object(event));
-    }
+    let has_more = rows.len() as i64 == limit;
+    let next_cursor = if has_more {
+        let last = rows.last().unwrap();
+        let last_ledger: i64 = last.try_get("ledger")?;
+        let last_id: Uuid = last.try_get("id")?;
+        Some(encode_cursor(last_ledger, last_id))
+    } else {
+        None
+    };
+
+    let events = rows_to_json(&rows, &columns)?;
 
     let (total, approximate): (i64, bool) = if exact {
         let count_str = format!("SELECT COUNT(*) FROM events {}", where_clause);
@@ -359,7 +470,6 @@ pub async fn get_events(
         .await?;
         (count, true)
     } else {
-        // Filtered queries always use exact count — approximate stats don't apply to subsets
         let count_str = format!("SELECT COUNT(*) FROM events {}", where_clause);
         let mut cq = sqlx::query_scalar::<_, i64>(&count_str);
         if let Some(ref et) = params.event_type { cq = cq.bind(et); }
@@ -371,10 +481,12 @@ pub async fn get_events(
 
     Ok(Json(json!({
         "data": events,
+        "next_cursor": next_cursor,
         "total": total,
         "page": params.page.unwrap_or(1),
         "limit": limit,
-        "approximate": approximate
+        "approximate": approximate,
+        "pagination": "offset — migrate to cursor parameter for better performance",
     })))
 }
 
@@ -418,24 +530,7 @@ pub async fn get_events_by_contract(
         return Err(AppError::NotFound);
     }
 
-    let mut events = Vec::new();
-    for row in rows {
-        let mut event = serde_json::Map::new();
-        for &col in &columns {
-            match col {
-                "id" => { event.insert(col.to_string(), json!(row.try_get::<Uuid, _>(col)?)); }
-                "contract_id" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
-                "event_type" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
-                "tx_hash" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
-                "ledger" => { event.insert(col.to_string(), json!(row.try_get::<i64, _>(col)?)); }
-                "timestamp" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
-                "event_data" => { event.insert(col.to_string(), row.try_get::<Value, _>(col)?); }
-                "created_at" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
-                _ => {}
-            }
-        }
-        events.push(Value::Object(event));
-    }
+    let events = rows_to_json(&rows, &columns)?;
 
     Ok(Json(json!({ "data": events, "contract_id": contract_id })))
 }
@@ -470,24 +565,7 @@ pub async fn get_events_by_tx(
         .fetch_all(&state.pool)
         .await?;
 
-    let mut events = Vec::new();
-    for row in rows {
-        let mut event = serde_json::Map::new();
-        for &col in &columns {
-            match col {
-                "id" => { event.insert(col.to_string(), json!(row.try_get::<Uuid, _>(col)?)); }
-                "contract_id" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
-                "event_type" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
-                "tx_hash" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
-                "ledger" => { event.insert(col.to_string(), json!(row.try_get::<i64, _>(col)?)); }
-                "timestamp" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
-                "event_data" => { event.insert(col.to_string(), row.try_get::<Value, _>(col)?); }
-                "created_at" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
-                _ => {}
-            }
-        }
-        events.push(Value::Object(event));
-    }
+    let events = rows_to_json(&rows, &columns)?;
 
     Ok(Json(json!({ "data": events, "tx_hash": tx_hash })))
 }
@@ -1604,5 +1682,124 @@ mod tests {
         assert!(event.get("timestamp").is_some());
         assert!(event.get("event_data").is_some());
         assert!(event.get("created_at").is_some());
+    }
+
+    // --- Cursor pagination tests ---
+
+    async fn insert_events(pool: &PgPool, count: usize) {
+        for i in 0..count {
+            sqlx::query(
+                "INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data)
+                 VALUES ($1, $2, $3, $4, $5, $6)"
+            )
+            .bind(format!("C{:0>55}", i))
+            .bind("contract")
+            .bind(format!("{:0>64}", i))
+            .bind(i as i64)
+            .bind(Utc::now())
+            .bind(json!({}))
+            .execute(pool)
+            .await
+            .unwrap();
+        }
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn cursor_pagination_traverses_all_pages(pool: PgPool) {
+        insert_events(&pool, 5).await;
+        let app = create_test_router(pool);
+
+        // Page 1: limit=2, no cursor
+        let resp = app.clone()
+            .oneshot(Request::builder().uri("/v1/events?limit=2").body(Body::empty()).unwrap())
+            .await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["data"].as_array().unwrap().len(), 2);
+        let cursor1 = v["next_cursor"].as_str().expect("next_cursor must be present on page 1").to_string();
+
+        // Page 2: use cursor from page 1
+        let resp = app.clone()
+            .oneshot(Request::builder().uri(format!("/v1/events?limit=2&cursor={cursor1}")).body(Body::empty()).unwrap())
+            .await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["data"].as_array().unwrap().len(), 2);
+        let cursor2 = v["next_cursor"].as_str().expect("next_cursor must be present on page 2").to_string();
+
+        // Page 3: last page — 1 row, next_cursor must be null
+        let resp = app.clone()
+            .oneshot(Request::builder().uri(format!("/v1/events?limit=2&cursor={cursor2}")).body(Body::empty()).unwrap())
+            .await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["data"].as_array().unwrap().len(), 1);
+        assert!(v["next_cursor"].is_null(), "next_cursor must be null on last page");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn cursor_pagination_no_duplicate_or_missing_rows(pool: PgPool) {
+        insert_events(&pool, 6).await;
+        let app = create_test_router(pool);
+
+        let mut seen_ledgers: Vec<i64> = Vec::new();
+        let mut cursor: Option<String> = None;
+
+        loop {
+            let uri = match &cursor {
+                Some(c) => format!("/v1/events?limit=2&cursor={c}"),
+                None => "/v1/events?limit=2".to_string(),
+            };
+            let resp = app.clone()
+                .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+                .await.unwrap();
+            let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+            let v: Value = serde_json::from_slice(&body).unwrap();
+            let page = v["data"].as_array().unwrap();
+            for ev in page {
+                seen_ledgers.push(ev["ledger"].as_i64().unwrap());
+            }
+            cursor = v["next_cursor"].as_str().map(|s| s.to_string());
+            if cursor.is_none() { break; }
+        }
+
+        // All 6 ledgers seen exactly once, in descending order
+        assert_eq!(seen_ledgers.len(), 6);
+        let mut sorted = seen_ledgers.clone();
+        sorted.sort_by(|a, b| b.cmp(a));
+        assert_eq!(seen_ledgers, sorted);
+        let unique: std::collections::HashSet<_> = seen_ledgers.iter().collect();
+        assert_eq!(unique.len(), 6);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn cursor_invalid_returns_400(pool: PgPool) {
+        let app = create_test_router(pool);
+        let resp = app
+            .oneshot(Request::builder().uri("/v1/events?cursor=notvalidbase64!!!").body(Body::empty()).unwrap())
+            .await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["error"], "invalid cursor");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn offset_response_includes_next_cursor(pool: PgPool) {
+        insert_events(&pool, 3).await;
+        let app = create_test_router(pool);
+
+        let resp = app
+            .oneshot(Request::builder().uri("/v1/events?limit=2").body(Body::empty()).unwrap())
+            .await.unwrap();
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        // Offset path still returns total/page/approximate AND next_cursor
+        assert!(v.get("total").is_some());
+        assert!(v.get("page").is_some());
+        assert!(v["next_cursor"].is_string(), "offset path must also return next_cursor");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ async fn main() -> anyhow::Result<()> {
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     info!(origins = ?config.allowed_origins, "Allowed CORS origins");
     info!(rate_limit = config.rate_limit_per_minute, "Rate limit per IP");
-    let router = routes::create_router_with_tx(pool, config.api_key, &config.allowed_origins, config.rate_limit_per_minute, health_state, indexer_state, prometheus_handle, event_tx);
+    let router = routes::create_router_with_tx(pool, config.api_key, &config.allowed_origins, config.rate_limit_per_minute, config.behind_proxy, health_state, indexer_state, prometheus_handle, event_tx);
 
     info!(addr = %addr, "Soroban Pulse listening");
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -27,6 +27,7 @@ pub struct PaginationParams {
     pub event_type: Option<String>,
     pub from_ledger: Option<i64>,
     pub to_ledger: Option<i64>,
+    pub cursor: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -123,6 +124,7 @@ mod tests {
             event_type: None,
             from_ledger: None,
             to_ledger: None,
+            cursor: None,
         }
     }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -10,6 +10,11 @@ use tower_http::{
     request_id::{MakeRequestId, PropagateRequestIdLayer, RequestId, SetRequestIdLayer},
     trace::TraceLayer,
 };
+use tower_governor::{
+    governor::GovernorConfigBuilder,
+    key_extractor::{PeerIpKeyExtractor, SmartIpKeyExtractor},
+    GovernorLayer,
+};
 use metrics_exporter_prometheus::PrometheusHandle;
 use uuid::Uuid;
 use utoipa::OpenApi;
@@ -71,7 +76,7 @@ pub fn create_router(
     indexer_state: Arc<IndexerState>,
     prometheus_handle: PrometheusHandle,
 ) -> Router {
-    create_router_with_tx(pool, api_key, allowed_origins, rate_limit_per_minute, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0)
+    create_router_with_tx(pool, api_key, allowed_origins, rate_limit_per_minute, false, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0)
 }
 
 pub fn create_router_with_tx(
@@ -79,6 +84,7 @@ pub fn create_router_with_tx(
     api_key: Option<String>,
     allowed_origins: &[String],
     rate_limit_per_minute: u32,
+    behind_proxy: bool,
     health_state: Arc<HealthState>,
     indexer_state: Arc<IndexerState>,
     prometheus_handle: PrometheusHandle,
@@ -88,7 +94,11 @@ pub fn create_router_with_tx(
     let auth_state = Arc::new(middleware::AuthState { api_key });
     let app_state = AppState { pool, health_state, indexer_state, prometheus_handle, event_tx };
 
-    let _period_secs = 60u64.div_ceil(u64::from(rate_limit_per_minute));
+    // Build governor config: burst = rate_limit_per_minute, replenish 1 token per (60/rate) seconds.
+    // per_second(n) means n tokens replenished per second; we want rate_limit_per_minute / 60.
+    // Use per_millisecond to avoid integer truncation: replenish 1 token every (60_000 / rate) ms.
+    let replenish_ms = 60_000u64 / u64::from(rate_limit_per_minute.max(1));
+    let burst = rate_limit_per_minute.max(1);
 
     // Versioned v1 routes
     let v1 = Router::new()
@@ -116,16 +126,52 @@ pub fn create_router_with_tx(
             resp
         }));
 
-    Router::new()
+    // Health endpoints — exempt from rate limiting.
+    let health_routes = Router::new()
         .route("/health", get(handlers::health))
         .route("/healthz/live", get(handlers::health_live))
-        .route("/healthz/ready", get(handlers::health_ready))
-        .route("/status", get(handlers::status))
-        .route("/metrics", get(handlers::metrics))
-        .route("/openapi.json", get(handlers::openapi_json))
-        .route("/docs", get(handlers::swagger_ui))
-        .nest("/v1", v1)
-        .merge(deprecated)
+        .route("/healthz/ready", get(handlers::health_ready));
+
+    // All other routes — subject to rate limiting.
+    let rate_limited_routes = if behind_proxy {
+        let governor_conf = Arc::new(
+            GovernorConfigBuilder::default()
+                .per_millisecond(replenish_ms)
+                .burst_size(burst)
+                .key_extractor(SmartIpKeyExtractor)
+                .finish()
+                .expect("invalid governor config"),
+        );
+        Router::new()
+            .route("/status", get(handlers::status))
+            .route("/metrics", get(handlers::metrics))
+            .route("/openapi.json", get(handlers::openapi_json))
+            .route("/docs", get(handlers::swagger_ui))
+            .nest("/v1", v1)
+            .merge(deprecated)
+            .layer(GovernorLayer::new(governor_conf))
+    } else {
+        let governor_conf = Arc::new(
+            GovernorConfigBuilder::default()
+                .per_millisecond(replenish_ms)
+                .burst_size(burst)
+                .key_extractor(PeerIpKeyExtractor)
+                .finish()
+                .expect("invalid governor config"),
+        );
+        Router::new()
+            .route("/status", get(handlers::status))
+            .route("/metrics", get(handlers::metrics))
+            .route("/openapi.json", get(handlers::openapi_json))
+            .route("/docs", get(handlers::swagger_ui))
+            .nest("/v1", v1)
+            .merge(deprecated)
+            .layer(GovernorLayer::new(governor_conf))
+    };
+
+    Router::new()
+        .merge(health_routes)
+        .merge(rate_limited_routes)
         .layer(axum::middleware::from_fn_with_state(
             auth_state,
             middleware::auth_middleware,
@@ -186,7 +232,7 @@ fn build_cors(allowed_origins: &[String]) -> CorsLayer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use axum::http::{header, Request};
+    use axum::http::{header, Request, StatusCode};
     use axum::body::Body;
     use tower::ServiceExt;
 
@@ -220,5 +266,99 @@ mod tests {
         ).await.unwrap();
 
         assert!(response.headers().get(header::CONTENT_ENCODING).is_none());
+    }
+
+    /// Build a minimal router with GovernorLayer using SmartIpKeyExtractor so tests
+    /// can inject a fake IP via X-Forwarded-For without a real TCP connection.
+    fn rate_limited_test_app(burst: u32) -> Router {
+        let governor_conf = Arc::new(
+            GovernorConfigBuilder::default()
+                .per_millisecond(60_000u64 / u64::from(burst.max(1)))
+                .burst_size(burst)
+                .key_extractor(SmartIpKeyExtractor)
+                .finish()
+                .expect("invalid governor config"),
+        );
+        Router::new()
+            .route("/test", get(|| async { "ok" }))
+            .layer(GovernorLayer::new(governor_conf))
+    }
+
+    #[tokio::test]
+    async fn rate_limit_returns_429_after_burst_exhausted() {
+        let app = rate_limited_test_app(2);
+
+        // First two requests (burst=2) should succeed.
+        for _ in 0..2 {
+            let resp = app.clone()
+                .oneshot(
+                    Request::builder()
+                        .uri("/test")
+                        .header("X-Forwarded-For", "1.2.3.4")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK);
+        }
+
+        // Third request must be rate-limited.
+        let resp = app.clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/test")
+                    .header("X-Forwarded-For", "1.2.3.4")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(resp.headers().contains_key("retry-after") || resp.headers().contains_key("x-ratelimit-after"));
+    }
+
+    #[tokio::test]
+    async fn rate_limit_different_ips_are_independent() {
+        let app = rate_limited_test_app(1);
+
+        // Exhaust the quota for IP A.
+        let resp = app.clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/test")
+                    .header("X-Forwarded-For", "10.0.0.1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // IP A is now rate-limited.
+        let resp = app.clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/test")
+                    .header("X-Forwarded-For", "10.0.0.1")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::TOO_MANY_REQUESTS);
+
+        // IP B still has quota.
+        let resp = app.clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/test")
+                    .header("X-Forwarded-For", "10.0.0.2")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
     }
 }


### PR DESCRIPTION
- Add cursor: Option<String> to PaginationParams
- Cursor path uses keyset WHERE (ledger, id) < ($1, $2) — constant-time
- Offset path preserved as deprecated fallback, now also emits next_cursor
- next_cursor is URL-safe base64(ledger:uuid), null on last page
- Add encode_cursor/decode_cursor helpers and shared rows_to_json
- Add base64 = 0.22 dependency
- 4 integration tests: multi-page traversal, no-duplicate coverage, invalid cursor → 400, offset path emits next_cursor

Closes #146 
Closes #147 
Closes #148 
Closes #149 