### PR TITLE
fix(security): remove redundant RPC URL log line and audit log statem…

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,6 +66,17 @@ lefthook install
 
 Hooks typically complete in under 30 seconds on a typical change. If a hook fails, fix the reported issue and re-commit.
 
+## Security: Never Log Sensitive Values
+
+Never log passwords, API keys, tokens, or other credentials at any log level. This includes:
+
+- `DATABASE_URL` — use `config.safe_db_url()` which strips credentials before logging
+- `STELLAR_RPC_URL` — already sanitized by `validate_rpc_url()` before being stored in `Config`; the stored `config.stellar_rpc_url` is safe to log
+- `API_KEY` / `API_KEY_SECONDARY` — never log these values
+- Any request header that may contain `Authorization` or `X-Api-Key` values
+
+When adding new log statements, double-check that no field contains a raw secret. If in doubt, strip credentials before logging (see `Config::safe_db_url()` for the pattern).
+
 ## Code Style
 
 - Formatting is enforced by `rustfmt` using the project's `rustfmt.toml` (`max_width = 100`, `edition = "2021"`).

--- a/src/config.rs
+++ b/src/config.rs
@@ -480,4 +480,22 @@ mod tests {
         config.database_url = "not-a-url".to_string();
         assert_eq!(config.safe_db_url(), "<unparseable>");
     }
+
+    #[test]
+    fn startup_log_fields_do_not_contain_credentials() {
+        // Verify that the fields logged at startup are safe.
+        // safe_db_url() must strip credentials.
+        let mut config = Config::default();
+        config.database_url = "postgres://admin:supersecret@db.example.com/mydb".to_string();
+        config.stellar_rpc_url = "https://user:token@rpc.example.com".to_string();
+
+        let safe_db = config.safe_db_url();
+        assert!(!safe_db.contains("supersecret"), "safe_db_url must not contain password");
+        assert!(!safe_db.contains("admin"), "safe_db_url must not contain username");
+
+        // stellar_rpc_url is already sanitized by validate_rpc_url() at parse time;
+        // confirm the stored value has no credentials.
+        assert!(!config.stellar_rpc_url.contains("token"), "stellar_rpc_url must not contain token");
+        assert!(!config.stellar_rpc_url.contains("user:"), "stellar_rpc_url must not contain user credentials");
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,7 +109,6 @@ async fn main() -> anyhow::Result<()> {
     let _ = db::run_migrations(&pool).await;
 
     info!("Migrations applied successfully");
-    info!(url = %config.stellar_rpc_url, "Soroban RPC URL");
     info!(environment = ?config.environment, "Running environment");
 
     // Create shared health state for indexer and HTTP handlers


### PR DESCRIPTION
…ents for credentials

- Remove redundant info!(url = %config.stellar_rpc_url, "Soroban RPC URL") log line from main.rs; the RPC URL is already logged in the startup config block above
- Add test verifying safe_db_url() and stellar_rpc_url never expose credentials
- Add security note to CONTRIBUTING.md about never logging sensitive values

Closes #188

## Summary

<!-- A clear, concise description of what this PR does. -->

## Related Issue

Closes #<!-- issue number -->

## Changes

<!-- List the key changes made. -->

- 

## Testing

<!-- Describe how you tested this. -->

- [ ] `cargo test` passes
- [ ] `cargo clippy` reports no warnings
- [ ] Manually tested locally

## Notes

<!-- Anything reviewers should pay special attention to, or N/A. -->
