### PR TITLE
feat: add AES-256-GCM application-level encryption for event_data

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,12 @@ async-trait = "0.1"
 tower_governor = { version = "0.8", features = ["axum"] }
 base64 = "0.22"
 sha2 = "0.10"
+aes-gcm = { version = "0.10", optional = true }
+rand = { version = "0.8", optional = true }
 
 [features]
 otel = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-otlp"]
+encryption = ["aes-gcm", "rand"]
 
 [dev-dependencies]
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "chrono", "uuid", "json", "migrate"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,12 @@ pub struct Config {
     pub environment: Environment,
     pub max_body_size_bytes: usize,
     pub log_sample_rate: u32,
+    /// AES-256-GCM key for encrypting event_data at the application level.
+    /// Set via EVENT_DATA_ENCRYPTION_KEY (64 hex chars = 32 bytes).
+    pub event_data_encryption_key: Option<[u8; 32]>,
+    /// Previous encryption key for key rotation support.
+    /// Set via EVENT_DATA_ENCRYPTION_KEY_OLD.
+    pub event_data_encryption_key_old: Option<[u8; 32]>,
 }
 
 impl Default for Config {
@@ -161,6 +167,8 @@ impl Default for Config {
             environment: Environment::Development,
             max_body_size_bytes: 1024 * 1024, // 1 MB default
             log_sample_rate: 1,
+            event_data_encryption_key: None,
+            event_data_encryption_key_old: None,
         }
     }
 }
@@ -223,6 +231,20 @@ fn resolve_database_url() -> String {
     } else {
         env::var("DATABASE_URL").expect("DATABASE_URL must be set (or DATABASE_URL_FILE)")
     }
+}
+
+/// Parse a 64-hex-char string into a 32-byte key, panicking with a clear message on failure.
+fn parse_hex_key(var: &str, value: &str) -> [u8; 32] {
+    if value.len() != 64 {
+        panic!("{var} must be exactly 64 hex characters (32 bytes), got {} chars", value.len());
+    }
+    let mut key = [0u8; 32];
+    for (i, chunk) in value.as_bytes().chunks(2).enumerate() {
+        let hex = std::str::from_utf8(chunk).expect("valid utf8");
+        key[i] = u8::from_str_radix(hex, 16)
+            .unwrap_or_else(|_| panic!("{var} contains non-hex character in byte {i}"));
+    }
+    key
 }
 
 impl Config {
@@ -384,6 +406,14 @@ impl Config {
                 assert!(v > 0, "LOG_SAMPLE_RATE must be a positive integer, got {v}");
                 v
             },
+            event_data_encryption_key: env::var("EVENT_DATA_ENCRYPTION_KEY")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .map(|s| parse_hex_key("EVENT_DATA_ENCRYPTION_KEY", &s)),
+            event_data_encryption_key_old: env::var("EVENT_DATA_ENCRYPTION_KEY_OLD")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .map(|s| parse_hex_key("EVENT_DATA_ENCRYPTION_KEY_OLD", &s)),
         }
     }
 }

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -1,0 +1,178 @@
+//! Optional AES-256-GCM application-level encryption for `event_data`.
+//!
+//! Enabled by the `encryption` feature flag.
+//! Encrypted values are stored as:
+//! `{"encrypted": true, "data": "<base64>", "nonce": "<base64>"}`
+
+#[cfg(feature = "encryption")]
+mod inner {
+    use aes_gcm::{
+        aead::{Aead, KeyInit},
+        Aes256Gcm, Nonce,
+    };
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    use rand::RngCore;
+    use serde_json::{json, Value};
+
+    const NONCE_LEN: usize = 12;
+
+    /// Encrypt a JSON value. Returns the ciphertext envelope on success.
+    pub fn encrypt(key: &[u8; 32], plaintext: &Value) -> Result<Value, String> {
+        let cipher = Aes256Gcm::new_from_slice(key).map_err(|e| e.to_string())?;
+        let mut nonce_bytes = [0u8; NONCE_LEN];
+        rand::thread_rng().fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+
+        let plaintext_bytes = serde_json::to_vec(plaintext).map_err(|e| e.to_string())?;
+        let ciphertext = cipher
+            .encrypt(nonce, plaintext_bytes.as_slice())
+            .map_err(|e| e.to_string())?;
+
+        Ok(json!({
+            "encrypted": true,
+            "data": STANDARD.encode(&ciphertext),
+            "nonce": STANDARD.encode(&nonce_bytes),
+        }))
+    }
+
+    /// Decrypt a ciphertext envelope. Tries `key` first, then `old_key` if provided.
+    /// Returns the original JSON value, or the envelope unchanged if it is not encrypted.
+    pub fn decrypt(
+        key: &[u8; 32],
+        old_key: Option<&[u8; 32]>,
+        value: &Value,
+    ) -> Result<Value, String> {
+        // Not an encrypted envelope — pass through.
+        if value.get("encrypted") != Some(&Value::Bool(true)) {
+            return Ok(value.clone());
+        }
+
+        let data_b64 = value["data"]
+            .as_str()
+            .ok_or("missing 'data' field in encrypted envelope")?;
+        let nonce_b64 = value["nonce"]
+            .as_str()
+            .ok_or("missing 'nonce' field in encrypted envelope")?;
+
+        let ciphertext = STANDARD.decode(data_b64).map_err(|e| e.to_string())?;
+        let nonce_bytes = STANDARD.decode(nonce_b64).map_err(|e| e.to_string())?;
+        if nonce_bytes.len() != NONCE_LEN {
+            return Err(format!("invalid nonce length: {}", nonce_bytes.len()));
+        }
+
+        // Try current key first, then fall back to old key.
+        let plaintext_bytes = try_decrypt_with_key(key, &nonce_bytes, &ciphertext)
+            .or_else(|e| {
+                old_key
+                    .ok_or(e)
+                    .and_then(|k| try_decrypt_with_key(k, &nonce_bytes, &ciphertext))
+            })?;
+
+        serde_json::from_slice(&plaintext_bytes).map_err(|e| e.to_string())
+    }
+
+    fn try_decrypt_with_key(key: &[u8; 32], nonce_bytes: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, String> {
+        let cipher = Aes256Gcm::new_from_slice(key).map_err(|e| e.to_string())?;
+        let nonce = Nonce::from_slice(nonce_bytes);
+        cipher.decrypt(nonce, ciphertext).map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(feature = "encryption")]
+pub use inner::{decrypt, encrypt};
+
+/// No-op stubs when the feature is disabled — callers compile cleanly either way.
+#[cfg(not(feature = "encryption"))]
+pub fn encrypt(_key: &[u8; 32], plaintext: &serde_json::Value) -> Result<serde_json::Value, String> {
+    Ok(plaintext.clone())
+}
+
+#[cfg(not(feature = "encryption"))]
+pub fn decrypt(
+    _key: &[u8; 32],
+    _old_key: Option<&[u8; 32]>,
+    value: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    Ok(value.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    fn test_key(byte: u8) -> [u8; 32] {
+        [byte; 32]
+    }
+
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn round_trip_encrypt_decrypt() {
+        let key = test_key(0x42);
+        let plaintext = json!({"value": {"amount": 100}, "topic": ["transfer"]});
+
+        let envelope = super::encrypt(&key, &plaintext).unwrap();
+        assert_eq!(envelope["encrypted"], true);
+        assert!(envelope["data"].is_string());
+        assert!(envelope["nonce"].is_string());
+
+        let recovered = super::decrypt(&key, None, &envelope).unwrap();
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn decrypt_with_old_key_on_rotation() {
+        let old_key = test_key(0x01);
+        let new_key = test_key(0x02);
+
+        // Data encrypted with old key
+        let plaintext = json!({"value": null, "topic": null});
+        let envelope = super::encrypt(&old_key, &plaintext).unwrap();
+
+        // Decrypting with new key alone fails
+        assert!(super::decrypt(&new_key, None, &envelope).is_err());
+
+        // Decrypting with new key + old key succeeds
+        let recovered = super::decrypt(&new_key, Some(&old_key), &envelope).unwrap();
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn non_encrypted_value_passes_through() {
+        let key = test_key(0x42);
+        let plain = json!({"value": {"foo": "bar"}, "topic": []});
+        let result = super::decrypt(&key, None, &plain).unwrap();
+        assert_eq!(result, plain);
+    }
+
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn wrong_key_returns_error() {
+        let key = test_key(0xAA);
+        let wrong_key = test_key(0xBB);
+        let plaintext = json!({"x": 1});
+        let envelope = super::encrypt(&key, &plaintext).unwrap();
+        assert!(super::decrypt(&wrong_key, None, &envelope).is_err());
+    }
+
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn each_encryption_produces_unique_nonce() {
+        let key = test_key(0x42);
+        let plaintext = json!({"v": 1});
+        let e1 = super::encrypt(&key, &plaintext).unwrap();
+        let e2 = super::encrypt(&key, &plaintext).unwrap();
+        // Different nonces (probabilistically certain)
+        assert_ne!(e1["nonce"], e2["nonce"]);
+    }
+
+    #[cfg(not(feature = "encryption"))]
+    #[test]
+    fn stubs_are_identity() {
+        let key = [0u8; 32];
+        let v = json!({"a": 1});
+        assert_eq!(super::encrypt(&key, &v).unwrap(), v);
+        assert_eq!(super::decrypt(&key, None, &v).unwrap(), v);
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -51,7 +51,7 @@ fn decode_cursor(cursor: &str) -> Result<(i64, Uuid), AppError> {
 }
 
 /// Map sqlx rows to a JSON array, projecting only the requested columns.
-fn rows_to_json(rows: &[sqlx::postgres::PgRow], columns: &[&str]) -> Result<Vec<Value>, AppError> {
+fn rows_to_json(rows: &[sqlx::postgres::PgRow], columns: &[&str], enc_key: Option<&[u8; 32]>, enc_key_old: Option<&[u8; 32]>) -> Result<Vec<Value>, AppError> {
     let mut events = Vec::with_capacity(rows.len());
     for row in rows {
         let mut event = serde_json::Map::new();
@@ -63,7 +63,11 @@ fn rows_to_json(rows: &[sqlx::postgres::PgRow], columns: &[&str]) -> Result<Vec<
                 "tx_hash" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
                 "ledger" => { event.insert(col.to_string(), json!(row.try_get::<i64, _>(col)?)); }
                 "timestamp" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
-                "event_data" => { event.insert(col.to_string(), row.try_get::<Value, _>(col)?); }
+                "event_data" => {
+                    let raw: Value = row.try_get::<Value, _>(col)?;
+                    let decrypted = decrypt_event_data(&raw, enc_key, enc_key_old);
+                    event.insert(col.to_string(), decrypted);
+                }
                 "created_at" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
                 _ => {}
             }
@@ -420,8 +424,11 @@ async fn stream_events_internal(
     };
 
     let rx = state.event_tx.subscribe();
+    let enc_key = state.encryption_key;
+    let enc_key_old = state.encryption_key_old;
 
-    let replay_stream = stream::iter(replay.into_iter().map(move |ev| {
+    let replay_stream = stream::iter(replay.into_iter().map(move |mut ev| {
+        ev.event_data = decrypt_event_data(&ev.event_data, enc_key.as_ref(), enc_key_old.as_ref());
         let data = serde_json::to_string(&ev).unwrap_or_default();
         Ok(Event::default()
             .id(ev.id.to_string())
@@ -479,8 +486,20 @@ async fn stream_events_internal(
     ))
 }
 
+/// Decrypt event_data if an encryption key is configured.
+fn decrypt_event_data(raw: &Value, key: Option<&[u8; 32]>, old_key: Option<&[u8; 32]>) -> Value {
+    if let Some(k) = key {
+        crate::encryption::decrypt(k, old_key, raw).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "Failed to decrypt event_data, returning raw value");
+            raw.clone()
+        })
+    } else {
+        raw.clone()
+    }
+}
+
 /// Converts an `Event` to a JSON object containing only the requested fields.
-fn filter_fields(event: &models::Event, columns: &[&str]) -> Value {
+fn filter_fields(event: &models::Event, columns: &[&str], enc_key: Option<&[u8; 32]>, enc_key_old: Option<&[u8; 32]>) -> Value {
     let mut map = serde_json::Map::new();
     for &col in columns {
         match col {
@@ -490,7 +509,10 @@ fn filter_fields(event: &models::Event, columns: &[&str]) -> Value {
             "tx_hash"     => { map.insert(col.to_string(), json!(event.tx_hash)); }
             "ledger"      => { map.insert(col.to_string(), json!(event.ledger)); }
             "timestamp"   => { map.insert(col.to_string(), json!(event.timestamp)); }
-            "event_data"  => { map.insert(col.to_string(), event.event_data.clone()); }
+            "event_data"  => {
+                let decrypted = decrypt_event_data(&event.event_data, enc_key, enc_key_old);
+                map.insert(col.to_string(), decrypted);
+            }
             "created_at"  => { map.insert(col.to_string(), json!(event.created_at)); }
             _ => {}
         }
@@ -588,7 +610,7 @@ pub async fn get_events(
             None
         };
 
-        let events = rows_to_json(&rows, &columns)?;
+        let events = rows_to_json(&rows, &columns, state.encryption_key.as_ref(), state.encryption_key_old.as_ref())?;
 
         return Ok(Json(json!({
             "data": events,
@@ -654,7 +676,7 @@ pub async fn get_events(
         None
     };
 
-    let events = rows_to_json(&rows, &columns)?;
+    let events = rows_to_json(&rows, &columns, state.encryption_key.as_ref(), state.encryption_key_old.as_ref())?;
 
     let (total, approximate): (i64, bool) = if exact {
         let count_str = format!("SELECT COUNT(*) FROM events {}", where_clause);
@@ -752,7 +774,7 @@ pub async fn get_events_by_contract(
         return Err(AppError::NotFound);
     }
 
-    let events: Vec<Value> = rows.iter().map(|e| filter_fields(e, &columns)).collect();
+    let events: Vec<Value> = rows.iter().map(|e| filter_fields(e, &columns, state.encryption_key.as_ref(), state.encryption_key_old.as_ref())).collect();
 
     let mut response = json!({
         "data": events,
@@ -809,7 +831,7 @@ pub async fn get_events_by_tx(
         .fetch_all(&state.pool)
         .await?;
 
-    let events = rows_to_json(&rows, &columns)?;
+    let events = rows_to_json(&rows, &columns, state.encryption_key.as_ref(), state.encryption_key_old.as_ref())?;
 
     Ok(Json(json!({ "data": events, "tx_hash": tx_hash })))
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -520,6 +520,15 @@ impl<R: RpcClient> Indexer<R> {
             "topic": event.topic
         });
 
+        let event_data = if let Some(ref key) = self.config.event_data_encryption_key {
+            crate::encryption::encrypt(key, &event_data).unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "Failed to encrypt event_data, storing plaintext");
+                event_data
+            })
+        } else {
+            event_data
+        };
+
         let result = sqlx::query(
             r#"
             INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data)
@@ -737,6 +746,8 @@ mod tests {
                 environment: crate::config::Environment::Development,
                 max_body_size_bytes: 1024 * 1024,
                 log_sample_rate: 1,
+                event_data_encryption_key: None,
+                event_data_encryption_key_old: None,
             },
             shutdown_rx,
             MockRpcClient::new(),
@@ -877,7 +888,7 @@ mod tests {
                 indexer_lag_warn_threshold: 1000,
                 rpc_connect_timeout_secs: 30,
                 rpc_request_timeout_secs: 60,
-                api_key: None,
+                api_keys: Vec::new(),
                 db_max_connections: 10,
                 db_min_connections: 2,
                 allowed_origins: vec!["*".to_string()],
@@ -886,7 +897,13 @@ mod tests {
                 db_statement_timeout_ms: 5000,
                 indexer_poll_interval_ms: 5000,
                 indexer_error_backoff_ms: 10000,
+                sse_keepalive_interval_ms: 15000,
+                sse_max_connections: 1000,
                 environment: crate::config::Environment::Development,
+                max_body_size_bytes: 1024 * 1024,
+                log_sample_rate: 1,
+                event_data_encryption_key: None,
+                event_data_encryption_key_old: None,
             },
             shutdown_rx,
             mock_client,

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 )]
 mod config;
 mod db;
+mod encryption;
 mod error;
 mod handlers;
 mod indexer;
@@ -166,7 +167,7 @@ async fn main() -> anyhow::Result<()> {
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     info!(origins = ?config.allowed_origins, "Allowed CORS origins");
     info!(rate_limit = config.rate_limit_per_minute, "Rate limit per IP");
-    let router = routes::create_router_with_tx(pool, config.api_keys.clone(), &config.allowed_origins, config.rate_limit_per_minute, config.behind_proxy, health_state, indexer_state, prometheus_handle, event_tx, config.sse_keepalive_interval_ms, config.sse_max_connections, 2000);
+    let router = routes::create_router_with_tx(pool, config.api_keys.clone(), &config.allowed_origins, config.rate_limit_per_minute, config.behind_proxy, health_state, indexer_state, prometheus_handle, event_tx, config.sse_keepalive_interval_ms, config.sse_max_connections, 2000, config.event_data_encryption_key, config.event_data_encryption_key_old);
 
     info!(addr = %addr, "Soroban Pulse listening");
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -45,6 +45,8 @@ pub struct AppState {
     pub sse_connections: Arc<AtomicUsize>,
     pub sse_max_connections: usize,
     pub health_check_timeout_ms: u64,
+    pub encryption_key: Option<[u8; 32]>,
+    pub encryption_key_old: Option<[u8; 32]>,
 }
 
 /// OpenAPI spec — all paths are documented via #[utoipa::path] on handlers.
@@ -88,7 +90,7 @@ pub fn create_router(
     prometheus_handle: PrometheusHandle,
     health_check_timeout_ms: u64,
 ) -> Router {
-    create_router_with_tx(pool, api_keys, allowed_origins, rate_limit_per_minute, false, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0, 15000, 1000, health_check_timeout_ms)
+    create_router_with_tx(pool, api_keys, allowed_origins, rate_limit_per_minute, false, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0, 15000, 1000, health_check_timeout_ms, None, None)
 }
 
 pub fn create_router_with_tx(
@@ -104,6 +106,8 @@ pub fn create_router_with_tx(
     sse_keepalive_interval_ms: u64,
     sse_max_connections: usize,
     health_check_timeout_ms: u64,
+    encryption_key: Option<[u8; 32]>,
+    encryption_key_old: Option<[u8; 32]>,
 ) -> Router {
     let cors = build_cors(allowed_origins);
     let auth_state = Arc::new(middleware::AuthState { api_keys });
@@ -117,6 +121,8 @@ pub fn create_router_with_tx(
         sse_connections: Arc::new(AtomicUsize::new(0)),
         sse_max_connections,
         health_check_timeout_ms,
+        encryption_key,
+        encryption_key_old,
     };
 
     // Build governor config: burst = rate_limit_per_minute, replenish 1 token per (60/rate) seconds.


### PR DESCRIPTION
Add AES-256-GCM application-level encryption for event_data
  
  Adds optional encryption of the event_data JSONB column at the application layer, ensuring data cannot be read from
  the database without the encryption key even if storage-level encryption is bypassed.
  
  How it works
  
  - Set EVENT_DATA_ENCRYPTION_KEY to a 64-hex-char (32-byte) key to enable encryption
  - Encrypted rows are stored as {"encrypted": true, "data": "<base64>", "nonce": "<base64>"}
  - Decryption is transparent on all read paths (paginated events, by-contract, by-tx, SSE replay)
  - Set EVENT_DATA_ENCRYPTION_KEY_OLD during key rotation — the service will decrypt old ciphertext with the previous
  key while writing new data with the current key
  - Feature is compiled in via --features encryption; without the feature, all paths are no-ops
  
  Changes
  
  - Cargo.toml — aes-gcm and rand added as optional deps under the encryption feature
  - src/encryption.rs — new module with encrypt/decrypt and no-op stubs when feature is off
  - src/config.rs — EVENT_DATA_ENCRYPTION_KEY / EVENT_DATA_ENCRYPTION_KEY_OLD env var parsing
  - src/indexer.rs — encrypts event_data before insert
  - src/handlers.rs — decrypts event_data on all read paths
  - src/routes.rs / src/main.rs — threads keys through AppState
  
  Testing
  
  Unit tests in src/encryption.rs cover: round-trip encrypt/decrypt, key rotation fallback, wrong-key rejection, nonce
  uniqueness, and identity stubs when the feature is disabled.


closes #257 