### PR TITLE
feat: return 400 for unknown field names in fields query parameter (#…

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -71,7 +71,16 @@ fn rows_to_json(rows: &[sqlx::postgres::PgRow], columns: &[&str]) -> Result<Vec<
     Ok(events)
 }
 
-fn validate_contract_id(contract_id: &str) -> Result<(), AppError> {
+/// Resolve requested columns or return a 400 with unknown field names.
+fn resolve_columns<'a>(params: &'a PaginationParams) -> Result<Vec<&'a str>, AppError> {
+    params.columns().map_err(|(unknown, allowed)| {
+        AppError::Validation(format!(
+            "unknown fields: [{}]; valid fields are: [{}]",
+            unknown.join(", "),
+            allowed.join(", ")
+        ))
+    })
+}
     if contract_id.len() != 56 {
         return Err(AppError::Validation("invalid contract_id format".to_string()));
     }
@@ -470,7 +479,7 @@ pub async fn get_events(
     }
 
     let limit = params.limit();
-    let columns = params.columns();
+    let columns = resolve_columns(&params)?;
 
     // Cursor-based path
     if let Some(ref cursor_str) = params.cursor {
@@ -641,7 +650,7 @@ pub async fn get_events_by_contract(
 
     let limit = params.limit();
     let offset = params.offset();
-    let columns = params.columns();
+    let columns = resolve_columns(&params)?;
 
     let rows: Vec<models::Event> = sqlx::query_as::<_, models::Event>(
         "SELECT * FROM events WHERE contract_id = $1 ORDER BY ledger DESC LIMIT $2 OFFSET $3",
@@ -680,7 +689,7 @@ pub async fn get_events_by_tx(
 ) -> Result<Json<Value>, AppError> {
     validate_tx_hash(&tx_hash)?;
 
-    let columns = params.columns();
+    let columns = resolve_columns(&params)?;
 
     let events = rows_to_json(&rows, &columns)?;
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -109,14 +109,21 @@ impl PaginationParams {
         "created_at",
     ];
 
-    pub fn columns(&self) -> Vec<&str> {
+    pub fn columns(&self) -> Result<Vec<&str>, (Vec<String>, Vec<&'static str>)> {
         match &self.fields {
-            Some(f) if !f.trim().is_empty() => f
-                .split(',')
-                .map(|s| s.trim())
-                .filter(|s| Self::ALLOWED_FIELDS.contains(s))
-                .collect(),
-            _ => Self::ALLOWED_FIELDS.to_vec(),
+            Some(f) if !f.trim().is_empty() => {
+                let requested: Vec<&str> = f.split(',').map(|s| s.trim()).collect();
+                let unknown: Vec<String> = requested
+                    .iter()
+                    .filter(|s| !Self::ALLOWED_FIELDS.contains(s))
+                    .map(|s| s.to_string())
+                    .collect();
+                if !unknown.is_empty() {
+                    return Err((unknown, Self::ALLOWED_FIELDS));
+                }
+                Ok(requested)
+            }
+            _ => Ok(Self::ALLOWED_FIELDS.to_vec()),
         }
     }
     pub fn offset(&self) -> i64 {

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -135,3 +135,61 @@ async fn metrics_endpoint_returns_prometheus_text(pool: PgPool) {
         String::from_utf8(to_bytes(resp.into_body(), usize::MAX).await.unwrap().to_vec()).unwrap();
     assert!(body.contains("soroban_pulse"));
 }
+
+// --- Issue #183: unknown fields return 400 ---
+
+#[sqlx::test(migrations = "./migrations")]
+async fn unknown_field_returns_400_with_details(pool: PgPool) {
+    let app = make_router(pool, None);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/events?fields=ledger,contarct_id")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(resp.into_body(), usize::MAX).await.unwrap()).unwrap();
+    let error = body["error"].as_str().unwrap();
+    assert!(error.contains("contarct_id"), "error should list unrecognized field");
+    assert!(error.contains("contract_id"), "error should list valid fields");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn valid_fields_param_returns_200(pool: PgPool) {
+    let app = make_router(pool, None);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/events?fields=ledger,contract_id")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn omitted_fields_param_returns_all_fields(pool: PgPool) {
+    let app = make_router(pool, None);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/events")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+}


### PR DESCRIPTION
…183)

- columns() in PaginationParams now returns Result<Vec<&str>, (Vec<String>, &[&str])>
- Unknown field names cause a 400 Bad Request with the list of unrecognized fields and the list of valid field names in the error message
- Add resolve_columns() helper in handlers.rs to convert the error into AppError
- Valid fields and omitted fields parameter continue to work as before
- Add integration tests for unknown field (400), valid fields (200), omitted fields (200)

Closes #183

