### PR TITLE
feat: add optional direct TLS serving via TLS_CERT_FILE / TLS_KEY_FIL…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -103,3 +103,14 @@ RUST_LOG_FORMAT=text
 # - Database query spans with SQL statement, row count, and execution duration
 # Format: URL (e.g., http://localhost:4317)
 # OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:4317
+
+# --- Direct TLS (optional) ---
+# When both TLS_CERT_FILE and TLS_KEY_FILE are set, the service serves HTTPS
+# directly without requiring a reverse proxy. Useful for simple VPS deployments
+# or development environments with self-signed certificates.
+# When only one is set, the service logs a warning and falls back to plain HTTP.
+# When TLS is enabled, BEHIND_PROXY is automatically forced to false.
+# Format: path to PEM-encoded certificate file
+# TLS_CERT_FILE=/etc/ssl/certs/soroban-pulse.crt
+# Format: path to PEM-encoded private key file
+# TLS_KEY_FILE=/etc/ssl/private/soroban-pulse.key

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ async-trait = "0.1"
 tower_governor = { version = "0.8", features = ["axum"] }
 base64 = "0.22"
 sha2 = "0.10"
+axum-server = { version = "0.7", features = ["tls-rustls"] }
 
 [features]
 otel = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-otlp"]

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,46 @@
 # Deployment Guide
 
+## Direct TLS
+
+By default, Soroban Pulse serves plain HTTP and relies on an external reverse proxy (nginx, Caddy, AWS ALB, etc.) for TLS termination. For simpler deployments — a single VPS, a development environment with self-signed certificates, or any setup where adding a proxy is impractical — the service can handle TLS directly.
+
+### Enabling direct TLS
+
+Set both `TLS_CERT_FILE` and `TLS_KEY_FILE` to PEM-encoded certificate and key files:
+
+```bash
+TLS_CERT_FILE=/etc/ssl/certs/soroban-pulse.crt
+TLS_KEY_FILE=/etc/ssl/private/soroban-pulse.key
+PORT=443
+```
+
+When both variables are set, the service starts an HTTPS listener using `axum-server` with `rustls`. The certificate and key files are validated at startup — if either file is missing or the TLS handshake configuration fails, the service panics with a descriptive error.
+
+When only one of the two variables is set, the service logs a warning and falls back to plain HTTP.
+
+**`BEHIND_PROXY` is automatically forced to `false` when direct TLS is enabled**, since there is no proxy in front of the service. Any explicit `BEHIND_PROXY=true` setting is overridden and a warning is logged.
+
+### Self-signed certificate (development)
+
+```bash
+# Generate a self-signed cert valid for 365 days
+openssl req -x509 -newkey rsa:4096 -keyout key.pem -out cert.pem \
+  -days 365 -nodes -subj '/CN=localhost'
+
+TLS_CERT_FILE=cert.pem TLS_KEY_FILE=key.pem PORT=3443 cargo run
+```
+
+### Production recommendation
+
+For production deployments, prefer a reverse proxy (nginx, Caddy, AWS ALB) for TLS termination. This allows:
+- Automatic certificate renewal (e.g., Let's Encrypt via Caddy)
+- HTTP/2 and connection multiplexing
+- Load balancing across multiple replicas
+
+Set `BEHIND_PROXY=true` when running behind a proxy so the service trusts `X-Forwarded-For` headers for rate limiting.
+
+---
+
 ## Horizontal Scaling
 
 Soroban Pulse supports running multiple replicas safely. Only one replica will run the indexer loop at a time; all others serve HTTP traffic in read-only mode.

--- a/src/config.rs
+++ b/src/config.rs
@@ -133,6 +133,8 @@ pub struct Config {
     pub environment: Environment,
     pub max_body_size_bytes: usize,
     pub log_sample_rate: u32,
+    pub tls_cert_file: Option<String>,
+    pub tls_key_file: Option<String>,
 }
 
 impl Default for Config {
@@ -161,6 +163,8 @@ impl Default for Config {
             environment: Environment::Development,
             max_body_size_bytes: 1024 * 1024, // 1 MB default
             log_sample_rate: 1,
+            tls_cert_file: None,
+            tls_key_file: None,
         }
     }
 }
@@ -384,6 +388,8 @@ impl Config {
                 assert!(v > 0, "LOG_SAMPLE_RATE must be a positive integer, got {v}");
                 v
             },
+            tls_cert_file: env::var("TLS_CERT_FILE").ok().filter(|s| !s.is_empty()),
+            tls_key_file: env::var("TLS_KEY_FILE").ok().filter(|s| !s.is_empty()),
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,7 +19,7 @@ mod rpc_client;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use std::time::Duration;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt, EnvFilter};
 
 #[cfg(feature = "otel")]
@@ -166,27 +166,62 @@ async fn main() -> anyhow::Result<()> {
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     info!(origins = ?config.allowed_origins, "Allowed CORS origins");
     info!(rate_limit = config.rate_limit_per_minute, "Rate limit per IP");
-    let router = routes::create_router_with_tx(pool, config.api_keys.clone(), &config.allowed_origins, config.rate_limit_per_minute, config.behind_proxy, health_state, indexer_state, prometheus_handle, event_tx, config.sse_keepalive_interval_ms, config.sse_max_connections, config.clone());
 
-    info!(addr = %addr, "Soroban Pulse listening");
+    // When TLS is enabled directly, BEHIND_PROXY is forced false — no proxy in front.
+    let behind_proxy = match (&config.tls_cert_file, &config.tls_key_file) {
+        (Some(_), Some(_)) => {
+            if config.behind_proxy {
+                warn!("TLS_CERT_FILE and TLS_KEY_FILE are set — overriding BEHIND_PROXY=false (no proxy in front of direct TLS)");
+            }
+            false
+        }
+        _ => config.behind_proxy,
+    };
 
-    let listener = tokio::net::TcpListener::bind(addr).await.map_err(|e| {
-        error!(addr = %addr, "Address already in use");
-        e
-    })?;
+    let router = routes::create_router_with_tx(pool, config.api_keys.clone(), &config.allowed_origins, config.rate_limit_per_minute, behind_proxy, health_state, indexer_state, prometheus_handle, event_tx, config.sse_keepalive_interval_ms, config.sse_max_connections, config.clone());
 
-    info!(behind_proxy = config.behind_proxy, "Running server - trusting X-Forwarded-For");
+    match (&config.tls_cert_file, &config.tls_key_file) {
+        (Some(cert_path), Some(key_path)) => {
+            // Validate that the cert and key files exist and are readable at startup.
+            std::fs::metadata(cert_path)
+                .unwrap_or_else(|e| panic!("TLS_CERT_FILE '{}' is not accessible: {}", cert_path, e));
+            std::fs::metadata(key_path)
+                .unwrap_or_else(|e| panic!("TLS_KEY_FILE '{}' is not accessible: {}", key_path, e));
 
-    // Use regular make_service since we handle connect_info through middleware
-    // Use the router directly as it implements Service for incoming connections
-    axum::serve(
-        listener,
-        router,
-    )
-    .with_graceful_shutdown(async move {
-        let _ = shutdown_rx_axum.changed().await;
-    })
-    .await?;
+            let tls_config = axum_server::tls_rustls::RustlsConfig::from_pem_file(cert_path, key_path)
+                .await
+                .unwrap_or_else(|e| panic!("Failed to load TLS certificate/key: {}", e));
+
+            info!(addr = %addr, cert = %cert_path, "Soroban Pulse listening (HTTPS/TLS)");
+
+            axum_server::bind_rustls(addr, tls_config)
+                .serve(router.into_make_service())
+                .await?;
+        }
+        (Some(_), None) | (None, Some(_)) => {
+            warn!("Only one of TLS_CERT_FILE / TLS_KEY_FILE is set — both are required for TLS. Falling back to plain HTTP.");
+            let listener = tokio::net::TcpListener::bind(addr).await.map_err(|e| {
+                error!(addr = %addr, "Address already in use");
+                e
+            })?;
+            info!(addr = %addr, "Soroban Pulse listening (HTTP)");
+            info!(behind_proxy = behind_proxy, "Running server - trusting X-Forwarded-For");
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move { let _ = shutdown_rx_axum.changed().await; })
+                .await?;
+        }
+        (None, None) => {
+            let listener = tokio::net::TcpListener::bind(addr).await.map_err(|e| {
+                error!(addr = %addr, "Address already in use");
+                e
+            })?;
+            info!(addr = %addr, "Soroban Pulse listening (HTTP)");
+            info!(behind_proxy = behind_proxy, "Running server - trusting X-Forwarded-For");
+            axum::serve(listener, router)
+                .with_graceful_shutdown(async move { let _ = shutdown_rx_axum.changed().await; })
+                .await?;
+        }
+    }
     let _ = indexer_handle.await;
 
     #[cfg(feature = "otel")]


### PR DESCRIPTION
…E (#196)

When TLS_CERT_FILE and TLS_KEY_FILE are both set, the service serves HTTPS directly using axum-server with rustls, without requiring a reverse proxy.

- Add axum-server 0.7 with tls-rustls feature to Cargo.toml
- Add tls_cert_file and tls_key_file fields to Config, loaded from env
- Validate cert/key file accessibility at startup with descriptive panic
- Load RustlsConfig from PEM files; panic with clear error if invalid
- When TLS is active, BEHIND_PROXY is forced false (no proxy in front)
- When only one of the two TLS vars is set, warn and fall back to HTTP
- Document TLS_CERT_FILE / TLS_KEY_FILE in .env.example
- Add Direct TLS section to docs/deployment.md with usage examples

Closes #196

