### PR TITLE
Add per-route metrics labels for accurate latency tracking

### DIFF
--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,5 +1,6 @@
 use axum::{body::Body, routing::get, Router};
 use axum::http::{HeaderValue, Method, Request};
+use axum::extract::MatchedPath;
 use sqlx::PgPool;
 use std::sync::Arc;
 use std::time::Instant;
@@ -132,7 +133,10 @@ pub fn create_router_with_tx(
         ))
         .layer(axum::middleware::from_fn(|req: axum::http::Request<Body>, next: axum::middleware::Next| async move {
             let method = req.method().as_str().to_string();
-            let route = req.uri().path().to_string();
+            let route = req.extensions()
+                .get::<MatchedPath>()
+                .map(|p| p.as_str().to_string())
+                .unwrap_or_else(|| "<unknown>".to_string());
             let start = Instant::now();
             let response = next.run(req).await;
             let duration = start.elapsed();


### PR DESCRIPTION
Use Axum's MatchedPath extractor to record the matched route pattern (e.g., /v1/events/contract/:contract_id) instead of the actual URI path in the soroban_pulse_http_request_duration_seconds metric.

This prevents metric cardinality explosion where each unique contract ID or transaction hash would create a separate metric series. Now all requests to /v1/events/contract/* are recorded under the same series with the label /v1/events/contract/:contract_id.

Unmatched routes (404s) use the label <unknown> to distinguish them from valid routes.

This change makes Prometheus dashboards usable and prevents overwhelming the metrics system with high-cardinality data.

Closes #163

## Summary

<!-- A clear, concise description of what this PR does. -->

## Related Issue

Closes #<!-- issue number -->

## Changes

<!-- List the key changes made. -->

- 

## Testing

<!-- Describe how you tested this. -->

- [ ] `cargo test` passes
- [ ] `cargo clippy` reports no warnings
- [ ] Manually tested locally

## Notes

<!-- Anything reviewers should pay special attention to, or N/A. -->
