### PR TITLE
Feat:Add support for event data normalization pipeline

### DIFF
--- a/migrations/20260427000000_normalization.down.sql
+++ b/migrations/20260427000000_normalization.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE events DROP COLUMN IF EXISTS event_data_normalized;
+DROP TABLE IF EXISTS normalization_rules;

--- a/migrations/20260427000000_normalization.sql
+++ b/migrations/20260427000000_normalization.sql
@@ -1,0 +1,14 @@
+-- normalization_rules: per-contract transformation pipeline
+CREATE TABLE IF NOT EXISTS normalization_rules (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    contract_id TEXT NOT NULL,
+    pointer     TEXT NOT NULL,          -- JSON Pointer (RFC 6901) to the target field
+    transform   TEXT NOT NULL,          -- one of: divide_by_decimals, hex_to_decimal, base64_decode
+    params      JSONB NOT NULL DEFAULT '{}',  -- transform-specific params (e.g. {"decimals": 7})
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_normalization_rules_contract_id ON normalization_rules(contract_id);
+
+-- normalized event data stored alongside the original
+ALTER TABLE events ADD COLUMN IF NOT EXISTS event_data_normalized JSONB;

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -65,6 +65,7 @@ fn rows_to_json(rows: &[sqlx::postgres::PgRow], columns: &[&str]) -> Result<Vec<
                 "ledger" => { event.insert(col.to_string(), json!(row.try_get::<i64, _>(col)?)); }
                 "timestamp" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
                 "event_data" => { event.insert(col.to_string(), row.try_get::<Value, _>(col)?); }
+                "event_data_normalized" => { event.insert(col.to_string(), row.try_get::<Option<Value>, _>(col)?.unwrap_or(Value::Null)); }
                 "created_at" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
                 _ => {}
             }
@@ -397,7 +398,7 @@ async fn stream_events_internal(
     let replay: Vec<crate::models::Event> = if let Some(last_id) = last_event_id {
         let q = if let Some(ref cid) = contract_filter {
             sqlx::query_as::<_, crate::models::Event>(
-                "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, created_at, 0::bigint AS total_count \
+                "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, event_data_normalized, created_at, 0::bigint AS total_count \
                  FROM events WHERE created_at > (SELECT created_at FROM events WHERE id = $1) \
                  AND contract_id = $2 ORDER BY created_at ASC",
             )
@@ -407,7 +408,7 @@ async fn stream_events_internal(
             .await
         } else {
             sqlx::query_as::<_, crate::models::Event>(
-                "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, created_at, 0::bigint AS total_count \
+                "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, event_data_normalized, created_at, 0::bigint AS total_count \
                  FROM events WHERE created_at > (SELECT created_at FROM events WHERE id = $1) \
                  ORDER BY created_at ASC",
             )
@@ -492,6 +493,7 @@ fn filter_fields(event: &models::Event, columns: &[&str]) -> Value {
             "ledger"      => { map.insert(col.to_string(), json!(event.ledger)); }
             "timestamp"   => { map.insert(col.to_string(), json!(event.timestamp)); }
             "event_data"  => { map.insert(col.to_string(), event.event_data.clone()); }
+            "event_data_normalized" => { map.insert(col.to_string(), event.event_data_normalized.clone().unwrap_or(Value::Null)); }
             "created_at"  => { map.insert(col.to_string(), json!(event.created_at)); }
             _ => {}
         }
@@ -737,7 +739,7 @@ pub async fn get_events_by_contract(
 
     let where_clause = format!("WHERE {}", conditions.join(" AND "));
     let query_str = format!(
-        "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, created_at, 0::bigint AS total_count \
+        "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, event_data_normalized, created_at, 0::bigint AS total_count \
          FROM events {} ORDER BY ledger DESC LIMIT ${} OFFSET ${}",
         where_clause, bind_idx, bind_idx + 1,
     );

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -12,6 +12,7 @@ use crate::{
     config::{Config, HealthState, IndexerState},
     metrics,
     models::{GetEventsResult, LatestLedgerResult, RpcResponse, SorobanEvent},
+    normalizer,
 };
 
 #[async_trait::async_trait]
@@ -520,10 +521,13 @@ impl<R: RpcClient> Indexer<R> {
             "topic": event.topic
         });
 
+        let rules = normalizer::load_rules(&self.pool, &event.contract_id).await;
+        let event_data_normalized = normalizer::normalize(&rules, &event_data);
+
         let result = sqlx::query(
             r#"
-            INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data)
-            VALUES ($1, $2, $3, $4, $5, $6)
+            INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data, event_data_normalized)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
             ON CONFLICT (tx_hash, contract_id, event_type) DO NOTHING
             "#,
         )
@@ -532,7 +536,8 @@ impl<R: RpcClient> Indexer<R> {
         .bind(&event.tx_hash)
         .bind(ledger)
         .bind(timestamp)
-        .bind(event_data)
+        .bind(&event_data)
+        .bind(event_data_normalized.as_ref())
         .execute(&self.pool)
         .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub mod handlers;
 pub mod metrics;
 pub mod middleware;
 pub mod models;
+pub mod normalizer;
 pub mod rpc_client;
 pub mod routes;

--- a/src/models.rs
+++ b/src/models.rs
@@ -45,6 +45,7 @@ pub struct Event {
     pub ledger: i64,
     pub timestamp: DateTime<Utc>,
     pub event_data: Value,
+    pub event_data_normalized: Option<Value>,
     pub created_at: DateTime<Utc>,
     #[sqlx(default)]
     #[serde(skip)]
@@ -112,6 +113,7 @@ impl PaginationParams {
         "ledger",
         "timestamp",
         "event_data",
+        "event_data_normalized",
         "created_at",
     ];
 

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -1,0 +1,284 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sqlx::PgPool;
+
+/// A single normalization rule loaded from the DB.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct NormalizationRule {
+    pub pointer: String,
+    pub transform: String,
+    pub params: Value,
+}
+
+/// Built-in transform names.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Transform {
+    DivideByDecimals,
+    HexToDecimal,
+    Base64Decode,
+}
+
+impl std::str::FromStr for Transform {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "divide_by_decimals" => Ok(Transform::DivideByDecimals),
+            "hex_to_decimal" => Ok(Transform::HexToDecimal),
+            "base64_decode" => Ok(Transform::Base64Decode),
+            other => Err(format!("unknown transform: {other}")),
+        }
+    }
+}
+
+/// Apply a single transform to a JSON value, returning the transformed value.
+pub fn apply_transform(transform: &Transform, params: &Value, value: &Value) -> Result<Value, String> {
+    match transform {
+        Transform::DivideByDecimals => {
+            let decimals = params
+                .get("decimals")
+                .and_then(|v| v.as_u64())
+                .ok_or("divide_by_decimals requires params.decimals (u64)")?;
+            let raw = value
+                .as_i64()
+                .or_else(|| value.as_str().and_then(|s| s.parse::<i64>().ok()))
+                .ok_or_else(|| format!("divide_by_decimals: expected integer, got {value}"))?;
+            let divisor = 10_i64.pow(decimals as u32);
+            // Return as a JSON number (f64) — sufficient for display purposes
+            Ok(Value::from(raw as f64 / divisor as f64))
+        }
+        Transform::HexToDecimal => {
+            let hex = value
+                .as_str()
+                .ok_or_else(|| format!("hex_to_decimal: expected string, got {value}"))?
+                .trim_start_matches("0x");
+            let n = u128::from_str_radix(hex, 16)
+                .map_err(|e| format!("hex_to_decimal: {e}"))?;
+            // u128 may exceed f64 precision; store as string to preserve accuracy
+            Ok(Value::String(n.to_string()))
+        }
+        Transform::Base64Decode => {
+            let encoded = value
+                .as_str()
+                .ok_or_else(|| format!("base64_decode: expected string, got {value}"))?;
+            let bytes = STANDARD
+                .decode(encoded)
+                .map_err(|e| format!("base64_decode: {e}"))?;
+            match std::str::from_utf8(&bytes) {
+                Ok(s) => Ok(Value::String(s.to_owned())),
+                Err(_) => {
+                    // Not valid UTF-8 — return hex representation
+                    let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+                    Ok(Value::String(hex))
+                }
+            }
+        }
+    }
+}
+
+/// Resolve a JSON Pointer (RFC 6901) to a mutable reference within a Value.
+fn pointer_get(value: &Value, pointer: &str) -> Option<Value> {
+    if pointer.is_empty() || pointer == "/" {
+        return Some(value.clone());
+    }
+    let mut current = value;
+    for token in pointer.trim_start_matches('/').split('/') {
+        let token = token.replace("~1", "/").replace("~0", "~");
+        current = match current {
+            Value::Object(map) => map.get(&token)?,
+            Value::Array(arr) => {
+                let idx: usize = token.parse().ok()?;
+                arr.get(idx)?
+            }
+            _ => return None,
+        };
+    }
+    Some(current.clone())
+}
+
+/// Set a value at a JSON Pointer path (mutates `root`).
+fn pointer_set(root: &mut Value, pointer: &str, new_val: Value) {
+    if pointer.is_empty() || pointer == "/" {
+        *root = new_val;
+        return;
+    }
+    let tokens: Vec<String> = pointer
+        .trim_start_matches('/')
+        .split('/')
+        .map(|t| t.replace("~1", "/").replace("~0", "~"))
+        .collect();
+    let mut current = root;
+    for (i, token) in tokens.iter().enumerate() {
+        let is_last = i == tokens.len() - 1;
+        current = match current {
+            Value::Object(map) => {
+                if is_last {
+                    map.insert(token.clone(), new_val);
+                    return;
+                }
+                map.entry(token.clone()).or_insert(Value::Object(Default::default()))
+            }
+            Value::Array(arr) => {
+                if let Ok(idx) = token.parse::<usize>() {
+                    if is_last {
+                        if idx < arr.len() {
+                            arr[idx] = new_val;
+                        }
+                        return;
+                    }
+                    if idx < arr.len() { &mut arr[idx] } else { return; }
+                } else {
+                    return;
+                }
+            }
+            _ => return,
+        };
+    }
+}
+
+/// Run the normalization pipeline for a given contract and event_data.
+/// Returns `None` if there are no rules for this contract.
+pub fn normalize(rules: &[NormalizationRule], event_data: &Value) -> Option<Value> {
+    if rules.is_empty() {
+        return None;
+    }
+    let mut normalized = event_data.clone();
+    for rule in rules {
+        let transform: Transform = match rule.transform.parse() {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(transform = %rule.transform, error = %e, "Unknown transform, skipping");
+                continue;
+            }
+        };
+        let current = match pointer_get(&normalized, &rule.pointer) {
+            Some(v) => v,
+            None => {
+                tracing::debug!(pointer = %rule.pointer, "JSON Pointer not found in event_data, skipping");
+                continue;
+            }
+        };
+        match apply_transform(&transform, &rule.params, &current) {
+            Ok(new_val) => pointer_set(&mut normalized, &rule.pointer, new_val),
+            Err(e) => tracing::warn!(pointer = %rule.pointer, error = %e, "Transform failed, skipping"),
+        }
+    }
+    Some(normalized)
+}
+
+/// Load normalization rules for a contract from the DB.
+pub async fn load_rules(pool: &PgPool, contract_id: &str) -> Vec<NormalizationRule> {
+    sqlx::query_as::<_, NormalizationRule>(
+        "SELECT pointer, transform, params FROM normalization_rules WHERE contract_id = $1 ORDER BY created_at",
+    )
+    .bind(contract_id)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn rule(pointer: &str, transform: &str, params: Value) -> NormalizationRule {
+        NormalizationRule { pointer: pointer.to_string(), transform: transform.to_string(), params }
+    }
+
+    // --- divide_by_decimals ---
+
+    #[test]
+    fn divide_by_decimals_integer() {
+        let t = Transform::DivideByDecimals;
+        let result = apply_transform(&t, &json!({"decimals": 7}), &json!(10_000_000)).unwrap();
+        assert_eq!(result, json!(1.0));
+    }
+
+    #[test]
+    fn divide_by_decimals_string_input() {
+        let t = Transform::DivideByDecimals;
+        let result = apply_transform(&t, &json!({"decimals": 2}), &json!("500")).unwrap();
+        assert_eq!(result, json!(5.0));
+    }
+
+    #[test]
+    fn divide_by_decimals_missing_params() {
+        let t = Transform::DivideByDecimals;
+        assert!(apply_transform(&t, &json!({}), &json!(100)).is_err());
+    }
+
+    // --- hex_to_decimal ---
+
+    #[test]
+    fn hex_to_decimal_plain() {
+        let t = Transform::HexToDecimal;
+        let result = apply_transform(&t, &json!({}), &json!("ff")).unwrap();
+        assert_eq!(result, json!("255"));
+    }
+
+    #[test]
+    fn hex_to_decimal_with_prefix() {
+        let t = Transform::HexToDecimal;
+        let result = apply_transform(&t, &json!({}), &json!("0x1a")).unwrap();
+        assert_eq!(result, json!("26"));
+    }
+
+    #[test]
+    fn hex_to_decimal_invalid() {
+        let t = Transform::HexToDecimal;
+        assert!(apply_transform(&t, &json!({}), &json!("xyz")).is_err());
+    }
+
+    // --- base64_decode ---
+
+    #[test]
+    fn base64_decode_utf8() {
+        let t = Transform::Base64Decode;
+        // "hello" in standard base64
+        let result = apply_transform(&t, &json!({}), &json!("aGVsbG8=")).unwrap();
+        assert_eq!(result, json!("hello"));
+    }
+
+    #[test]
+    fn base64_decode_binary_returns_hex() {
+        let t = Transform::Base64Decode;
+        // bytes [0xff, 0xfe] — not valid UTF-8
+        let result = apply_transform(&t, &json!({}), &json!("//4=")).unwrap();
+        assert_eq!(result, json!("fffe"));
+    }
+
+    #[test]
+    fn base64_decode_invalid() {
+        let t = Transform::Base64Decode;
+        assert!(apply_transform(&t, &json!({}), &json!("!!!")).is_err());
+    }
+
+    // --- pipeline ---
+
+    #[test]
+    fn normalize_applies_rules_in_order() {
+        let rules = vec![rule("/value/amount", "divide_by_decimals", json!({"decimals": 2}))];
+        let data = json!({"value": {"amount": 1000}, "topic": []});
+        let result = normalize(&rules, &data).unwrap();
+        assert_eq!(result["value"]["amount"], json!(10.0));
+        // original untouched fields preserved
+        assert_eq!(result["topic"], json!([]));
+    }
+
+    #[test]
+    fn normalize_no_rules_returns_none() {
+        let data = json!({"value": {}, "topic": []});
+        assert!(normalize(&[], &data).is_none());
+    }
+
+    #[test]
+    fn normalize_missing_pointer_skips() {
+        let rules = vec![rule("/value/nonexistent", "hex_to_decimal", json!({}))];
+        let data = json!({"value": {}, "topic": []});
+        // Should not panic, just skip
+        let result = normalize(&rules, &data).unwrap();
+        assert_eq!(result, data);
+    }
+}


### PR DESCRIPTION
## Summary

Added support for event data normalization pipeline

## Related Issue

Closes #259 

## Changes

                                                                              
  `migrations/20260427000000_normalization.sql` (new)                           
                                                                                
  - Creates normalization_rules table with contract_id, pointer (JSON Pointer   
  RFC 6901), transform, and params (JSONB) columns.                             
  - Adds event_data_normalized JSONB column to events.                          
                                                                                
  `src/normalizer.rs` (new)                                                     
                                                                                
  - NormalizationRule — sqlx row type loaded from DB.                           
  - Transform enum — DivideByDecimals, HexToDecimal, Base64Decode.              
  - apply_transform() — applies a single transform to a JSON value:             
    - divide_by_decimals: divides an integer (or numeric string) by 10^decimals,
  returns f64.                                                                  
    - hex_to_decimal: parses hex string (with or without 0x prefix) to decimal, 
  returns string to preserve u128 precision.                                    
    - base64_decode: decodes standard base64 to UTF-8 string, or hex string if  
  bytes aren't valid UTF-8.                                                     
                                                                                
  - normalize() — runs the pipeline over event_data, returns None if no rules   
  exist (avoids writing a redundant copy).                                      
  - load_rules() — fetches rules for a contract from the DB.                    
  - 11 unit tests covering all transforms and pipeline edge cases.              
                                                                                
  `src/indexer.rs`                                                              
                                                                                
  - store_event() now calls load_rules + normalize after building event_data,   
  then stores event_data_normalized as the 7th bind parameter in the INSERT.    
                                                                                
  `src/models.rs`                                                               
                                                                                
  - Event struct gains event_data_normalized: Option<Value>.                    
  - ALLOWED_FIELDS gains "event_data_normalized".                               
                                                                                
  `src/handlers.rs`                                                             
                                                                                
  - rows_to_json() handles the new column.                                      
  - filter_fields() handles the new column.                                     
  - All three explicit SELECT column lists (SSE replay queries, contract        
  handler) updated to include event_data_normalized.                            
                                                                                
  `src/lib.rs`                                                                  
                                                                                
  - pub mod normalizer; registered.                                             
                                                                                
  How to add rules                                                              
                                                                                
  INSERT INTO normalization_rules (contract_id, pointer, transform, params)     
  VALUES                                                                        
    ('CABC...', '/value/amount', 'divide_by_decimals', '{"decimals": 7}'),      
    ('CABC...', '/value/token_id', 'hex_to_decimal', '{}');                     
                                                                                
  Rules are applied in created_at order. Events with no rules get               
  event_data_normalized: null in the API response.     

- 

## Testing

<!-- Describe how you tested this. -->

- [ x] `cargo test` passes
- [ x] `cargo clippy` reports no warnings
- [ x] Manually tested locally

## Notes

<!-- Anything reviewers should pay special attention to, or N/A. -->
