### PR TITLE
feat: add from_ledger/to_ledger filtering to GET /v1/events/contract/…

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 use chrono::{DateTime, Utc};
 
 use std::sync::atomic::Ordering;
-use crate::{error::AppError, models::{ContractSummary, PaginationParams, StreamParams}, routes::AppState};
+use crate::{error::AppError, models::{self, ContractSummary, PaginationParams, StreamParams}, routes::AppState};
 
 /// Simple in-process cache entry for the contracts list.
 struct CacheEntry {
@@ -625,10 +625,14 @@ pub async fn get_events(
     tag = "events",
     params(
         ("contract_id" = String, Path, description = "Stellar contract ID (56-char, starts with C)"),
+        ("page" = Option<i64>, Query, description = "Page number (default: 1)"),
+        ("limit" = Option<i64>, Query, description = "Results per page, 1–100 (default: 20)"),
+        ("from_ledger" = Option<i64>, Query, description = "Return events at or after this ledger"),
+        ("to_ledger" = Option<i64>, Query, description = "Return events at or before this ledger"),
     ),
     responses(
         (status = 200, description = "Events for the given contract"),
-        (status = 400, description = "Invalid contract_id format"),
+        (status = 400, description = "Invalid contract_id format or ledger range"),
         (status = 404, description = "No events found for contract"),
     )
 )]
@@ -639,26 +643,68 @@ pub async fn get_events_by_contract(
 ) -> Result<Json<Value>, AppError> {
     validate_contract_id(&contract_id)?;
 
+    // Validate ledger range
+    if let (Some(from), Some(to)) = (params.from_ledger, params.to_ledger) {
+        if from > to {
+            return Err(AppError::Validation(
+                "from_ledger must be <= to_ledger".to_string(),
+            ));
+        }
+    }
+
     let limit = params.limit();
     let offset = params.offset();
     let columns = params.columns();
 
-    let rows: Vec<models::Event> = sqlx::query_as::<_, models::Event>(
-        "SELECT * FROM events WHERE contract_id = $1 ORDER BY ledger DESC LIMIT $2 OFFSET $3",
-    )
-    .bind(&contract_id)
-    .bind(limit)
-    .bind(offset)
-    .fetch_all(&state.pool)
-    .await?;
+    // Build query dynamically based on optional ledger filters
+    let mut conditions: Vec<String> = vec!["contract_id = $1".to_string()];
+    let mut bind_idx: i32 = 2;
+
+    if params.from_ledger.is_some() {
+        conditions.push(format!("ledger >= ${bind_idx}"));
+        bind_idx += 1;
+    }
+    if params.to_ledger.is_some() {
+        conditions.push(format!("ledger <= ${bind_idx}"));
+        bind_idx += 1;
+    }
+
+    let where_clause = format!("WHERE {}", conditions.join(" AND "));
+    let query_str = format!(
+        "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, created_at, 0::bigint AS total_count \
+         FROM events {} ORDER BY ledger DESC LIMIT ${} OFFSET ${}",
+        where_clause, bind_idx, bind_idx + 1,
+    );
+
+    let mut q = sqlx::query_as::<_, models::Event>(&query_str).bind(&contract_id);
+    if let Some(fl) = params.from_ledger { q = q.bind(fl); }
+    if let Some(tl) = params.to_ledger { q = q.bind(tl); }
+    q = q.bind(limit).bind(offset);
+
+    let rows = q.fetch_all(&state.pool).await?;
 
     if rows.is_empty() {
         return Err(AppError::NotFound);
     }
 
-    let events = rows_to_json(&rows, &columns)?;
+    let events: Vec<Value> = rows.iter().map(|e| filter_fields(e, &columns)).collect();
 
-    Ok(Json(json!({ "data": events, "contract_id": contract_id })))
+    let mut response = json!({
+        "data": events,
+        "contract_id": contract_id,
+        "page": params.page.unwrap_or(1),
+        "limit": limit,
+    });
+
+    // Echo back applied filters for client confirmation
+    if let Some(fl) = params.from_ledger {
+        response["from_ledger"] = json!(fl);
+    }
+    if let Some(tl) = params.to_ledger {
+        response["to_ledger"] = json!(tl);
+    }
+
+    Ok(Json(response))
 }
 
 #[utoipa::path(

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -135,3 +135,107 @@ async fn metrics_endpoint_returns_prometheus_text(pool: PgPool) {
         String::from_utf8(to_bytes(resp.into_body(), usize::MAX).await.unwrap().to_vec()).unwrap();
     assert!(body.contains("soroban_pulse"));
 }
+
+// --- Issue #185: from_ledger / to_ledger on contract endpoint ---
+
+async fn insert_contract_events(pool: &PgPool, contract_id: &str, ledgers: &[i64]) {
+    for (i, &ledger) in ledgers.iter().enumerate() {
+        sqlx::query(
+            "INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data)
+             VALUES ($1, $2, $3, $4, NOW(), $5)",
+        )
+        .bind(contract_id)
+        .bind("contract")
+        .bind(format!("{:0>63}{}", i, ledger))
+        .bind(ledger)
+        .bind(serde_json::json!({}))
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn contract_ledger_range_filters_correctly(pool: PgPool) {
+    let contract_id = "C1234567890123456789012345678901234567890123456789012345";
+    insert_contract_events(&pool, contract_id, &[100, 200, 300, 400, 500]).await;
+
+    let app = make_router(pool, None);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/v1/events/contract/{}?from_ledger=200&to_ledger=400",
+                    contract_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(resp.into_body(), usize::MAX).await.unwrap()).unwrap();
+
+    let data = body["data"].as_array().unwrap();
+    assert_eq!(data.len(), 3);
+    for event in data {
+        let ledger = event["ledger"].as_i64().unwrap();
+        assert!((200..=400).contains(&ledger));
+    }
+    assert_eq!(body["from_ledger"], 200);
+    assert_eq!(body["to_ledger"], 400);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn contract_ledger_range_inverted_returns_400(pool: PgPool) {
+    let contract_id = "C1234567890123456789012345678901234567890123456789012345";
+    insert_contract_events(&pool, contract_id, &[100]).await;
+
+    let app = make_router(pool, None);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/v1/events/contract/{}?from_ledger=500&to_ledger=100",
+                    contract_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(resp.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert!(body["error"]
+        .as_str()
+        .unwrap()
+        .contains("from_ledger must be <= to_ledger"));
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn contract_without_ledger_range_returns_all_events(pool: PgPool) {
+    let contract_id = "C1234567890123456789012345678901234567890123456789012345";
+    insert_contract_events(&pool, contract_id, &[100, 200, 300]).await;
+
+    let app = make_router(pool, None);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/events/contract/{}", contract_id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(resp.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert_eq!(body["data"].as_array().unwrap().len(), 3);
+    assert!(body.get("from_ledger").is_none());
+    assert!(body.get("to_ledger").is_none());
+}


### PR DESCRIPTION
…:id (#185)

- Accept from_ledger and to_ledger query parameters on the contract endpoint
- Return 400 Bad Request when from_ledger > to_ledger
- Dynamically build SQL WHERE clause with ledger range conditions
- Echo applied filter values in response for client confirmation
- Update OpenAPI spec with new query parameters
- Add integration tests for filtering, inverted range, and no-filter cases

Closes #185

