### PR TITLE
feat: implement issues #158, #159, #160, #161

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,6 +61,21 @@ RATE_LIMIT_PER_MINUTE=60
 # Format: integer (e.g., 100, 500)
 INDEXER_LAG_WARN_THRESHOLD=100
 
+# Indexer poll interval when no new ledgers are available (milliseconds).
+# Lower values reduce event propagation latency; higher values reduce RPC API usage.
+# Valid range: 100–60000 ms
+INDEXER_POLL_INTERVAL_MS=5000
+
+# Indexer backoff duration after an RPC error (milliseconds).
+# Valid range: 100–60000 ms
+INDEXER_ERROR_BACKOFF_MS=10000
+
+# SSE keep-alive comment interval (milliseconds).
+# Controls how often a ": ping" comment is sent to prevent proxy idle-connection timeouts.
+# Set below your reverse proxy's idle timeout (nginx/ALB default is often 60 s).
+# Valid range: 1000–60000 ms
+SSE_KEEPALIVE_INTERVAL_MS=15000
+
 # Log output format (text or json)
 # Format: string (text, json)
 RUST_LOG_FORMAT=text

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ otel = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-otlp"]
 sqlx = { version = "0.7", features = ["postgres", "runtime-tokio-rustls", "chrono", "uuid", "json", "migrate"] }
 async-trait = "0.1"
 criterion = { version = "0.5", features = ["html_reports"] }
+http-body-util = "0.1"
 
 [[bench]]
 name = "pagination"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,17 @@
-FROM rust:1.76-slim AS builder
-
+FROM rust:1.87-slim AS chef
+RUN cargo install cargo-chef --locked
 WORKDIR /app
-RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
 
-COPY Cargo.toml Cargo.lock ./
-# Cache dependencies
-RUN mkdir src && echo "fn main() {}" > src/main.rs && cargo build --release && rm -rf src
-
+FROM chef AS planner
 COPY . .
-RUN touch src/main.rs && cargo build --release
+RUN cargo chef prepare --recipe-path recipe.json
+
+FROM chef AS builder
+RUN apt-get update && apt-get install -y pkg-config libssl-dev && rm -rf /var/lib/apt/lists/*
+COPY --from=planner /app/recipe.json recipe.json
+RUN cargo chef cook --release --recipe-path recipe.json
+COPY . .
+RUN cargo build --release
 
 # debian:bookworm-slim — digest pinned 2025-07-14. Update via Dependabot or manually with:
 # docker inspect --format='{{index .RepoDigests 0}}' debian:bookworm-slim

--- a/src/config.rs
+++ b/src/config.rs
@@ -123,6 +123,9 @@ pub struct Config {
     pub indexer_lag_warn_threshold: u64,
     pub indexer_stall_timeout_secs: u64,
     pub db_statement_timeout_ms: u64,
+    pub indexer_poll_interval_ms: u64,
+    pub indexer_error_backoff_ms: u64,
+    pub sse_keepalive_interval_ms: u64,
     pub environment: Environment,
 }
 
@@ -145,6 +148,9 @@ impl Default for Config {
             indexer_lag_warn_threshold: 100,
             indexer_stall_timeout_secs: 60,
             db_statement_timeout_ms: 5000,
+            indexer_poll_interval_ms: 5000,
+            indexer_error_backoff_ms: 10000,
+            sse_keepalive_interval_ms: 15000,
             environment: Environment::Development,
         }
     }
@@ -308,6 +314,33 @@ impl Config {
                 .unwrap_or_else(|_| "5000".to_string())
                 .parse()
                 .expect("DB_STATEMENT_TIMEOUT_MS must be a number"),
+            indexer_poll_interval_ms: {
+                let v: u64 = env::var("INDEXER_POLL_INTERVAL_MS")
+                    .unwrap_or_else(|_| "5000".to_string())
+                    .parse()
+                    .expect("INDEXER_POLL_INTERVAL_MS must be a number");
+                assert!((100..=60000).contains(&v),
+                    "INDEXER_POLL_INTERVAL_MS must be between 100 and 60000 ms, got {v}");
+                v
+            },
+            indexer_error_backoff_ms: {
+                let v: u64 = env::var("INDEXER_ERROR_BACKOFF_MS")
+                    .unwrap_or_else(|_| "10000".to_string())
+                    .parse()
+                    .expect("INDEXER_ERROR_BACKOFF_MS must be a number");
+                assert!((100..=60000).contains(&v),
+                    "INDEXER_ERROR_BACKOFF_MS must be between 100 and 60000 ms, got {v}");
+                v
+            },
+            sse_keepalive_interval_ms: {
+                let v: u64 = env::var("SSE_KEEPALIVE_INTERVAL_MS")
+                    .unwrap_or_else(|_| "15000".to_string())
+                    .parse()
+                    .expect("SSE_KEEPALIVE_INTERVAL_MS must be a number");
+                assert!((1000..=60000).contains(&v),
+                    "SSE_KEEPALIVE_INTERVAL_MS must be between 1000 and 60000 ms, got {v}");
+                v
+            },
             environment,
         }
     }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -5,11 +5,25 @@ use serde_json::{json, Value};
 use sqlx::Row;
 use std::convert::Infallible;
 use std::time::Duration;
+use std::sync::OnceLock;
+use tokio::sync::Mutex;
 use uuid::Uuid;
 use chrono::{DateTime, Utc};
 
 use std::sync::atomic::Ordering;
-use crate::{error::AppError, models::{PaginationParams, StreamParams}, routes::AppState};
+use crate::{error::AppError, models::{ContractSummary, PaginationParams, StreamParams}, routes::AppState};
+
+/// Simple in-process cache entry for the contracts list.
+struct CacheEntry {
+    data: Value,
+    expires_at: std::time::Instant,
+}
+
+static CONTRACTS_CACHE: OnceLock<Mutex<Option<CacheEntry>>> = OnceLock::new();
+
+fn contracts_cache() -> &'static Mutex<Option<CacheEntry>> {
+    CONTRACTS_CACHE.get_or_init(|| Mutex::new(None))
+}
 
 fn validate_contract_id(contract_id: &str) -> Result<(), AppError> {
     if contract_id.len() != 56 {
@@ -212,13 +226,56 @@ pub async fn swagger_ui() -> impl IntoResponse {
 pub async fn stream_events(
     State(state): State<AppState>,
     Query(params): Query<StreamParams>,
+    headers: axum::http::HeaderMap,
 ) -> Sse<impl Stream<Item = Result<Event, Infallible>>> {
-    let mut rx = state.event_tx.subscribe();
+    let keepalive_ms = state.sse_keepalive_interval_ms;
     let contract_filter = params.contract_id;
 
-    let s = stream::unfold(rx, move |mut rx| {
-        let filter = contract_filter.clone();
-        async move {
+    // Replay missed events if the client sends Last-Event-ID (a UUID).
+    let last_event_id = headers
+        .get("last-event-id")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| Uuid::parse_str(s).ok());
+
+    let replay: Vec<crate::models::Event> = if let Some(last_id) = last_event_id {
+        let q = if let Some(ref cid) = contract_filter {
+            sqlx::query_as::<_, crate::models::Event>(
+                "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, created_at, 0::bigint AS total_count \
+                 FROM events WHERE created_at > (SELECT created_at FROM events WHERE id = $1) \
+                 AND contract_id = $2 ORDER BY created_at ASC",
+            )
+            .bind(last_id)
+            .bind(cid)
+            .fetch_all(&state.pool)
+            .await
+        } else {
+            sqlx::query_as::<_, crate::models::Event>(
+                "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, created_at, 0::bigint AS total_count \
+                 FROM events WHERE created_at > (SELECT created_at FROM events WHERE id = $1) \
+                 ORDER BY created_at ASC",
+            )
+            .bind(last_id)
+            .fetch_all(&state.pool)
+            .await
+        };
+        q.unwrap_or_default()
+    } else {
+        vec![]
+    };
+
+    let rx = state.event_tx.subscribe();
+
+    let replay_stream = stream::iter(replay.into_iter().map(|ev| {
+        let data = serde_json::to_string(&ev).unwrap_or_default();
+        Ok(Event::default()
+            .id(ev.id.to_string())
+            .retry(Duration::from_millis(keepalive_ms))
+            .data(data))
+    }));
+
+    let live_stream = stream::unfold(
+        (rx, contract_filter, keepalive_ms),
+        move |(mut rx, filter, ka)| async move {
             loop {
                 match rx.recv().await {
                     Ok(event) => {
@@ -228,16 +285,26 @@ pub async fn stream_events(
                             }
                         }
                         let data = serde_json::to_string(&event).unwrap_or_default();
-                        return Some((Ok(Event::default().data(data)), rx));
+                        let sse = Event::default()
+                            .id(format!("{}-{}", event.tx_hash, event.ledger))
+                            .retry(Duration::from_millis(ka))
+                            .data(data);
+                        return Some((Ok(sse), (rx, filter, ka)));
                     }
                     Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => continue,
                     Err(tokio::sync::broadcast::error::RecvError::Closed) => return None,
                 }
             }
-        }
-    });
+        },
+    );
 
-    Sse::new(s).keep_alive(KeepAlive::default())
+    let combined = replay_stream.chain(live_stream);
+
+    Sse::new(combined).keep_alive(
+        KeepAlive::new()
+            .interval(Duration::from_millis(keepalive_ms))
+            .text("ping"),
+    )
 }
 
 #[utoipa::path(
@@ -490,6 +557,68 @@ pub async fn get_events_by_tx(
     }
 
     Ok(Json(json!({ "data": events, "tx_hash": tx_hash })))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/contracts",
+    tag = "events",
+    params(
+        ("page" = Option<i64>, Query, description = "Page number (default 1)"),
+        ("limit" = Option<i64>, Query, description = "Items per page (1-100, default 20)"),
+    ),
+    responses(
+        (status = 200, description = "Paginated list of indexed contract IDs"),
+    )
+)]
+pub async fn get_contracts(
+    State(state): State<AppState>,
+    Query(params): Query<PaginationParams>,
+) -> Result<Json<Value>, AppError> {
+    let limit = params.limit();
+    let offset = params.offset();
+
+    // Check cache
+    {
+        let cache = contracts_cache().lock().await;
+        if let Some(ref entry) = *cache {
+            if entry.expires_at > std::time::Instant::now() {
+                return Ok(Json(entry.data.clone()));
+            }
+        }
+    }
+
+    let rows = sqlx::query_as::<_, ContractSummary>(
+        "SELECT contract_id, COUNT(*) AS event_count, MAX(ledger) AS latest_ledger \
+         FROM events GROUP BY contract_id ORDER BY latest_ledger DESC \
+         LIMIT $1 OFFSET $2",
+    )
+    .bind(limit)
+    .bind(offset)
+    .fetch_all(&state.pool)
+    .await?;
+
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(DISTINCT contract_id) FROM events")
+        .fetch_one(&state.pool)
+        .await?;
+
+    let result = json!({
+        "data": rows,
+        "total": total,
+        "page": params.page.unwrap_or(1),
+        "limit": limit,
+    });
+
+    // Store in cache with 30-second TTL
+    {
+        let mut cache = contracts_cache().lock().await;
+        *cache = Some(CacheEntry {
+            data: result.clone(),
+            expires_at: std::time::Instant::now() + Duration::from_secs(30),
+        });
+    }
+
+    Ok(Json(result))
 }
 
 #[cfg(test)]
@@ -1604,5 +1733,116 @@ mod tests {
         assert!(event.get("timestamp").is_some());
         assert!(event.get("event_data").is_some());
         assert!(event.get("created_at").is_some());
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn get_contracts_empty_returns_empty_data(pool: PgPool) {
+        let app = create_test_router(pool);
+        let response = app
+            .oneshot(Request::builder().uri("/v1/contracts").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(v["data"], json!([]));
+        assert_eq!(v["total"], 0);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn get_contracts_returns_aggregated_data(pool: PgPool) {
+        let contract_a = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
+        let contract_b = "CBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+
+        for (contract, ledger) in [(contract_a, 10_i64), (contract_a, 20_i64), (contract_b, 5_i64)] {
+            sqlx::query(
+                "INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data) \
+                 VALUES ($1, 'contract', $2, $3, $4, '{}'::jsonb)",
+            )
+            .bind(contract)
+            .bind("a".repeat(64))
+            .bind(ledger)
+            .bind(Utc::now())
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        let app = create_test_router(pool);
+        let response = app
+            .oneshot(Request::builder().uri("/v1/contracts").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+
+        assert_eq!(v["total"], 2);
+        let data = v["data"].as_array().unwrap();
+        assert_eq!(data.len(), 2);
+        // Ordered by latest_ledger DESC — contract_a (ledger 20) first
+        assert_eq!(data[0]["contract_id"], contract_a);
+        assert_eq!(data[0]["event_count"], 2);
+        assert_eq!(data[0]["latest_ledger"], 20);
+        assert_eq!(data[1]["contract_id"], contract_b);
+        assert_eq!(data[1]["event_count"], 1);
+        assert_eq!(data[1]["latest_ledger"], 5);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn get_contracts_deprecated_alias_has_deprecation_header(pool: PgPool) {
+        let app = create_test_router(pool);
+        let response = app
+            .oneshot(Request::builder().uri("/contracts").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers().get("Deprecation").unwrap(), "true");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn sse_keepalive_comment_sent_within_interval(pool: PgPool) {
+        use http_body_util::BodyExt;
+        use tokio::time::{timeout, Duration};
+
+        let health_state = Arc::new(crate::config::HealthState::new(60));
+        let indexer_state = Arc::new(crate::config::IndexerState::new());
+        let prometheus_handle = crate::metrics::init_metrics();
+        let (event_tx, _) = tokio::sync::broadcast::channel(16);
+        // Use a 200 ms keep-alive so the test completes quickly.
+        let app = crate::routes::create_router_with_tx(
+            pool, None, &[], 60,
+            health_state, indexer_state, prometheus_handle,
+            event_tx, 200,
+        );
+
+        let response = app
+            .oneshot(Request::builder().uri("/v1/events/stream").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers().get("content-type").unwrap(), "text/event-stream");
+
+        // Read frames for up to 600 ms and look for the ": ping" keep-alive comment.
+        let mut body = response.into_body();
+        let mut buf = Vec::new();
+        let found = timeout(Duration::from_millis(600), async {
+            while let Some(frame) = body.frame().await {
+                if let Ok(f) = frame {
+                    if let Ok(data) = f.into_data() {
+                        buf.extend_from_slice(&data);
+                        if buf.windows(6).any(|w| w == b": ping") {
+                            return true;
+                        }
+                    }
+                }
+            }
+            false
+        })
+        .await
+        .unwrap_or(false);
+
+        assert!(found, "expected SSE keep-alive comment within 600 ms");
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -300,7 +300,7 @@ impl<R: RpcClient> Indexer<R> {
                             }
                         }
                     } else {
-                        sleep(Duration::from_secs(5)).await;
+                        sleep(Duration::from_millis(self.config.indexer_poll_interval_ms)).await;
                     }
                 }
                 Err(IndexerFetchError::DbConnection(e)) => {
@@ -322,7 +322,7 @@ impl<R: RpcClient> Indexer<R> {
                 }
                 Err(IndexerFetchError::Rpc(msg)) => {
                     error!(error = %msg, "Indexer error");
-                    sleep(Duration::from_secs(10)).await;
+                    sleep(Duration::from_millis(self.config.indexer_error_backoff_ms)).await;
                 }
             }
         }
@@ -577,6 +577,8 @@ mod tests {
                 rate_limit_per_minute: 60,
                 indexer_stall_timeout_secs: 60,
                 db_statement_timeout_ms: 5000,
+                indexer_poll_interval_ms: 5000,
+                indexer_error_backoff_ms: 10000,
                 environment: crate::config::Environment::Development,
             },
             shutdown_rx,
@@ -681,6 +683,8 @@ mod tests {
                 rate_limit_per_minute: 60,
                 indexer_stall_timeout_secs: 60,
                 db_statement_timeout_ms: 5000,
+                indexer_poll_interval_ms: 5000,
+                indexer_error_backoff_ms: 10000,
                 environment: crate::config::Environment::Development,
             },
             shutdown_rx,

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ async fn main() -> anyhow::Result<()> {
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     info!(origins = ?config.allowed_origins, "Allowed CORS origins");
     info!(rate_limit = config.rate_limit_per_minute, "Rate limit per IP");
-    let router = routes::create_router_with_tx(pool, config.api_key, &config.allowed_origins, config.rate_limit_per_minute, health_state, indexer_state, prometheus_handle, event_tx);
+    let router = routes::create_router_with_tx(pool, config.api_key, &config.allowed_origins, config.rate_limit_per_minute, health_state, indexer_state, prometheus_handle, event_tx, config.sse_keepalive_interval_ms);
 
     info!(addr = %addr, "Soroban Pulse listening");
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -34,6 +34,13 @@ pub struct StreamParams {
     pub contract_id: Option<String>,
 }
 
+#[derive(Debug, Serialize, sqlx::FromRow, utoipa::ToSchema)]
+pub struct ContractSummary {
+    pub contract_id: String,
+    pub event_count: i64,
+    pub latest_ledger: i64,
+}
+
 impl PaginationParams {
     pub const ALLOWED_FIELDS: &'static [&'static str] = &[
         "id",

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -33,6 +33,7 @@ pub struct AppState {
     pub indexer_state: Arc<IndexerState>,
     pub prometheus_handle: PrometheusHandle,
     pub event_tx: broadcast::Sender<SorobanEvent>,
+    pub sse_keepalive_interval_ms: u64,
 }
 
 /// OpenAPI spec — all paths are documented via #[utoipa::path] on handlers.
@@ -50,10 +51,12 @@ pub struct AppState {
         handlers::get_events_by_contract,
         handlers::get_events_by_tx,
         handlers::stream_events,
+        handlers::get_contracts,
     ),
     components(schemas(
         crate::models::Event,
         crate::models::PaginationParams,
+        crate::models::ContractSummary,
     )),
     tags(
         (name = "events", description = "Event indexing endpoints"),
@@ -71,7 +74,7 @@ pub fn create_router(
     indexer_state: Arc<IndexerState>,
     prometheus_handle: PrometheusHandle,
 ) -> Router {
-    create_router_with_tx(pool, api_key, allowed_origins, rate_limit_per_minute, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0)
+    create_router_with_tx(pool, api_key, allowed_origins, rate_limit_per_minute, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0, 15000)
 }
 
 pub fn create_router_with_tx(
@@ -83,10 +86,11 @@ pub fn create_router_with_tx(
     indexer_state: Arc<IndexerState>,
     prometheus_handle: PrometheusHandle,
     event_tx: broadcast::Sender<SorobanEvent>,
+    sse_keepalive_interval_ms: u64,
 ) -> Router {
     let cors = build_cors(allowed_origins);
     let auth_state = Arc::new(middleware::AuthState { api_key });
-    let app_state = AppState { pool, health_state, indexer_state, prometheus_handle, event_tx };
+    let app_state = AppState { pool, health_state, indexer_state, prometheus_handle, event_tx, sse_keepalive_interval_ms };
 
     let _period_secs = 60u64.div_ceil(u64::from(rate_limit_per_minute));
 
@@ -95,7 +99,8 @@ pub fn create_router_with_tx(
         .route("/events", get(handlers::get_events))
         .route("/events/stream", get(handlers::stream_events))
         .route("/events/contract/:contract_id", get(handlers::get_events_by_contract))
-        .route("/events/tx/:tx_hash", get(handlers::get_events_by_tx));
+        .route("/events/tx/:tx_hash", get(handlers::get_events_by_tx))
+        .route("/contracts", get(handlers::get_contracts));
 
     // Unversioned deprecated aliases (same handlers, add Deprecation header via middleware)
     let deprecated = Router::new()
@@ -103,6 +108,7 @@ pub fn create_router_with_tx(
         .route("/events/stream", get(handlers::stream_events))
         .route("/events/contract/:contract_id", get(handlers::get_events_by_contract))
         .route("/events/tx/:tx_hash", get(handlers::get_events_by_tx))
+        .route("/contracts", get(handlers::get_contracts))
         .layer(axum::middleware::from_fn(|req: Request<Body>, next: axum::middleware::Next| async move {
             let mut resp = next.run(req).await;
             resp.headers_mut().insert(


### PR DESCRIPTION
#158 - Dockerfile multi-stage build with cargo-chef
- Replace dummy src/main.rs cache trick with cargo-chef stages
- Add chef/planner/builder/runtime stages
- Bump base image to rust:1.87-slim

#159 - Add GET /v1/contracts endpoint
- Add ContractSummary model with contract_id, event_count, latest_ledger
- Add get_contracts handler with 30s in-process TTL cache
- Register /v1/contracts and deprecated /contracts alias
- Add to OpenAPI spec; integration tests for shape and deprecation header

#160 - Configurable indexer poll interval
- Add INDEXER_POLL_INTERVAL_MS (default 5000, range 100-60000)
- Add INDEXER_ERROR_BACKOFF_MS (default 10000, range 100-60000)
- Replace hardcoded Duration::from_secs literals in run_loop
- Document both vars in .env.example

#161 - SSE heartbeat and reconnection handling
- Add SSE_KEEPALIVE_INTERVAL_MS config (default 15000, range 1000-60000)
- Configure explicit KeepAlive interval with ping comment text
- Add id: and retry: fields to each SSE event
- Replay missed events from DB on Last-Event-ID reconnection
- Add sse_keepalive_interval_ms to AppState and create_router_with_tx
- Add http-body-util dev-dependency for frame-level SSE test
- Document SSE_KEEPALIVE_INTERVAL_MS in .env.example
Closes #158 
Closes #159 
Closes #160 
Closes #161 