### PR TITLE
feat: add contract_id filter to GET /v1/events (#194)

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -510,6 +510,7 @@ fn filter_fields(event: &models::Event, columns: &[&str]) -> Value {
         ("event_type" = Option<EventType>, Query, description = "Filter by event type: contract, diagnostic, system"),
         ("from_ledger" = Option<i64>, Query, description = "Return events at or after this ledger"),
         ("to_ledger" = Option<i64>, Query, description = "Return events at or before this ledger"),
+        ("contract_id" = Option<String>, Query, description = "Filter by contract ID (56-char Stellar contract address starting with C)"),
     ),
     responses(
         (status = 200, description = "Paginated list of events"),
@@ -530,6 +531,11 @@ pub async fn get_events(
         }
     }
 
+    // Validate contract_id if provided
+    if let Some(ref cid) = params.contract_id {
+        validate_contract_id(cid)?;
+    }
+
     let limit = params.limit();
     let columns = resolve_columns(&params)?;
 
@@ -542,6 +548,10 @@ pub async fn get_events(
         ];
         let mut bind_idx: i32 = 3;
 
+        if params.contract_id.is_some() {
+            conditions.push(format!("contract_id = ${bind_idx}"));
+            bind_idx += 1;
+        }
         if params.event_type.is_some() {
             conditions.push(format!("event_type = ${bind_idx}"));
             bind_idx += 1;
@@ -572,6 +582,7 @@ pub async fn get_events(
         let mut q = sqlx::query(&query_str)
             .bind(cursor_ledger)
             .bind(cursor_id);
+        if let Some(ref cid) = params.contract_id { q = q.bind(cid); }
         if let Some(ref et) = params.event_type { q = q.bind(et); }
         if let Some(fl) = params.from_ledger { q = q.bind(fl); }
         if let Some(tl) = params.to_ledger { q = q.bind(tl); }
@@ -605,6 +616,10 @@ pub async fn get_events(
     let mut conditions: Vec<String> = Vec::new();
     let mut bind_idx: i32 = 1;
 
+    if params.contract_id.is_some() {
+        conditions.push(format!("contract_id = ${bind_idx}"));
+        bind_idx += 1;
+    }
     if params.event_type.is_some() {
         conditions.push(format!("event_type = ${bind_idx}"));
         bind_idx += 1;
@@ -638,6 +653,7 @@ pub async fn get_events(
     );
 
     let mut q = sqlx::query(&query_str);
+    if let Some(ref cid) = params.contract_id { q = q.bind(cid); }
     if let Some(ref et) = params.event_type { q = q.bind(et); }
     if let Some(fl) = params.from_ledger { q = q.bind(fl); }
     if let Some(tl) = params.to_ledger { q = q.bind(tl); }
@@ -660,6 +676,7 @@ pub async fn get_events(
     let (total, approximate): (i64, bool) = if exact {
         let count_str = format!("SELECT COUNT(*) FROM events {}", where_clause);
         let mut cq = sqlx::query_scalar::<_, i64>(&count_str);
+        if let Some(ref cid) = params.contract_id { cq = cq.bind(cid); }
         if let Some(ref et) = params.event_type { cq = cq.bind(et); }
         if let Some(fl) = params.from_ledger { cq = cq.bind(fl); }
         if let Some(tl) = params.to_ledger { cq = cq.bind(tl); }

--- a/src/models.rs
+++ b/src/models.rs
@@ -61,6 +61,7 @@ pub struct PaginationParams {
     pub from_ledger: Option<i64>,
     pub to_ledger: Option<i64>,
     pub cursor: Option<String>,
+    pub contract_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, utoipa::ToSchema)]

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -299,3 +299,87 @@ async fn sse_deprecated_contract_stream_unversioned_alias_works(pool: PgPool) {
     assert_eq!(resp.status(), StatusCode::OK);
     assert_eq!(resp.headers().get("Deprecation").unwrap(), "true");
 }
+
+// --- Issue #194: contract_id filter on GET /v1/events ---
+
+#[sqlx::test(migrations = "./migrations")]
+async fn events_contract_id_filter_returns_matching_events(pool: PgPool) {
+    let contract_a = "C1111111111111111111111111111111111111111111111111111111";
+    let contract_b = "C2222222222222222222222222222222222222222222222222222222";
+    
+    insert_contract_events(&pool, contract_a, &[100, 200]).await;
+    insert_contract_events(&pool, contract_b, &[150, 250]).await;
+
+    let app = make_router(pool, None);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/v1/events?contract_id={}", contract_a))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(resp.into_body(), usize::MAX).await.unwrap()).unwrap();
+
+    let data = body["data"].as_array().unwrap();
+    assert_eq!(data.len(), 2);
+    for event in data {
+        assert_eq!(event["contract_id"].as_str().unwrap(), contract_a);
+    }
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn events_contract_id_with_ledger_range_filters_correctly(pool: PgPool) {
+    let contract_id = "C1234567890123456789012345678901234567890123456789012345";
+    insert_contract_events(&pool, contract_id, &[100, 200, 300, 400, 500]).await;
+
+    let app = make_router(pool, None);
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri(format!(
+                    "/v1/events?contract_id={}&from_ledger=200&to_ledger=400",
+                    contract_id
+                ))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(resp.into_body(), usize::MAX).await.unwrap()).unwrap();
+
+    let data = body["data"].as_array().unwrap();
+    assert_eq!(data.len(), 3);
+    for event in data {
+        assert_eq!(event["contract_id"].as_str().unwrap(), contract_id);
+        let ledger = event["ledger"].as_i64().unwrap();
+        assert!((200..=400).contains(&ledger));
+    }
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn events_invalid_contract_id_returns_400(pool: PgPool) {
+    let app = make_router(pool, None);
+
+    let resp = app
+        .oneshot(
+            Request::builder()
+                .uri("/v1/events?contract_id=INVALID")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(resp.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert!(body["error"].as_str().unwrap().contains("invalid contract_id format"));
+}


### PR DESCRIPTION
Add optional contract_id query parameter to the main events endpoint, allowing clients to combine all available filters in a single request: GET /v1/events?contract_id=CABC...&event_type=contract&from_ledger=100&to_ledger=200

- Extend PaginationParams with optional contract_id field
- Validate contract_id using existing validate_contract_id (400 on invalid)
- Add contract_id condition to both cursor-based and offset-based WHERE clause builders
- Update utoipa OpenAPI path doc to document the new parameter
- Add integration tests: filter alone, combined with ledger range, invalid ID

Closes #194

## Summary

<!-- A clear, concise description of what this PR does. -->

## Related Issue

Closes #<!-- issue number -->

## Changes

<!-- List the key changes made. -->

- 

## Testing

<!-- Describe how you tested this. -->

- [ ] `cargo test` passes
- [ ] `cargo clippy` reports no warnings
- [ ] Manually tested locally

## Notes

<!-- Anything reviewers should pay special attention to, or N/A. -->
