### PR TITLE
feat: expose indexer_mode in GET /status endpoint (#182)

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use std::env;
-use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use url::Url;
@@ -8,6 +8,8 @@ use url::Url;
 pub struct IndexerState {
     pub current_ledger: AtomicU64,
     pub latest_ledger: AtomicU64,
+    /// True when this replica holds the advisory lock and is actively indexing.
+    pub is_active_indexer: AtomicBool,
     started_at: u64,
 }
 
@@ -20,6 +22,7 @@ impl IndexerState {
         Self {
             current_ledger: AtomicU64::new(0),
             latest_ledger: AtomicU64::new(0),
+            is_active_indexer: AtomicBool::new(false),
             started_at,
         }
     }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -221,6 +221,12 @@ pub async fn status(State(state): State<AppState>) -> Json<Value> {
         "running"
     };
 
+    let indexer_mode = if state.indexer_state.is_active_indexer.load(Ordering::Relaxed) {
+        "active"
+    } else {
+        "read_only"
+    };
+
     let total_events: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM events")
         .fetch_one(&state.pool)
         .await
@@ -256,6 +262,7 @@ pub async fn status(State(state): State<AppState>) -> Json<Value> {
         "total_events": total_events,
         "events_by_type": events_by_type,
         "indexer_status": indexer_status,
+        "indexer_mode": indexer_mode,
     }))
 }
 

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -205,6 +205,10 @@ impl<R: RpcClient> Indexer<R> {
 
         if !acquired {
             info!("Indexer lock not acquired, running in read-only mode");
+            // Set mode to read_only so /status reflects this replica's role
+            if let Some(ref s) = self.indexer_state {
+                s.is_active_indexer.store(false, std::sync::atomic::Ordering::Relaxed);
+            }
             // Hold the connection open so we can detect when the lock owner dies
             // and re-attempt on the next startup/restart cycle.
             drop(lock_conn);
@@ -212,6 +216,10 @@ impl<R: RpcClient> Indexer<R> {
         }
 
         info!("Indexer lock acquired, starting indexing");
+        // Set mode to active so /status reflects this replica's role
+        if let Some(ref s) = self.indexer_state {
+            s.is_active_indexer.store(true, std::sync::atomic::Ordering::Relaxed);
+        }
 
         // Run the actual indexing loop; release lock on exit.
         self.run_loop().await;

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -135,3 +135,44 @@ async fn metrics_endpoint_returns_prometheus_text(pool: PgPool) {
         String::from_utf8(to_bytes(resp.into_body(), usize::MAX).await.unwrap().to_vec()).unwrap();
     assert!(body.contains("soroban_pulse"));
 }
+
+// --- Issue #182: indexer_mode in /status ---
+
+#[sqlx::test(migrations = "./migrations")]
+async fn status_includes_indexer_mode_read_only_by_default(pool: PgPool) {
+    // IndexerState::new() defaults is_active_indexer to false
+    let app = make_router(pool, None);
+
+    let resp = app
+        .oneshot(Request::builder().uri("/status").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(resp.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert_eq!(body["indexer_mode"], "read_only");
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn status_includes_indexer_mode_active_when_lock_held(pool: PgPool) {
+    use std::sync::atomic::Ordering;
+
+    let health_state = Arc::new(HealthState::new(60));
+    health_state.update_last_poll();
+    let indexer_state = Arc::new(IndexerState::new());
+    // Simulate the indexer acquiring the lock
+    indexer_state.is_active_indexer.store(true, Ordering::Relaxed);
+    let prometheus_handle = init_metrics();
+    let app = create_router(pool, None, &[], 60, health_state, indexer_state, prometheus_handle, 1_048_576);
+
+    let resp = app
+        .oneshot(Request::builder().uri("/status").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(resp.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert_eq!(body["indexer_mode"], "active");
+}


### PR DESCRIPTION
- Add is_active_indexer: AtomicBool field to IndexerState in src/config.rs
- Set is_active_indexer = true in Indexer::run when advisory lock is acquired
- Set is_active_indexer = false when lock is not acquired (read-only mode)
- GET /status response now includes indexer_mode: 'active' or 'read_only'
- Add integration tests verifying read_only (default) and active (lock held) modes

Closes #182

