### PR TITLE
Feat/s3 event archival

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,3 +103,14 @@ RUST_LOG_FORMAT=text
 # - Database query spans with SQL statement, row count, and execution duration
 # Format: URL (e.g., http://localhost:4317)
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
+# ── Archive feature (requires building with --features archive) ───────────────
+# Number of days after which events are moved from PostgreSQL to S3 (default: 365).
+# ARCHIVE_AFTER_DAYS=365
+
+# S3 bucket to store archived events. When unset, the archiver is disabled.
+# ARCHIVE_S3_BUCKET=my-soroban-archive-bucket
+
+# S3 key prefix for archived files (default: soroban-pulse/events).
+# Files are stored as: <prefix>/YYYY/MM/DD/events.ndjson.gz
+# ARCHIVE_S3_PREFIX=soroban-pulse/events

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,10 +34,14 @@ base64 = "0.22"
 sha2 = "0.10"
 aes-gcm = { version = "0.10", optional = true }
 rand = { version = "0.8", optional = true }
+aws-config = { version = "1", optional = true }
+aws-sdk-s3 = { version = "1", optional = true }
+flate2 = { version = "1", optional = true }
 
 [features]
 otel = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-otlp"]
 encryption = ["aes-gcm", "rand"]
+archive = ["aws-config", "aws-sdk-s3", "flate2"]
 
 [dev-dependencies]
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "chrono", "uuid", "json", "migrate"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,9 +32,12 @@ async-trait = "0.1"
 tower_governor = { version = "0.8", features = ["axum"] }
 base64 = "0.22"
 sha2 = "0.10"
+aes-gcm = { version = "0.10", optional = true }
+rand = { version = "0.8", optional = true }
 
 [features]
 otel = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-otlp"]
+encryption = ["aes-gcm", "rand"]
 
 [dev-dependencies]
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "chrono", "uuid", "json", "migrate"] }

--- a/src/archiver.rs
+++ b/src/archiver.rs
@@ -1,0 +1,185 @@
+//! Background archival job: moves events older than `archive_after_days` from
+//! PostgreSQL to S3-compatible object storage as gzip-compressed NDJSON files.
+//!
+//! Only compiled when the `archive` feature is enabled.
+
+use aws_sdk_s3::primitives::ByteStream;
+use chrono::{NaiveDate, Utc};
+use flate2::{write::GzEncoder, Compression};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use std::io::Write;
+use tracing::{error, info, warn};
+
+use crate::config::Config;
+
+/// Metadata returned by `GET /v1/events/archive`.
+#[derive(Debug, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct ArchiveFile {
+    /// S3 key of the archive file.
+    pub key: String,
+    /// Date the events were archived (YYYY-MM-DD).
+    pub date: String,
+    /// Size of the compressed file in bytes.
+    pub size_bytes: i64,
+}
+
+/// Run the archival loop: every `interval` seconds, archive events older than
+/// `archive_after_days` days.
+pub async fn run_archiver(pool: PgPool, config: Config) {
+    let Some(ref bucket) = config.archive_s3_bucket else {
+        warn!("ARCHIVE_S3_BUCKET not set — archiver disabled");
+        return;
+    };
+    let bucket = bucket.clone();
+    let prefix = config.archive_s3_prefix.clone();
+    let after_days = i64::from(config.archive_after_days);
+
+    let aws_cfg = aws_config::load_from_env().await;
+    let s3 = aws_sdk_s3::Client::new(&aws_cfg);
+
+    info!(bucket = %bucket, prefix = %prefix, after_days, "Archiver started");
+
+    loop {
+        if let Err(e) = archive_once(&pool, &s3, &bucket, &prefix, after_days).await {
+            error!(error = %e, "Archival run failed");
+        }
+        // Run once per day.
+        tokio::time::sleep(tokio::time::Duration::from_secs(86_400)).await;
+    }
+}
+
+/// One archival pass: find distinct dates with archivable events, process each.
+async fn archive_once(
+    pool: &PgPool,
+    s3: &aws_sdk_s3::Client,
+    bucket: &str,
+    prefix: &str,
+    after_days: i64,
+) -> anyhow::Result<()> {
+    let cutoff = Utc::now() - chrono::Duration::days(after_days);
+
+    // Fetch distinct dates that have events older than the cutoff.
+    let dates: Vec<NaiveDate> = sqlx::query_scalar(
+        "SELECT DISTINCT DATE(timestamp) FROM events WHERE timestamp < $1 ORDER BY 1",
+    )
+    .bind(cutoff)
+    .fetch_all(pool)
+    .await?;
+
+    for date in dates {
+        if let Err(e) = archive_date(pool, s3, bucket, prefix, date).await {
+            error!(date = %date, error = %e, "Failed to archive date");
+        }
+    }
+    Ok(())
+}
+
+/// Archive all events for a single calendar date, then delete them from the DB.
+async fn archive_date(
+    pool: &PgPool,
+    s3: &aws_sdk_s3::Client,
+    bucket: &str,
+    prefix: &str,
+    date: NaiveDate,
+) -> anyhow::Result<()> {
+    let day_start = date.and_hms_opt(0, 0, 0).unwrap().and_utc();
+    let day_end = date.and_hms_opt(23, 59, 59).unwrap().and_utc();
+
+    let rows: Vec<crate::models::Event> = sqlx::query_as(
+        "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, created_at, 0::bigint AS total_count \
+         FROM events WHERE timestamp BETWEEN $1 AND $2 ORDER BY ledger, id",
+    )
+    .bind(day_start)
+    .bind(day_end)
+    .fetch_all(pool)
+    .await?;
+
+    if rows.is_empty() {
+        return Ok(());
+    }
+
+    let count = rows.len();
+    let gz_bytes = encode_ndjson_gz(&rows)?;
+
+    let key = format!(
+        "{}/{}/{}/{}/events.ndjson.gz",
+        prefix,
+        date.format("%Y"),
+        date.format("%m"),
+        date.format("%d"),
+    );
+
+    s3.put_object()
+        .bucket(bucket)
+        .key(&key)
+        .body(ByteStream::from(gz_bytes))
+        .content_type("application/x-ndjson")
+        .content_encoding("gzip")
+        .send()
+        .await?;
+
+    // Delete only after a successful upload.
+    sqlx::query("DELETE FROM events WHERE timestamp BETWEEN $1 AND $2")
+        .bind(day_start)
+        .bind(day_end)
+        .execute(pool)
+        .await?;
+
+    info!(date = %date, count, key = %key, "Archived events");
+    Ok(())
+}
+
+/// Serialize events as NDJSON and gzip-compress the result.
+fn encode_ndjson_gz(events: &[crate::models::Event]) -> anyhow::Result<Vec<u8>> {
+    let mut enc = GzEncoder::new(Vec::new(), Compression::default());
+    for ev in events {
+        let line = serde_json::to_string(ev)?;
+        enc.write_all(line.as_bytes())?;
+        enc.write_all(b"\n")?;
+    }
+    Ok(enc.finish()?)
+}
+
+/// List archive files available in S3 under the configured prefix.
+pub async fn list_archive_files(
+    s3: &aws_sdk_s3::Client,
+    bucket: &str,
+    prefix: &str,
+) -> anyhow::Result<Vec<ArchiveFile>> {
+    let mut files = Vec::new();
+    let mut continuation: Option<String> = None;
+
+    loop {
+        let mut req = s3.list_objects_v2().bucket(bucket).prefix(prefix);
+        if let Some(ref tok) = continuation {
+            req = req.continuation_token(tok);
+        }
+        let resp = req.send().await?;
+
+        for obj in resp.contents() {
+            let key = obj.key().unwrap_or_default().to_string();
+            // Extract date from key: <prefix>/YYYY/MM/DD/events.ndjson.gz
+            let date = key
+                .trim_start_matches(prefix)
+                .trim_start_matches('/')
+                .split('/')
+                .take(3)
+                .collect::<Vec<_>>()
+                .join("-");
+            files.push(ArchiveFile {
+                key: key.clone(),
+                date,
+                size_bytes: obj.size().unwrap_or(0),
+            });
+        }
+
+        if resp.is_truncated().unwrap_or(false) {
+            continuation = resp.next_continuation_token().map(str::to_string);
+        } else {
+            break;
+        }
+    }
+
+    Ok(files)
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -139,6 +139,12 @@ pub struct Config {
     /// Previous encryption key for key rotation support.
     /// Set via EVENT_DATA_ENCRYPTION_KEY_OLD.
     pub event_data_encryption_key_old: Option<[u8; 32]>,
+    /// Archive feature: events older than this many days are moved to S3.
+    pub archive_after_days: u32,
+    /// Archive feature: S3 bucket name for archived events.
+    pub archive_s3_bucket: Option<String>,
+    /// Archive feature: S3 key prefix (e.g. "soroban-pulse/events").
+    pub archive_s3_prefix: String,
 }
 
 impl Default for Config {
@@ -169,6 +175,9 @@ impl Default for Config {
             log_sample_rate: 1,
             event_data_encryption_key: None,
             event_data_encryption_key_old: None,
+            archive_after_days: 365,
+            archive_s3_bucket: None,
+            archive_s3_prefix: "soroban-pulse/events".to_string(),
         }
     }
 }
@@ -414,6 +423,15 @@ impl Config {
                 .ok()
                 .filter(|s| !s.is_empty())
                 .map(|s| parse_hex_key("EVENT_DATA_ENCRYPTION_KEY_OLD", &s)),
+            archive_after_days: env::var("ARCHIVE_AFTER_DAYS")
+                .unwrap_or_else(|_| "365".to_string())
+                .parse()
+                .expect("ARCHIVE_AFTER_DAYS must be a positive integer"),
+            archive_s3_bucket: env::var("ARCHIVE_S3_BUCKET")
+                .ok()
+                .filter(|s| !s.is_empty()),
+            archive_s3_prefix: env::var("ARCHIVE_S3_PREFIX")
+                .unwrap_or_else(|_| "soroban-pulse/events".to_string()),
         }
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,12 @@ pub struct Config {
     pub environment: Environment,
     pub max_body_size_bytes: usize,
     pub log_sample_rate: u32,
+    /// AES-256-GCM key for encrypting event_data at the application level.
+    /// Set via EVENT_DATA_ENCRYPTION_KEY (64 hex chars = 32 bytes).
+    pub event_data_encryption_key: Option<[u8; 32]>,
+    /// Previous encryption key for key rotation support.
+    /// Set via EVENT_DATA_ENCRYPTION_KEY_OLD.
+    pub event_data_encryption_key_old: Option<[u8; 32]>,
 }
 
 impl Default for Config {
@@ -161,6 +167,8 @@ impl Default for Config {
             environment: Environment::Development,
             max_body_size_bytes: 1024 * 1024, // 1 MB default
             log_sample_rate: 1,
+            event_data_encryption_key: None,
+            event_data_encryption_key_old: None,
         }
     }
 }
@@ -223,6 +231,20 @@ fn resolve_database_url() -> String {
     } else {
         env::var("DATABASE_URL").expect("DATABASE_URL must be set (or DATABASE_URL_FILE)")
     }
+}
+
+/// Parse a 64-hex-char string into a 32-byte key, panicking with a clear message on failure.
+fn parse_hex_key(var: &str, value: &str) -> [u8; 32] {
+    if value.len() != 64 {
+        panic!("{var} must be exactly 64 hex characters (32 bytes), got {} chars", value.len());
+    }
+    let mut key = [0u8; 32];
+    for (i, chunk) in value.as_bytes().chunks(2).enumerate() {
+        let hex = std::str::from_utf8(chunk).expect("valid utf8");
+        key[i] = u8::from_str_radix(hex, 16)
+            .unwrap_or_else(|_| panic!("{var} contains non-hex character in byte {i}"));
+    }
+    key
 }
 
 impl Config {
@@ -384,6 +406,14 @@ impl Config {
                 assert!(v > 0, "LOG_SAMPLE_RATE must be a positive integer, got {v}");
                 v
             },
+            event_data_encryption_key: env::var("EVENT_DATA_ENCRYPTION_KEY")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .map(|s| parse_hex_key("EVENT_DATA_ENCRYPTION_KEY", &s)),
+            event_data_encryption_key_old: env::var("EVENT_DATA_ENCRYPTION_KEY_OLD")
+                .ok()
+                .filter(|s| !s.is_empty())
+                .map(|s| parse_hex_key("EVENT_DATA_ENCRYPTION_KEY_OLD", &s)),
         }
     }
 }

--- a/src/encryption.rs
+++ b/src/encryption.rs
@@ -1,0 +1,178 @@
+//! Optional AES-256-GCM application-level encryption for `event_data`.
+//!
+//! Enabled by the `encryption` feature flag.
+//! Encrypted values are stored as:
+//! `{"encrypted": true, "data": "<base64>", "nonce": "<base64>"}`
+
+#[cfg(feature = "encryption")]
+mod inner {
+    use aes_gcm::{
+        aead::{Aead, KeyInit},
+        Aes256Gcm, Nonce,
+    };
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    use rand::RngCore;
+    use serde_json::{json, Value};
+
+    const NONCE_LEN: usize = 12;
+
+    /// Encrypt a JSON value. Returns the ciphertext envelope on success.
+    pub fn encrypt(key: &[u8; 32], plaintext: &Value) -> Result<Value, String> {
+        let cipher = Aes256Gcm::new_from_slice(key).map_err(|e| e.to_string())?;
+        let mut nonce_bytes = [0u8; NONCE_LEN];
+        rand::thread_rng().fill_bytes(&mut nonce_bytes);
+        let nonce = Nonce::from_slice(&nonce_bytes);
+
+        let plaintext_bytes = serde_json::to_vec(plaintext).map_err(|e| e.to_string())?;
+        let ciphertext = cipher
+            .encrypt(nonce, plaintext_bytes.as_slice())
+            .map_err(|e| e.to_string())?;
+
+        Ok(json!({
+            "encrypted": true,
+            "data": STANDARD.encode(&ciphertext),
+            "nonce": STANDARD.encode(&nonce_bytes),
+        }))
+    }
+
+    /// Decrypt a ciphertext envelope. Tries `key` first, then `old_key` if provided.
+    /// Returns the original JSON value, or the envelope unchanged if it is not encrypted.
+    pub fn decrypt(
+        key: &[u8; 32],
+        old_key: Option<&[u8; 32]>,
+        value: &Value,
+    ) -> Result<Value, String> {
+        // Not an encrypted envelope — pass through.
+        if value.get("encrypted") != Some(&Value::Bool(true)) {
+            return Ok(value.clone());
+        }
+
+        let data_b64 = value["data"]
+            .as_str()
+            .ok_or("missing 'data' field in encrypted envelope")?;
+        let nonce_b64 = value["nonce"]
+            .as_str()
+            .ok_or("missing 'nonce' field in encrypted envelope")?;
+
+        let ciphertext = STANDARD.decode(data_b64).map_err(|e| e.to_string())?;
+        let nonce_bytes = STANDARD.decode(nonce_b64).map_err(|e| e.to_string())?;
+        if nonce_bytes.len() != NONCE_LEN {
+            return Err(format!("invalid nonce length: {}", nonce_bytes.len()));
+        }
+
+        // Try current key first, then fall back to old key.
+        let plaintext_bytes = try_decrypt_with_key(key, &nonce_bytes, &ciphertext)
+            .or_else(|e| {
+                old_key
+                    .ok_or(e)
+                    .and_then(|k| try_decrypt_with_key(k, &nonce_bytes, &ciphertext))
+            })?;
+
+        serde_json::from_slice(&plaintext_bytes).map_err(|e| e.to_string())
+    }
+
+    fn try_decrypt_with_key(key: &[u8; 32], nonce_bytes: &[u8], ciphertext: &[u8]) -> Result<Vec<u8>, String> {
+        let cipher = Aes256Gcm::new_from_slice(key).map_err(|e| e.to_string())?;
+        let nonce = Nonce::from_slice(nonce_bytes);
+        cipher.decrypt(nonce, ciphertext).map_err(|e| e.to_string())
+    }
+}
+
+#[cfg(feature = "encryption")]
+pub use inner::{decrypt, encrypt};
+
+/// No-op stubs when the feature is disabled — callers compile cleanly either way.
+#[cfg(not(feature = "encryption"))]
+pub fn encrypt(_key: &[u8; 32], plaintext: &serde_json::Value) -> Result<serde_json::Value, String> {
+    Ok(plaintext.clone())
+}
+
+#[cfg(not(feature = "encryption"))]
+pub fn decrypt(
+    _key: &[u8; 32],
+    _old_key: Option<&[u8; 32]>,
+    value: &serde_json::Value,
+) -> Result<serde_json::Value, String> {
+    Ok(value.clone())
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    fn test_key(byte: u8) -> [u8; 32] {
+        [byte; 32]
+    }
+
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn round_trip_encrypt_decrypt() {
+        let key = test_key(0x42);
+        let plaintext = json!({"value": {"amount": 100}, "topic": ["transfer"]});
+
+        let envelope = super::encrypt(&key, &plaintext).unwrap();
+        assert_eq!(envelope["encrypted"], true);
+        assert!(envelope["data"].is_string());
+        assert!(envelope["nonce"].is_string());
+
+        let recovered = super::decrypt(&key, None, &envelope).unwrap();
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn decrypt_with_old_key_on_rotation() {
+        let old_key = test_key(0x01);
+        let new_key = test_key(0x02);
+
+        // Data encrypted with old key
+        let plaintext = json!({"value": null, "topic": null});
+        let envelope = super::encrypt(&old_key, &plaintext).unwrap();
+
+        // Decrypting with new key alone fails
+        assert!(super::decrypt(&new_key, None, &envelope).is_err());
+
+        // Decrypting with new key + old key succeeds
+        let recovered = super::decrypt(&new_key, Some(&old_key), &envelope).unwrap();
+        assert_eq!(recovered, plaintext);
+    }
+
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn non_encrypted_value_passes_through() {
+        let key = test_key(0x42);
+        let plain = json!({"value": {"foo": "bar"}, "topic": []});
+        let result = super::decrypt(&key, None, &plain).unwrap();
+        assert_eq!(result, plain);
+    }
+
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn wrong_key_returns_error() {
+        let key = test_key(0xAA);
+        let wrong_key = test_key(0xBB);
+        let plaintext = json!({"x": 1});
+        let envelope = super::encrypt(&key, &plaintext).unwrap();
+        assert!(super::decrypt(&wrong_key, None, &envelope).is_err());
+    }
+
+    #[cfg(feature = "encryption")]
+    #[test]
+    fn each_encryption_produces_unique_nonce() {
+        let key = test_key(0x42);
+        let plaintext = json!({"v": 1});
+        let e1 = super::encrypt(&key, &plaintext).unwrap();
+        let e2 = super::encrypt(&key, &plaintext).unwrap();
+        // Different nonces (probabilistically certain)
+        assert_ne!(e1["nonce"], e2["nonce"]);
+    }
+
+    #[cfg(not(feature = "encryption"))]
+    #[test]
+    fn stubs_are_identity() {
+        let key = [0u8; 32];
+        let v = json!({"a": 1});
+        assert_eq!(super::encrypt(&key, &v).unwrap(), v);
+        assert_eq!(super::decrypt(&key, None, &v).unwrap(), v);
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -4,7 +4,6 @@ use sqlx::Row;
 use base64::{engine::general_purpose::URL_SAFE_NO_PAD, Engine};
 use futures::stream::{self, Stream, StreamExt};
 use serde_json::{json, Value};
-use sqlx::Row;
 use std::convert::Infallible;
 use std::time::Duration;
 use std::sync::OnceLock;
@@ -2243,5 +2242,45 @@ mod tests {
         assert!(v.get("total").is_some());
         assert!(v.get("page").is_some());
         assert!(v["next_cursor"].is_string(), "offset path must also return next_cursor");
+    }
+}
+
+// ── Archive ──────────────────────────────────────────────────────────────────
+
+/// `GET /v1/events/archive` — list available archive files in S3.
+///
+/// Only available when the `archive` feature is enabled and `ARCHIVE_S3_BUCKET`
+/// is configured. Returns 501 otherwise.
+#[utoipa::path(
+    get,
+    path = "/v1/events/archive",
+    tag = "events",
+    responses(
+        (status = 200, description = "List of archive files"),
+        (status = 501, description = "Archive feature not enabled"),
+    )
+)]
+pub async fn list_archive(State(state): State<AppState>) -> Result<Json<Value>, AppError> {
+    #[cfg(feature = "archive")]
+    {
+        let (bucket, prefix) = match (&state.archive_s3_bucket, &state.archive_s3_prefix) {
+            (Some(b), p) => (b.clone(), p.clone()),
+            (None, _) => {
+                return Err(AppError::Validation(
+                    "ARCHIVE_S3_BUCKET is not configured".to_string(),
+                ))
+            }
+        };
+        let aws_cfg = aws_config::load_from_env().await;
+        let s3 = aws_sdk_s3::Client::new(&aws_cfg);
+        let files = crate::archiver::list_archive_files(&s3, &bucket, &prefix)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+        return Ok(Json(json!({ "data": files, "total": files.len() })));
+    }
+    #[cfg(not(feature = "archive"))]
+    {
+        let _ = state; // suppress unused warning
+        Err(AppError::Internal("archive feature not enabled".to_string()))
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -51,7 +51,7 @@ fn decode_cursor(cursor: &str) -> Result<(i64, Uuid), AppError> {
 }
 
 /// Map sqlx rows to a JSON array, projecting only the requested columns.
-fn rows_to_json(rows: &[sqlx::postgres::PgRow], columns: &[&str]) -> Result<Vec<Value>, AppError> {
+fn rows_to_json(rows: &[sqlx::postgres::PgRow], columns: &[&str], enc_key: Option<&[u8; 32]>, enc_key_old: Option<&[u8; 32]>) -> Result<Vec<Value>, AppError> {
     let mut events = Vec::with_capacity(rows.len());
     for row in rows {
         let mut event = serde_json::Map::new();
@@ -63,7 +63,11 @@ fn rows_to_json(rows: &[sqlx::postgres::PgRow], columns: &[&str]) -> Result<Vec<
                 "tx_hash" => { event.insert(col.to_string(), json!(row.try_get::<String, _>(col)?)); }
                 "ledger" => { event.insert(col.to_string(), json!(row.try_get::<i64, _>(col)?)); }
                 "timestamp" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
-                "event_data" => { event.insert(col.to_string(), row.try_get::<Value, _>(col)?); }
+                "event_data" => {
+                    let raw: Value = row.try_get::<Value, _>(col)?;
+                    let decrypted = decrypt_event_data(&raw, enc_key, enc_key_old);
+                    event.insert(col.to_string(), decrypted);
+                }
                 "created_at" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
                 _ => {}
             }
@@ -420,8 +424,11 @@ async fn stream_events_internal(
     };
 
     let rx = state.event_tx.subscribe();
+    let enc_key = state.encryption_key;
+    let enc_key_old = state.encryption_key_old;
 
-    let replay_stream = stream::iter(replay.into_iter().map(move |ev| {
+    let replay_stream = stream::iter(replay.into_iter().map(move |mut ev| {
+        ev.event_data = decrypt_event_data(&ev.event_data, enc_key.as_ref(), enc_key_old.as_ref());
         let data = serde_json::to_string(&ev).unwrap_or_default();
         Ok(Event::default()
             .id(ev.id.to_string())
@@ -479,8 +486,20 @@ async fn stream_events_internal(
     ))
 }
 
+/// Decrypt event_data if an encryption key is configured.
+fn decrypt_event_data(raw: &Value, key: Option<&[u8; 32]>, old_key: Option<&[u8; 32]>) -> Value {
+    if let Some(k) = key {
+        crate::encryption::decrypt(k, old_key, raw).unwrap_or_else(|e| {
+            tracing::warn!(error = %e, "Failed to decrypt event_data, returning raw value");
+            raw.clone()
+        })
+    } else {
+        raw.clone()
+    }
+}
+
 /// Converts an `Event` to a JSON object containing only the requested fields.
-fn filter_fields(event: &models::Event, columns: &[&str]) -> Value {
+fn filter_fields(event: &models::Event, columns: &[&str], enc_key: Option<&[u8; 32]>, enc_key_old: Option<&[u8; 32]>) -> Value {
     let mut map = serde_json::Map::new();
     for &col in columns {
         match col {
@@ -490,7 +509,10 @@ fn filter_fields(event: &models::Event, columns: &[&str]) -> Value {
             "tx_hash"     => { map.insert(col.to_string(), json!(event.tx_hash)); }
             "ledger"      => { map.insert(col.to_string(), json!(event.ledger)); }
             "timestamp"   => { map.insert(col.to_string(), json!(event.timestamp)); }
-            "event_data"  => { map.insert(col.to_string(), event.event_data.clone()); }
+            "event_data"  => {
+                let decrypted = decrypt_event_data(&event.event_data, enc_key, enc_key_old);
+                map.insert(col.to_string(), decrypted);
+            }
             "created_at"  => { map.insert(col.to_string(), json!(event.created_at)); }
             _ => {}
         }
@@ -588,7 +610,7 @@ pub async fn get_events(
             None
         };
 
-        let events = rows_to_json(&rows, &columns)?;
+        let events = rows_to_json(&rows, &columns, state.encryption_key.as_ref(), state.encryption_key_old.as_ref())?;
 
         return Ok(Json(json!({
             "data": events,
@@ -654,7 +676,7 @@ pub async fn get_events(
         None
     };
 
-    let events = rows_to_json(&rows, &columns)?;
+    let events = rows_to_json(&rows, &columns, state.encryption_key.as_ref(), state.encryption_key_old.as_ref())?;
 
     let (total, approximate): (i64, bool) = if exact {
         let count_str = format!("SELECT COUNT(*) FROM events {}", where_clause);
@@ -752,7 +774,7 @@ pub async fn get_events_by_contract(
         return Err(AppError::NotFound);
     }
 
-    let events: Vec<Value> = rows.iter().map(|e| filter_fields(e, &columns)).collect();
+    let events: Vec<Value> = rows.iter().map(|e| filter_fields(e, &columns, state.encryption_key.as_ref(), state.encryption_key_old.as_ref())).collect();
 
     let mut response = json!({
         "data": events,
@@ -809,7 +831,7 @@ pub async fn get_events_by_tx(
         .fetch_all(&state.pool)
         .await?;
 
-    let events = rows_to_json(&rows, &columns)?;
+    let events = rows_to_json(&rows, &columns, state.encryption_key.as_ref(), state.encryption_key_old.as_ref())?;
 
     Ok(Json(json!({ "data": events, "tx_hash": tx_hash })))
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -520,6 +520,15 @@ impl<R: RpcClient> Indexer<R> {
             "topic": event.topic
         });
 
+        let event_data = if let Some(ref key) = self.config.event_data_encryption_key {
+            crate::encryption::encrypt(key, &event_data).unwrap_or_else(|e| {
+                tracing::warn!(error = %e, "Failed to encrypt event_data, storing plaintext");
+                event_data
+            })
+        } else {
+            event_data
+        };
+
         let result = sqlx::query(
             r#"
             INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data)
@@ -737,6 +746,8 @@ mod tests {
                 environment: crate::config::Environment::Development,
                 max_body_size_bytes: 1024 * 1024,
                 log_sample_rate: 1,
+                event_data_encryption_key: None,
+                event_data_encryption_key_old: None,
             },
             shutdown_rx,
             MockRpcClient::new(),
@@ -877,7 +888,7 @@ mod tests {
                 indexer_lag_warn_threshold: 1000,
                 rpc_connect_timeout_secs: 30,
                 rpc_request_timeout_secs: 60,
-                api_key: None,
+                api_keys: Vec::new(),
                 db_max_connections: 10,
                 db_min_connections: 2,
                 allowed_origins: vec!["*".to_string()],
@@ -886,7 +897,13 @@ mod tests {
                 db_statement_timeout_ms: 5000,
                 indexer_poll_interval_ms: 5000,
                 indexer_error_backoff_ms: 10000,
+                sse_keepalive_interval_ms: 15000,
+                sse_max_connections: 1000,
                 environment: crate::config::Environment::Development,
+                max_body_size_bytes: 1024 * 1024,
+                log_sample_rate: 1,
+                event_data_encryption_key: None,
+                event_data_encryption_key_old: None,
             },
             shutdown_rx,
             mock_client,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,3 +7,6 @@ pub mod middleware;
 pub mod models;
 pub mod rpc_client;
 pub mod routes;
+
+#[cfg(feature = "archive")]
+pub mod archiver;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,9 @@ mod models;
 mod routes;
 mod rpc_client;
 
+#[cfg(feature = "archive")]
+mod archiver;
+
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
@@ -135,6 +138,10 @@ async fn main() -> anyhow::Result<()> {
         indexer.run().await;
     });
 
+    // Spawn archival background task (only when the `archive` feature is enabled).
+    #[cfg(feature = "archive")]
+    tokio::spawn(archiver::run_archiver(pool.clone(), config.clone()));
+
     async fn shutdown_signal() {
         #[cfg(unix)]
         {
@@ -167,7 +174,7 @@ async fn main() -> anyhow::Result<()> {
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     info!(origins = ?config.allowed_origins, "Allowed CORS origins");
     info!(rate_limit = config.rate_limit_per_minute, "Rate limit per IP");
-    let router = routes::create_router_with_tx(pool, config.api_keys.clone(), &config.allowed_origins, config.rate_limit_per_minute, config.behind_proxy, health_state, indexer_state, prometheus_handle, event_tx, config.sse_keepalive_interval_ms, config.sse_max_connections, 2000, config.event_data_encryption_key, config.event_data_encryption_key_old);
+    let router = routes::create_router_with_tx(pool, config.api_keys.clone(), &config.allowed_origins, config.rate_limit_per_minute, config.behind_proxy, health_state, indexer_state, prometheus_handle, event_tx, config.sse_keepalive_interval_ms, config.sse_max_connections, 2000, config.event_data_encryption_key, config.event_data_encryption_key_old, config.archive_s3_bucket.clone(), config.archive_s3_prefix.clone());
 
     info!(addr = %addr, "Soroban Pulse listening");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@
 )]
 mod config;
 mod db;
+mod encryption;
 mod error;
 mod handlers;
 mod indexer;
@@ -166,7 +167,7 @@ async fn main() -> anyhow::Result<()> {
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     info!(origins = ?config.allowed_origins, "Allowed CORS origins");
     info!(rate_limit = config.rate_limit_per_minute, "Rate limit per IP");
-    let router = routes::create_router_with_tx(pool, config.api_keys.clone(), &config.allowed_origins, config.rate_limit_per_minute, config.behind_proxy, health_state, indexer_state, prometheus_handle, event_tx, config.sse_keepalive_interval_ms, config.sse_max_connections, 2000);
+    let router = routes::create_router_with_tx(pool, config.api_keys.clone(), &config.allowed_origins, config.rate_limit_per_minute, config.behind_proxy, health_state, indexer_state, prometheus_handle, event_tx, config.sse_keepalive_interval_ms, config.sse_max_connections, 2000, config.event_data_encryption_key, config.event_data_encryption_key_old);
 
     info!(addr = %addr, "Soroban Pulse listening");
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -47,6 +47,8 @@ pub struct AppState {
     pub health_check_timeout_ms: u64,
     pub encryption_key: Option<[u8; 32]>,
     pub encryption_key_old: Option<[u8; 32]>,
+    pub archive_s3_bucket: Option<String>,
+    pub archive_s3_prefix: String,
 }
 
 /// OpenAPI spec — all paths are documented via #[utoipa::path] on handlers.
@@ -66,6 +68,7 @@ pub struct AppState {
         handlers::stream_events,
         handlers::stream_events_by_contract,
         handlers::get_contracts,
+        handlers::list_archive,
     ),
     components(schemas(
         crate::models::Event,
@@ -90,7 +93,7 @@ pub fn create_router(
     prometheus_handle: PrometheusHandle,
     health_check_timeout_ms: u64,
 ) -> Router {
-    create_router_with_tx(pool, api_keys, allowed_origins, rate_limit_per_minute, false, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0, 15000, 1000, health_check_timeout_ms, None, None)
+    create_router_with_tx(pool, api_keys, allowed_origins, rate_limit_per_minute, false, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0, 15000, 1000, health_check_timeout_ms, None, None, None, "soroban-pulse/events".to_string())
 }
 
 pub fn create_router_with_tx(
@@ -108,6 +111,8 @@ pub fn create_router_with_tx(
     health_check_timeout_ms: u64,
     encryption_key: Option<[u8; 32]>,
     encryption_key_old: Option<[u8; 32]>,
+    archive_s3_bucket: Option<String>,
+    archive_s3_prefix: String,
 ) -> Router {
     let cors = build_cors(allowed_origins);
     let auth_state = Arc::new(middleware::AuthState { api_keys });
@@ -123,6 +128,8 @@ pub fn create_router_with_tx(
         health_check_timeout_ms,
         encryption_key,
         encryption_key_old,
+        archive_s3_bucket,
+        archive_s3_prefix,
     };
 
     // Build governor config: burst = rate_limit_per_minute, replenish 1 token per (60/rate) seconds.
@@ -134,6 +141,7 @@ pub fn create_router_with_tx(
     // Versioned v1 routes
     let v1 = Router::new()
         .route("/events", get(handlers::get_events))
+        .route("/events/archive", get(handlers::list_archive))
         .route("/events/stream", get(handlers::stream_events))
         .route("/events/contract/:contract_id", get(handlers::get_events_by_contract))
         .route("/events/contract/:contract_id/stream", get(handlers::stream_events_by_contract))

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -45,6 +45,8 @@ pub struct AppState {
     pub sse_connections: Arc<AtomicUsize>,
     pub sse_max_connections: usize,
     pub health_check_timeout_ms: u64,
+    pub encryption_key: Option<[u8; 32]>,
+    pub encryption_key_old: Option<[u8; 32]>,
 }
 
 /// OpenAPI spec — all paths are documented via #[utoipa::path] on handlers.
@@ -88,7 +90,7 @@ pub fn create_router(
     prometheus_handle: PrometheusHandle,
     health_check_timeout_ms: u64,
 ) -> Router {
-    create_router_with_tx(pool, api_keys, allowed_origins, rate_limit_per_minute, false, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0, 15000, 1000, health_check_timeout_ms)
+    create_router_with_tx(pool, api_keys, allowed_origins, rate_limit_per_minute, false, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0, 15000, 1000, health_check_timeout_ms, None, None)
 }
 
 pub fn create_router_with_tx(
@@ -104,6 +106,8 @@ pub fn create_router_with_tx(
     sse_keepalive_interval_ms: u64,
     sse_max_connections: usize,
     health_check_timeout_ms: u64,
+    encryption_key: Option<[u8; 32]>,
+    encryption_key_old: Option<[u8; 32]>,
 ) -> Router {
     let cors = build_cors(allowed_origins);
     let auth_state = Arc::new(middleware::AuthState { api_keys });
@@ -117,6 +121,8 @@ pub fn create_router_with_tx(
         sse_connections: Arc::new(AtomicUsize::new(0)),
         sse_max_connections,
         health_check_timeout_ms,
+        encryption_key,
+        encryption_key_old,
     };
 
     // Build governor config: burst = rate_limit_per_minute, replenish 1 token per (60/rate) seconds.


### PR DESCRIPTION
Changes
  
  - archive feature flag — all S3 dependencies (aws-sdk-s3, aws-config, flate2) are optional and only
  compiled with --features archive
  - Background archiver — runs daily, selects events older than ARCHIVE_AFTER_DAYS (default: 365),
  writes them as gzip-compressed NDJSON to S3 at <prefix>/YYYY/MM/DD/events.ndjson.gz, then deletes
  them from the DB after a confirmed upload
  - GET /v1/events/archive — lists available archive files with date and size metadata
  - Config — three new env vars: ARCHIVE_AFTER_DAYS, ARCHIVE_S3_BUCKET, ARCHIVE_S3_PREFIX
  
  Notes
  
  - Archiver is a no-op if ARCHIVE_S3_BUCKET is unset
  - Uses the standard AWS credential chain (IAM role, env vars, etc.)
  - DB deletion only occurs after a successful S3 upload — no data loss on upload failure
  - The /v1/events/archive endpoint returns 400 if the bucket is unconfigured, 500 if the feature
  flag is off

closes #258 