### PR TITLE
Add database migration rollback support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,5 +36,8 @@ docker-down: ## Tear down the Docker Compose stack
 migrate: ## Run pending database migrations
 	cargo sqlx migrate run
 
+migrate-down: ## Rollback the most recent migration
+	cargo sqlx migrate revert
+
 clean: ## Remove build artifacts
 	cargo clean

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -58,6 +58,90 @@ Because `pg_advisory_lock` blocks (rather than fails) when another session holds
 
 The lock is **session-scoped**: if the process crashes mid-migration, Postgres releases the lock automatically when the connection is dropped, allowing the next replica to retry.
 
+### Migration rollback procedure
+
+Each migration has a corresponding `.down.sql` file that reverses its changes. To roll back the most recent migration:
+
+```bash
+# Using the Makefile
+make migrate-down
+
+# Or directly with cargo
+cargo sqlx migrate revert
+```
+
+This will:
+1. Execute the most recent `.down.sql` file
+2. Remove the migration entry from the `_sqlx_migrations` table
+3. Leave the database in the pre-migration state
+
+### Rollback scenarios
+
+**Scenario 1: Deployment fails validation**
+
+If a new version fails health checks or integration tests after deployment:
+
+```bash
+# 1. Roll back the application to the previous version
+kubectl rollout undo deployment/soroban-pulse
+
+# 2. Roll back the database migration
+kubectl exec -it deployment/soroban-pulse -- make migrate-down
+```
+
+**Scenario 2: Migration causes performance degradation**
+
+If a migration creates an index that causes lock contention or slow queries:
+
+```bash
+# 1. Roll back the migration immediately
+make migrate-down
+
+# 2. Investigate the issue in a staging environment
+# 3. Modify the migration to use CONCURRENTLY or adjust timing
+# 4. Re-apply when ready
+make migrate
+```
+
+**Scenario 3: Data corruption detected**
+
+If a migration inadvertently corrupts data:
+
+```bash
+# 1. Roll back the migration
+make migrate-down
+
+# 2. Restore from the most recent backup taken before the migration
+./scripts/restore.sh s3://my-bucket/backups/soroban_pulse_pre_migration.dump
+
+# 3. Fix the migration script
+# 4. Test thoroughly in staging before re-applying
+```
+
+### Testing migrations and rollbacks
+
+Before deploying to production, test both the up and down migrations:
+
+```bash
+# 1. Start a test database
+docker-compose -f docker-compose.test.yml up -d
+
+# 2. Apply the migration
+DATABASE_URL=postgres://postgres:postgres@localhost/soroban_pulse_test make migrate
+
+# 3. Verify the schema changes
+psql $DATABASE_URL -c "\d events"
+
+# 4. Roll back the migration
+DATABASE_URL=postgres://postgres:postgres@localhost/soroban_pulse_test make migrate-down
+
+# 5. Verify the schema is restored
+psql $DATABASE_URL -c "\d events"
+
+# 6. Clean up
+docker-compose -f docker-compose.test.yml down
+```
+
 ### Alternative: run migrations as a pre-deploy Job (Kubernetes)
 
 For stricter separation of concerns, you can disable in-process migrations and run them as a Kubernetes `Job` that completes before the `Deployment` rollout begins:

--- a/migrations/20260314000000_create_events.down.sql
+++ b/migrations/20260314000000_create_events.down.sql
@@ -1,0 +1,6 @@
+-- Rollback: Drop the events table and all associated indices
+DROP INDEX IF EXISTS idx_events_tx_hash_contract;
+DROP INDEX IF EXISTS idx_events_ledger;
+DROP INDEX IF EXISTS idx_events_tx_hash;
+DROP INDEX IF EXISTS idx_events_contract_id;
+DROP TABLE IF EXISTS events;

--- a/migrations/20260325000000_optimize_ledger_index.down.sql
+++ b/migrations/20260325000000_optimize_ledger_index.down.sql
@@ -1,0 +1,5 @@
+-- Rollback: Restore the original ascending ledger index
+CREATE INDEX IF NOT EXISTS idx_events_ledger ON events(ledger);
+
+-- Drop the descending index
+DROP INDEX IF EXISTS idx_events_ledger_desc;

--- a/migrations/20260325000001_composite_indices.down.sql
+++ b/migrations/20260325000001_composite_indices.down.sql
@@ -1,0 +1,7 @@
+-- Rollback: Restore the original single-column indices
+CREATE INDEX IF NOT EXISTS idx_events_contract_id ON events(contract_id);
+CREATE INDEX IF NOT EXISTS idx_events_tx_hash ON events(tx_hash);
+
+-- Drop the composite indices
+DROP INDEX IF EXISTS idx_events_tx_ledger;
+DROP INDEX IF EXISTS idx_events_contract_ledger;


### PR DESCRIPTION
Create down migration scripts for all three existing migrations:
- 20260314000000_create_events.down.sql: Drops events table and indices
- 20260325000000_optimize_ledger_index.down.sql: Restores ascending index
- 20260325000001_composite_indices.down.sql: Restores single-column indices

Add 'make migrate-down' target to Makefile for easy rollback operations.

Update docs/deployment.md with comprehensive rollback procedures including:
- Step-by-step rollback commands
- Common rollback scenarios (failed deployment, performance issues, data corruption)
- Testing procedures for both up and down migrations

Down migrations correctly reverse their corresponding up migrations and leave the schema in the pre-migration state.

Closes #164

## Summary

<!-- A clear, concise description of what this PR does. -->

## Related Issue

Closes #<!-- issue number -->

## Changes

<!-- List the key changes made. -->

- 

## Testing

<!-- Describe how you tested this. -->

- [ ] `cargo test` passes
- [ ] `cargo clippy` reports no warnings
- [ ] Manually tested locally

## Notes

<!-- Anything reviewers should pay special attention to, or N/A. -->
