### PR TITLE
Feature/issues 154 155 156 157

### DIFF
--- a/migrations/20260424000000_gin_index_event_data.sql
+++ b/migrations/20260424000000_gin_index_event_data.sql
@@ -1,0 +1,7 @@
+-- no-transaction
+-- CREATE INDEX CONCURRENTLY cannot run inside a transaction block.
+-- SQLx skips the implicit transaction wrapper when a migration starts with "-- no-transaction".
+-- IF NOT EXISTS makes this idempotent; a DO/EXCEPTION block is unnecessary and would
+-- reintroduce a transaction context, which is incompatible with CONCURRENTLY.
+CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_events_event_data_gin
+    ON events USING GIN (event_data jsonb_path_ops);

--- a/src/config.rs
+++ b/src/config.rs
@@ -124,6 +124,7 @@ pub struct Config {
     pub indexer_stall_timeout_secs: u64,
     pub db_statement_timeout_ms: u64,
     pub environment: Environment,
+    pub max_body_size_bytes: usize,
 }
 
 impl Default for Config {
@@ -308,6 +309,10 @@ impl Config {
                 .unwrap_or_else(|_| "5000".to_string())
                 .parse()
                 .expect("DB_STATEMENT_TIMEOUT_MS must be a number"),
+            max_body_size_bytes: env::var("MAX_BODY_SIZE_BYTES")
+                .unwrap_or_else(|_| "1048576".to_string())
+                .parse()
+                .expect("MAX_BODY_SIZE_BYTES must be a number"),
             environment,
         }
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,15 @@
 use thiserror::Error;
 use axum::{http::StatusCode, response::{IntoResponse, Response}, Json};
-use serde_json::json;
+use serde::Serialize;
 use uuid::Uuid;
+
+/// Machine-readable error response body.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ErrorResponse {
+    pub error: String,
+    pub code: &'static str,
+    pub correlation_id: String,
+}
 
 #[derive(Debug, Error)]
 pub enum AppError {
@@ -25,20 +33,25 @@ pub enum AppError {
 impl IntoResponse for AppError {
     fn into_response(self) -> Response {
         let correlation_id = Uuid::new_v4().to_string();
-        
-        let (status, message) = match &self {
-            AppError::NotFound => (StatusCode::NOT_FOUND, "not found".to_string()),
-            AppError::Validation(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+
+        let (status, message, code) = match &self {
+            AppError::NotFound => (StatusCode::NOT_FOUND, "not found".to_string(), "NOT_FOUND"),
+            AppError::Validation(msg) => (StatusCode::BAD_REQUEST, msg.clone(), "VALIDATION_ERROR"),
             AppError::Database(e) => {
                 if is_query_timeout(e) {
-                    return (StatusCode::SERVICE_UNAVAILABLE, Json(json!({ "error": "query timeout" }))).into_response();
+                    let body = ErrorResponse {
+                        error: "query timeout".to_string(),
+                        code: "DATABASE_ERROR",
+                        correlation_id,
+                    };
+                    return (StatusCode::SERVICE_UNAVAILABLE, Json(body)).into_response();
                 }
                 tracing::error!(
                     correlation_id = %correlation_id,
                     error = %e,
                     "Database error"
                 );
-                (StatusCode::INTERNAL_SERVER_ERROR, "internal server error".to_string())
+                (StatusCode::INTERNAL_SERVER_ERROR, "internal server error".to_string(), "DATABASE_ERROR")
             }
             AppError::Http(e) => {
                 tracing::error!(
@@ -46,7 +59,7 @@ impl IntoResponse for AppError {
                     error = %e,
                     "HTTP error"
                 );
-                (StatusCode::INTERNAL_SERVER_ERROR, "internal server error".to_string())
+                (StatusCode::INTERNAL_SERVER_ERROR, "internal server error".to_string(), "INTERNAL_ERROR")
             }
             AppError::Internal(msg) => {
                 tracing::error!(
@@ -54,11 +67,12 @@ impl IntoResponse for AppError {
                     error = %msg,
                     "Internal error"
                 );
-                (StatusCode::INTERNAL_SERVER_ERROR, "internal server error".to_string())
+                (StatusCode::INTERNAL_SERVER_ERROR, "internal server error".to_string(), "INTERNAL_ERROR")
             }
         };
-        
-        (status, Json(json!({ "error": message }))).into_response()
+
+        let body = ErrorResponse { error: message, code, correlation_id };
+        (status, Json(body)).into_response()
     }
 }
 

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -637,6 +637,8 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["error"], "invalid contract_id format");
+        assert_eq!(v["code"], "VALIDATION_ERROR");
+        assert!(v["correlation_id"].as_str().is_some());
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -657,6 +659,8 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["error"], "invalid contract_id format");
+        assert_eq!(v["code"], "VALIDATION_ERROR");
+        assert!(v["correlation_id"].as_str().is_some());
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -677,6 +681,8 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["error"], "invalid tx_hash format");
+        assert_eq!(v["code"], "VALIDATION_ERROR");
+        assert!(v["correlation_id"].as_str().is_some());
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -698,6 +704,8 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["error"], "invalid tx_hash format");
+        assert_eq!(v["code"], "VALIDATION_ERROR");
+        assert!(v["correlation_id"].as_str().is_some());
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -719,6 +727,8 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["error"], "invalid tx_hash format");
+        assert_eq!(v["code"], "VALIDATION_ERROR");
+        assert!(v["correlation_id"].as_str().is_some());
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -1119,6 +1129,8 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert!(v["error"].as_str().unwrap().contains("event_type must be one of"));
+        assert_eq!(v["code"], "VALIDATION_ERROR");
+        assert!(v["correlation_id"].as_str().is_some());
     }
 
     #[sqlx::test(migrations = "./migrations")]
@@ -1139,6 +1151,8 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let v: Value = serde_json::from_slice(&body).unwrap();
         assert!(v["error"].as_str().unwrap().contains("from_ledger must be <= to_ledger"));
+        assert_eq!(v["code"], "VALIDATION_ERROR");
+        assert!(v["correlation_id"].as_str().is_some());
     }
 
     // Events by contract tests - Happy path

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,6 @@
+pub mod config;
+pub mod error;
+pub mod metrics;
+pub mod middleware;
 pub mod models;
+pub mod routes;

--- a/src/main.rs
+++ b/src/main.rs
@@ -166,7 +166,7 @@ async fn main() -> anyhow::Result<()> {
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     info!(origins = ?config.allowed_origins, "Allowed CORS origins");
     info!(rate_limit = config.rate_limit_per_minute, "Rate limit per IP");
-    let router = routes::create_router_with_tx(pool, config.api_key, &config.allowed_origins, config.rate_limit_per_minute, health_state, indexer_state, prometheus_handle, event_tx);
+    let router = routes::create_router_with_tx(pool, config.api_key, &config.allowed_origins, config.rate_limit_per_minute, health_state, indexer_state, prometheus_handle, event_tx, config.max_body_size_bytes);
 
     info!(addr = %addr, "Soroban Pulse listening");
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -7,6 +7,7 @@ use tokio::sync::broadcast;
 use tower_http::{
     compression::CompressionLayer,
     cors::CorsLayer,
+    limit::RequestBodyLimitLayer,
     request_id::{MakeRequestId, PropagateRequestIdLayer, RequestId, SetRequestIdLayer},
     trace::TraceLayer,
 };
@@ -54,6 +55,7 @@ pub struct AppState {
     components(schemas(
         crate::models::Event,
         crate::models::PaginationParams,
+        crate::error::ErrorResponse,
     )),
     tags(
         (name = "events", description = "Event indexing endpoints"),
@@ -70,8 +72,9 @@ pub fn create_router(
     health_state: Arc<HealthState>,
     indexer_state: Arc<IndexerState>,
     prometheus_handle: PrometheusHandle,
+    max_body_size_bytes: usize,
 ) -> Router {
-    create_router_with_tx(pool, api_key, allowed_origins, rate_limit_per_minute, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0)
+    create_router_with_tx(pool, api_key, allowed_origins, rate_limit_per_minute, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0, max_body_size_bytes)
 }
 
 pub fn create_router_with_tx(
@@ -83,6 +86,7 @@ pub fn create_router_with_tx(
     indexer_state: Arc<IndexerState>,
     prometheus_handle: PrometheusHandle,
     event_tx: broadcast::Sender<SorobanEvent>,
+    max_body_size_bytes: usize,
 ) -> Router {
     let cors = build_cors(allowed_origins);
     let auth_state = Arc::new(middleware::AuthState { api_key });
@@ -160,6 +164,7 @@ pub fn create_router_with_tx(
         .layer(PropagateRequestIdLayer::x_request_id())
         .layer(CompressionLayer::new())
         .layer(SetRequestIdLayer::x_request_id(UuidMakeRequestId))
+        .layer(RequestBodyLimitLayer::new(max_body_size_bytes))
         .with_state(app_state)
 }
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -1,16 +1,137 @@
-// Integration tests for SorobanPulse
-// This file contains integration tests that verify the overall system behavior
+use axum::body::{to_bytes, Body};
+use axum::http::{header, Request, StatusCode};
+use sqlx::PgPool;
+use std::sync::Arc;
+use tower::ServiceExt;
 
-#[tokio::test]
-async fn test_health_endpoint_integration() {
-    // TODO: Set up test server and verify health endpoint
-    // This will be implemented once we have test utilities set up
-    assert!(true); // Placeholder
+use soroban_pulse::config::{HealthState, IndexerState};
+use soroban_pulse::metrics::init_metrics;
+use soroban_pulse::routes::create_router;
+
+fn make_router(pool: PgPool, api_key: Option<String>) -> axum::Router {
+    let health_state = Arc::new(HealthState::new(60));
+    health_state.update_last_poll();
+    let indexer_state = Arc::new(IndexerState::new());
+    let prometheus_handle = init_metrics();
+    create_router(pool, api_key, &[], 60, health_state, indexer_state, prometheus_handle, 1_048_576)
 }
 
-#[tokio::test]
-async fn test_api_basic_functionality() {
-    // TODO: Test basic API functionality with test database
-    // This will be implemented once we have test utilities set up
-    assert!(true); // Placeholder
+// --- Health ---
+
+#[sqlx::test(migrations = "./migrations")]
+async fn health_ready_with_live_db_returns_200(pool: PgPool) {
+    let app = make_router(pool, None);
+
+    let resp = app
+        .oneshot(Request::builder().uri("/healthz/ready").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(resp.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["db"], "ok");
+    assert_eq!(body["indexer"], "ok");
+}
+
+// --- Auth middleware ---
+
+#[sqlx::test(migrations = "./migrations")]
+async fn request_without_api_key_returns_401_when_key_configured(pool: PgPool) {
+    let app = make_router(pool, Some("secret".to_string()));
+
+    let resp = app
+        .oneshot(Request::builder().uri("/v1/events").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn request_with_bearer_token_passes_auth(pool: PgPool) {
+    let app = make_router(pool, Some("secret".to_string()));
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/events")
+                .header(header::AUTHORIZATION, "Bearer secret")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn request_with_x_api_key_header_passes_auth(pool: PgPool) {
+    let app = make_router(pool, Some("secret".to_string()));
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/events")
+                .header("X-Api-Key", "secret")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn health_endpoint_bypasses_auth(pool: PgPool) {
+    let app = make_router(pool, Some("secret".to_string()));
+
+    let resp = app
+        .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_ne!(resp.status(), StatusCode::UNAUTHORIZED);
+}
+
+// --- Deprecation headers on unversioned routes ---
+
+#[sqlx::test(migrations = "./migrations")]
+async fn unversioned_events_route_returns_deprecation_header(pool: PgPool) {
+    let app = make_router(pool, None);
+
+    let resp = app
+        .oneshot(Request::builder().uri("/events").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert_eq!(resp.headers().get("Deprecation").unwrap(), "true");
+    assert!(resp
+        .headers()
+        .get("Link")
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .contains("/v1/events"));
+}
+
+// --- Metrics endpoint ---
+
+#[sqlx::test(migrations = "./migrations")]
+async fn metrics_endpoint_returns_prometheus_text(pool: PgPool) {
+    let app = make_router(pool, None);
+
+    let resp = app
+        .oneshot(Request::builder().uri("/metrics").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body =
+        String::from_utf8(to_bytes(resp.into_body(), usize::MAX).await.unwrap().to_vec()).unwrap();
+    assert!(body.contains("soroban_pulse"));
 }


### PR DESCRIPTION
Closes #154 
Closes #155 
Closes #156 
Closes #157 

## Summary

Four hardening improvements across security, observability, testing, and database performance.

## Changes

#154 — Request body size limit
- Added MAX_BODY_SIZE_BYTES env var to Config (default 1 MB)
- Applied RequestBodyLimitLayer globally to all routes; oversized requests receive 413 Payload Too Large

#155 — Structured error codes
- All error responses now include code (VALIDATION_ERROR, NOT_FOUND, DATABASE_ERROR, INTERNAL_ERROR) and correlation_id alongside the existing error message
- ErrorResponse struct registered in the OpenAPI schema
- Existing error-path tests updated to assert on the new fields

#156 — Real integration tests
- Replaced two assert!(true) placeholders in tests/integration_tests.rs with 7 real tests
- Exported config, error, metrics, middleware, routes from lib.rs to make them accessible to the integration test binary
- Tests cover: /healthz/ready with a live DB, auth middleware rejection (401), Bearer and X-Api-Key pass-through, /health auth bypass, Deprecation: true header on unversioned 
routes, and Prometheus text format on /metrics
- All tests use #[sqlx::test(migrations = "./migrations")] for isolated per-test databases

#157 — GIN index on event_data
- New migration 20260424000000_gin_index_event_data.sql
- CREATE INDEX CONCURRENTLY IF NOT EXISTS with jsonb_path_ops enables efficient @> containment queries (e.g. filtering by topic) without a full table scan
- Migration starts with -- no-transaction so SQLx skips the implicit transaction wrapper, which is required for CONCURRENTLY

## Testing

- Existing unit tests in src/handlers.rs updated for the new error response shape
- New integration tests cover the cross-cutting concerns added in this PR
- Migration is idempotent via IF NOT EXISTS