### PR TITLE
Feat: Add support for event subscriptions with delivery guarantees

### DIFF
--- a/migrations/20260427000000_normalization.down.sql
+++ b/migrations/20260427000000_normalization.down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE events DROP COLUMN IF EXISTS event_data_normalized;
+DROP TABLE IF EXISTS normalization_rules;

--- a/migrations/20260427000000_normalization.sql
+++ b/migrations/20260427000000_normalization.sql
@@ -1,0 +1,14 @@
+-- normalization_rules: per-contract transformation pipeline
+CREATE TABLE IF NOT EXISTS normalization_rules (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    contract_id TEXT NOT NULL,
+    pointer     TEXT NOT NULL,          -- JSON Pointer (RFC 6901) to the target field
+    transform   TEXT NOT NULL,          -- one of: divide_by_decimals, hex_to_decimal, base64_decode
+    params      JSONB NOT NULL DEFAULT '{}',  -- transform-specific params (e.g. {"decimals": 7})
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_normalization_rules_contract_id ON normalization_rules(contract_id);
+
+-- normalized event data stored alongside the original
+ALTER TABLE events ADD COLUMN IF NOT EXISTS event_data_normalized JSONB;

--- a/migrations/20260427000001_subscriptions.down.sql
+++ b/migrations/20260427000001_subscriptions.down.sql
@@ -1,0 +1,2 @@
+DROP TABLE IF EXISTS delivery_queue;
+DROP TABLE IF EXISTS subscriptions;

--- a/migrations/20260427000001_subscriptions.sql
+++ b/migrations/20260427000001_subscriptions.sql
@@ -1,0 +1,24 @@
+CREATE TABLE IF NOT EXISTS subscriptions (
+    id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    callback_url TEXT NOT NULL,
+    from_ledger  BIGINT NOT NULL,
+    -- last ledger successfully acked by the client
+    acked_ledger BIGINT NOT NULL DEFAULT 0,
+    status       TEXT NOT NULL DEFAULT 'active', -- active | cancelled
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS delivery_queue (
+    id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    subscription_id UUID NOT NULL REFERENCES subscriptions(id) ON DELETE CASCADE,
+    event_id        UUID NOT NULL REFERENCES events(id) ON DELETE CASCADE,
+    ledger          BIGINT NOT NULL,
+    status          TEXT NOT NULL DEFAULT 'pending', -- pending | delivered | failed
+    attempts        INT NOT NULL DEFAULT 0,
+    next_attempt_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_error      TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_delivery_queue_sub_status
+    ON delivery_queue(subscription_id, status, next_attempt_at);

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -65,6 +65,7 @@ fn rows_to_json(rows: &[sqlx::postgres::PgRow], columns: &[&str]) -> Result<Vec<
                 "ledger" => { event.insert(col.to_string(), json!(row.try_get::<i64, _>(col)?)); }
                 "timestamp" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
                 "event_data" => { event.insert(col.to_string(), row.try_get::<Value, _>(col)?); }
+                "event_data_normalized" => { event.insert(col.to_string(), row.try_get::<Option<Value>, _>(col)?.unwrap_or(Value::Null)); }
                 "created_at" => { event.insert(col.to_string(), json!(row.try_get::<DateTime<Utc>, _>(col)?)); }
                 _ => {}
             }
@@ -397,7 +398,7 @@ async fn stream_events_internal(
     let replay: Vec<crate::models::Event> = if let Some(last_id) = last_event_id {
         let q = if let Some(ref cid) = contract_filter {
             sqlx::query_as::<_, crate::models::Event>(
-                "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, created_at, 0::bigint AS total_count \
+                "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, event_data_normalized, created_at, 0::bigint AS total_count \
                  FROM events WHERE created_at > (SELECT created_at FROM events WHERE id = $1) \
                  AND contract_id = $2 ORDER BY created_at ASC",
             )
@@ -407,7 +408,7 @@ async fn stream_events_internal(
             .await
         } else {
             sqlx::query_as::<_, crate::models::Event>(
-                "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, created_at, 0::bigint AS total_count \
+                "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, event_data_normalized, created_at, 0::bigint AS total_count \
                  FROM events WHERE created_at > (SELECT created_at FROM events WHERE id = $1) \
                  ORDER BY created_at ASC",
             )
@@ -492,6 +493,7 @@ fn filter_fields(event: &models::Event, columns: &[&str]) -> Value {
             "ledger"      => { map.insert(col.to_string(), json!(event.ledger)); }
             "timestamp"   => { map.insert(col.to_string(), json!(event.timestamp)); }
             "event_data"  => { map.insert(col.to_string(), event.event_data.clone()); }
+            "event_data_normalized" => { map.insert(col.to_string(), event.event_data_normalized.clone().unwrap_or(Value::Null)); }
             "created_at"  => { map.insert(col.to_string(), json!(event.created_at)); }
             _ => {}
         }
@@ -737,7 +739,7 @@ pub async fn get_events_by_contract(
 
     let where_clause = format!("WHERE {}", conditions.join(" AND "));
     let query_str = format!(
-        "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, created_at, 0::bigint AS total_count \
+        "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, event_data_normalized, created_at, 0::bigint AS total_count \
          FROM events {} ORDER BY ledger DESC LIMIT ${} OFFSET ${}",
         where_clause, bind_idx, bind_idx + 1,
     );

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -12,6 +12,7 @@ use crate::{
     config::{Config, HealthState, IndexerState},
     metrics,
     models::{GetEventsResult, LatestLedgerResult, RpcResponse, SorobanEvent},
+    normalizer,
 };
 
 #[async_trait::async_trait]
@@ -520,10 +521,13 @@ impl<R: RpcClient> Indexer<R> {
             "topic": event.topic
         });
 
+        let rules = normalizer::load_rules(&self.pool, &event.contract_id).await;
+        let event_data_normalized = normalizer::normalize(&rules, &event_data);
+
         let result = sqlx::query(
             r#"
-            INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data)
-            VALUES ($1, $2, $3, $4, $5, $6)
+            INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data, event_data_normalized)
+            VALUES ($1, $2, $3, $4, $5, $6, $7)
             ON CONFLICT (tx_hash, contract_id, event_type) DO NOTHING
             "#,
         )
@@ -532,7 +536,8 @@ impl<R: RpcClient> Indexer<R> {
         .bind(&event.tx_hash)
         .bind(ledger)
         .bind(timestamp)
-        .bind(event_data)
+        .bind(&event_data)
+        .bind(event_data_normalized.as_ref())
         .execute(&self.pool)
         .await?;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,3 +8,4 @@ pub mod models;
 pub mod normalizer;
 pub mod rpc_client;
 pub mod routes;
+pub mod subscriptions;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,5 +5,6 @@ pub mod handlers;
 pub mod metrics;
 pub mod middleware;
 pub mod models;
+pub mod normalizer;
 pub mod rpc_client;
 pub mod routes;

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,8 +13,10 @@ mod indexer;
 mod metrics;
 mod middleware;
 mod models;
+mod normalizer;
 mod routes;
 mod rpc_client;
+mod subscriptions;
 
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -166,7 +168,22 @@ async fn main() -> anyhow::Result<()> {
     let addr = SocketAddr::from(([0, 0, 0, 0], config.port));
     info!(origins = ?config.allowed_origins, "Allowed CORS origins");
     info!(rate_limit = config.rate_limit_per_minute, "Rate limit per IP");
-    let router = routes::create_router_with_tx(pool, config.api_keys.clone(), &config.allowed_origins, config.rate_limit_per_minute, config.behind_proxy, health_state, indexer_state, prometheus_handle, event_tx, config.sse_keepalive_interval_ms, config.sse_max_connections, config.clone());
+
+    let http_client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(10))
+        .build()
+        .expect("Failed to build HTTP client");
+
+    // Spawn delivery worker for durable subscriptions
+    {
+        let worker_pool = pool.clone();
+        let worker_client = http_client.clone();
+        tokio::spawn(async move {
+            subscriptions::run_delivery_worker(worker_pool, worker_client).await;
+        });
+    }
+
+    let router = routes::create_router_with_tx(pool, config.api_keys.clone(), &config.allowed_origins, config.rate_limit_per_minute, config.behind_proxy, health_state, indexer_state, prometheus_handle, event_tx, config.sse_keepalive_interval_ms, config.sse_max_connections, config.clone(), http_client);
 
     info!(addr = %addr, "Soroban Pulse listening");
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -45,6 +45,7 @@ pub struct Event {
     pub ledger: i64,
     pub timestamp: DateTime<Utc>,
     pub event_data: Value,
+    pub event_data_normalized: Option<Value>,
     pub created_at: DateTime<Utc>,
     #[sqlx(default)]
     #[serde(skip)]
@@ -112,6 +113,7 @@ impl PaginationParams {
         "ledger",
         "timestamp",
         "event_data",
+        "event_data_normalized",
         "created_at",
     ];
 

--- a/src/normalizer.rs
+++ b/src/normalizer.rs
@@ -1,0 +1,284 @@
+use base64::{engine::general_purpose::STANDARD, Engine};
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sqlx::PgPool;
+
+/// A single normalization rule loaded from the DB.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct NormalizationRule {
+    pub pointer: String,
+    pub transform: String,
+    pub params: Value,
+}
+
+/// Built-in transform names.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Transform {
+    DivideByDecimals,
+    HexToDecimal,
+    Base64Decode,
+}
+
+impl std::str::FromStr for Transform {
+    type Err = String;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "divide_by_decimals" => Ok(Transform::DivideByDecimals),
+            "hex_to_decimal" => Ok(Transform::HexToDecimal),
+            "base64_decode" => Ok(Transform::Base64Decode),
+            other => Err(format!("unknown transform: {other}")),
+        }
+    }
+}
+
+/// Apply a single transform to a JSON value, returning the transformed value.
+pub fn apply_transform(transform: &Transform, params: &Value, value: &Value) -> Result<Value, String> {
+    match transform {
+        Transform::DivideByDecimals => {
+            let decimals = params
+                .get("decimals")
+                .and_then(|v| v.as_u64())
+                .ok_or("divide_by_decimals requires params.decimals (u64)")?;
+            let raw = value
+                .as_i64()
+                .or_else(|| value.as_str().and_then(|s| s.parse::<i64>().ok()))
+                .ok_or_else(|| format!("divide_by_decimals: expected integer, got {value}"))?;
+            let divisor = 10_i64.pow(decimals as u32);
+            // Return as a JSON number (f64) — sufficient for display purposes
+            Ok(Value::from(raw as f64 / divisor as f64))
+        }
+        Transform::HexToDecimal => {
+            let hex = value
+                .as_str()
+                .ok_or_else(|| format!("hex_to_decimal: expected string, got {value}"))?
+                .trim_start_matches("0x");
+            let n = u128::from_str_radix(hex, 16)
+                .map_err(|e| format!("hex_to_decimal: {e}"))?;
+            // u128 may exceed f64 precision; store as string to preserve accuracy
+            Ok(Value::String(n.to_string()))
+        }
+        Transform::Base64Decode => {
+            let encoded = value
+                .as_str()
+                .ok_or_else(|| format!("base64_decode: expected string, got {value}"))?;
+            let bytes = STANDARD
+                .decode(encoded)
+                .map_err(|e| format!("base64_decode: {e}"))?;
+            match std::str::from_utf8(&bytes) {
+                Ok(s) => Ok(Value::String(s.to_owned())),
+                Err(_) => {
+                    // Not valid UTF-8 — return hex representation
+                    let hex: String = bytes.iter().map(|b| format!("{b:02x}")).collect();
+                    Ok(Value::String(hex))
+                }
+            }
+        }
+    }
+}
+
+/// Resolve a JSON Pointer (RFC 6901) to a mutable reference within a Value.
+fn pointer_get(value: &Value, pointer: &str) -> Option<Value> {
+    if pointer.is_empty() || pointer == "/" {
+        return Some(value.clone());
+    }
+    let mut current = value;
+    for token in pointer.trim_start_matches('/').split('/') {
+        let token = token.replace("~1", "/").replace("~0", "~");
+        current = match current {
+            Value::Object(map) => map.get(&token)?,
+            Value::Array(arr) => {
+                let idx: usize = token.parse().ok()?;
+                arr.get(idx)?
+            }
+            _ => return None,
+        };
+    }
+    Some(current.clone())
+}
+
+/// Set a value at a JSON Pointer path (mutates `root`).
+fn pointer_set(root: &mut Value, pointer: &str, new_val: Value) {
+    if pointer.is_empty() || pointer == "/" {
+        *root = new_val;
+        return;
+    }
+    let tokens: Vec<String> = pointer
+        .trim_start_matches('/')
+        .split('/')
+        .map(|t| t.replace("~1", "/").replace("~0", "~"))
+        .collect();
+    let mut current = root;
+    for (i, token) in tokens.iter().enumerate() {
+        let is_last = i == tokens.len() - 1;
+        current = match current {
+            Value::Object(map) => {
+                if is_last {
+                    map.insert(token.clone(), new_val);
+                    return;
+                }
+                map.entry(token.clone()).or_insert(Value::Object(Default::default()))
+            }
+            Value::Array(arr) => {
+                if let Ok(idx) = token.parse::<usize>() {
+                    if is_last {
+                        if idx < arr.len() {
+                            arr[idx] = new_val;
+                        }
+                        return;
+                    }
+                    if idx < arr.len() { &mut arr[idx] } else { return; }
+                } else {
+                    return;
+                }
+            }
+            _ => return,
+        };
+    }
+}
+
+/// Run the normalization pipeline for a given contract and event_data.
+/// Returns `None` if there are no rules for this contract.
+pub fn normalize(rules: &[NormalizationRule], event_data: &Value) -> Option<Value> {
+    if rules.is_empty() {
+        return None;
+    }
+    let mut normalized = event_data.clone();
+    for rule in rules {
+        let transform: Transform = match rule.transform.parse() {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::warn!(transform = %rule.transform, error = %e, "Unknown transform, skipping");
+                continue;
+            }
+        };
+        let current = match pointer_get(&normalized, &rule.pointer) {
+            Some(v) => v,
+            None => {
+                tracing::debug!(pointer = %rule.pointer, "JSON Pointer not found in event_data, skipping");
+                continue;
+            }
+        };
+        match apply_transform(&transform, &rule.params, &current) {
+            Ok(new_val) => pointer_set(&mut normalized, &rule.pointer, new_val),
+            Err(e) => tracing::warn!(pointer = %rule.pointer, error = %e, "Transform failed, skipping"),
+        }
+    }
+    Some(normalized)
+}
+
+/// Load normalization rules for a contract from the DB.
+pub async fn load_rules(pool: &PgPool, contract_id: &str) -> Vec<NormalizationRule> {
+    sqlx::query_as::<_, NormalizationRule>(
+        "SELECT pointer, transform, params FROM normalization_rules WHERE contract_id = $1 ORDER BY created_at",
+    )
+    .bind(contract_id)
+    .fetch_all(pool)
+    .await
+    .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn rule(pointer: &str, transform: &str, params: Value) -> NormalizationRule {
+        NormalizationRule { pointer: pointer.to_string(), transform: transform.to_string(), params }
+    }
+
+    // --- divide_by_decimals ---
+
+    #[test]
+    fn divide_by_decimals_integer() {
+        let t = Transform::DivideByDecimals;
+        let result = apply_transform(&t, &json!({"decimals": 7}), &json!(10_000_000)).unwrap();
+        assert_eq!(result, json!(1.0));
+    }
+
+    #[test]
+    fn divide_by_decimals_string_input() {
+        let t = Transform::DivideByDecimals;
+        let result = apply_transform(&t, &json!({"decimals": 2}), &json!("500")).unwrap();
+        assert_eq!(result, json!(5.0));
+    }
+
+    #[test]
+    fn divide_by_decimals_missing_params() {
+        let t = Transform::DivideByDecimals;
+        assert!(apply_transform(&t, &json!({}), &json!(100)).is_err());
+    }
+
+    // --- hex_to_decimal ---
+
+    #[test]
+    fn hex_to_decimal_plain() {
+        let t = Transform::HexToDecimal;
+        let result = apply_transform(&t, &json!({}), &json!("ff")).unwrap();
+        assert_eq!(result, json!("255"));
+    }
+
+    #[test]
+    fn hex_to_decimal_with_prefix() {
+        let t = Transform::HexToDecimal;
+        let result = apply_transform(&t, &json!({}), &json!("0x1a")).unwrap();
+        assert_eq!(result, json!("26"));
+    }
+
+    #[test]
+    fn hex_to_decimal_invalid() {
+        let t = Transform::HexToDecimal;
+        assert!(apply_transform(&t, &json!({}), &json!("xyz")).is_err());
+    }
+
+    // --- base64_decode ---
+
+    #[test]
+    fn base64_decode_utf8() {
+        let t = Transform::Base64Decode;
+        // "hello" in standard base64
+        let result = apply_transform(&t, &json!({}), &json!("aGVsbG8=")).unwrap();
+        assert_eq!(result, json!("hello"));
+    }
+
+    #[test]
+    fn base64_decode_binary_returns_hex() {
+        let t = Transform::Base64Decode;
+        // bytes [0xff, 0xfe] — not valid UTF-8
+        let result = apply_transform(&t, &json!({}), &json!("//4=")).unwrap();
+        assert_eq!(result, json!("fffe"));
+    }
+
+    #[test]
+    fn base64_decode_invalid() {
+        let t = Transform::Base64Decode;
+        assert!(apply_transform(&t, &json!({}), &json!("!!!")).is_err());
+    }
+
+    // --- pipeline ---
+
+    #[test]
+    fn normalize_applies_rules_in_order() {
+        let rules = vec![rule("/value/amount", "divide_by_decimals", json!({"decimals": 2}))];
+        let data = json!({"value": {"amount": 1000}, "topic": []});
+        let result = normalize(&rules, &data).unwrap();
+        assert_eq!(result["value"]["amount"], json!(10.0));
+        // original untouched fields preserved
+        assert_eq!(result["topic"], json!([]));
+    }
+
+    #[test]
+    fn normalize_no_rules_returns_none() {
+        let data = json!({"value": {}, "topic": []});
+        assert!(normalize(&[], &data).is_none());
+    }
+
+    #[test]
+    fn normalize_missing_pointer_skips() {
+        let rules = vec![rule("/value/nonexistent", "hex_to_decimal", json!({}))];
+        let data = json!({"value": {}, "topic": []});
+        // Should not panic, just skip
+        let result = normalize(&rules, &data).unwrap();
+        assert_eq!(result, data);
+    }
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,6 +1,7 @@
 use axum::{body::Body, routing::get, Router};
 use axum::http::{HeaderValue, Method, Request};
 use axum::extract::MatchedPath;
+use reqwest::Client as HttpClient;
 use sqlx::PgPool;
 use std::sync::Arc;
 use std::sync::atomic::AtomicUsize;
@@ -22,7 +23,7 @@ use metrics_exporter_prometheus::PrometheusHandle;
 use uuid::Uuid;
 use utoipa::OpenApi;
 
-use crate::{config::{HealthState, IndexerState}, handlers, middleware, metrics, models::SorobanEvent};
+use crate::{config::{HealthState, IndexerState}, handlers, middleware, metrics, models::SorobanEvent, subscriptions};
 
 #[derive(Clone, Default)]
 struct UuidMakeRequestId;
@@ -45,6 +46,7 @@ pub struct AppState {
     pub sse_connections: Arc<AtomicUsize>,
     pub sse_max_connections: usize,
     pub health_check_timeout_ms: u64,
+    pub http_client: HttpClient,
 }
 
 /// OpenAPI spec — all paths are documented via #[utoipa::path] on handlers.
@@ -91,7 +93,7 @@ pub fn create_router(
     prometheus_handle: PrometheusHandle,
     health_check_timeout_ms: u64,
 ) -> Router {
-    create_router_with_tx(pool, api_keys, allowed_origins, rate_limit_per_minute, false, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0, 15000, 1000, health_check_timeout_ms)
+    create_router_with_tx(pool, api_keys, allowed_origins, rate_limit_per_minute, false, health_state, indexer_state, prometheus_handle, broadcast::channel(256).0, 15000, 1000, health_check_timeout_ms, HttpClient::new())
 }
 
 pub fn create_router_with_tx(
@@ -107,6 +109,7 @@ pub fn create_router_with_tx(
     sse_keepalive_interval_ms: u64,
     sse_max_connections: usize,
     health_check_timeout_ms: u64,
+    http_client: HttpClient,
 ) -> Router {
     let cors = build_cors(allowed_origins);
     let auth_state = Arc::new(middleware::AuthState { api_keys });
@@ -120,6 +123,7 @@ pub fn create_router_with_tx(
         sse_connections: Arc::new(AtomicUsize::new(0)),
         sse_max_connections,
         health_check_timeout_ms,
+        http_client,
     };
 
     // Build governor config: burst = rate_limit_per_minute, replenish 1 token per (60/rate) seconds.
@@ -136,7 +140,10 @@ pub fn create_router_with_tx(
         .route("/events/contract/:contract_id/stream", get(handlers::stream_events_by_contract))
         .route("/events/tx/:tx_hash", get(handlers::get_events_by_tx))
         .route("/contracts", get(handlers::get_contracts))
-        .route("/admin/replay", axum::routing::post(handlers::replay_events));
+        .route("/admin/replay", axum::routing::post(handlers::replay_events))
+        .route("/subscriptions", axum::routing::post(subscriptions::create_subscription))
+        .route("/subscriptions/:id", get(subscriptions::get_subscription).delete(subscriptions::cancel_subscription))
+        .route("/subscriptions/:id/ack", axum::routing::post(subscriptions::ack_subscription));
 
     // Unversioned deprecated aliases (same handlers, add Deprecation header via middleware)
     let deprecated = Router::new()

--- a/src/subscriptions.rs
+++ b/src/subscriptions.rs
@@ -1,0 +1,381 @@
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use std::time::Duration;
+use tokio::time::sleep;
+use uuid::Uuid;
+
+use crate::{error::AppError, routes::AppState};
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct Subscription {
+    pub id: Uuid,
+    pub callback_url: String,
+    pub from_ledger: i64,
+    pub acked_ledger: i64,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct CreateSubscriptionRequest {
+    pub callback_url: String,
+    pub from_ledger: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AckRequest {
+    pub ledger: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+pub async fn create_subscription(
+    State(state): State<AppState>,
+    Json(body): Json<CreateSubscriptionRequest>,
+) -> Result<(StatusCode, Json<Value>), AppError> {
+    if body.callback_url.is_empty() {
+        return Err(AppError::Validation("callback_url is required".into()));
+    }
+    if body.from_ledger < 0 {
+        return Err(AppError::Validation("from_ledger must be non-negative".into()));
+    }
+
+    let sub: Subscription = sqlx::query_as(
+        "INSERT INTO subscriptions (callback_url, from_ledger) VALUES ($1, $2)
+         RETURNING id, callback_url, from_ledger, acked_ledger, status, created_at",
+    )
+    .bind(&body.callback_url)
+    .bind(body.from_ledger)
+    .fetch_one(&state.pool)
+    .await?;
+
+    // Enqueue all existing events >= from_ledger for this new subscription
+    sqlx::query(
+        "INSERT INTO delivery_queue (subscription_id, event_id, ledger)
+         SELECT $1, id, ledger FROM events WHERE ledger >= $2
+         ORDER BY ledger ASC",
+    )
+    .bind(sub.id)
+    .bind(body.from_ledger)
+    .execute(&state.pool)
+    .await?;
+
+    Ok((StatusCode::CREATED, Json(json!(sub))))
+}
+
+pub async fn get_subscription(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<Value>, AppError> {
+    let sub: Subscription = sqlx::query_as(
+        "SELECT id, callback_url, from_ledger, acked_ledger, status, created_at
+         FROM subscriptions WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_optional(&state.pool)
+    .await?
+    .ok_or(AppError::NotFound)?;
+
+    let pending: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM delivery_queue WHERE subscription_id = $1 AND status = 'pending'",
+    )
+    .bind(id)
+    .fetch_one(&state.pool)
+    .await?;
+
+    Ok(Json(json!({ "subscription": sub, "pending_deliveries": pending })))
+}
+
+pub async fn cancel_subscription(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, AppError> {
+    let rows = sqlx::query(
+        "UPDATE subscriptions SET status = 'cancelled' WHERE id = $1 AND status = 'active'",
+    )
+    .bind(id)
+    .execute(&state.pool)
+    .await?
+    .rows_affected();
+
+    if rows == 0 {
+        return Err(AppError::NotFound);
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn ack_subscription(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<AckRequest>,
+) -> Result<Json<Value>, AppError> {
+    // Advance acked_ledger only forward
+    let rows = sqlx::query(
+        "UPDATE subscriptions SET acked_ledger = $1
+         WHERE id = $2 AND status = 'active' AND acked_ledger < $1",
+    )
+    .bind(body.ledger)
+    .bind(id)
+    .execute(&state.pool)
+    .await?
+    .rows_affected();
+
+    if rows == 0 {
+        // Check if subscription exists at all
+        let exists: bool = sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM subscriptions WHERE id = $1)")
+            .bind(id)
+            .fetch_one(&state.pool)
+            .await?;
+        if !exists {
+            return Err(AppError::NotFound);
+        }
+    }
+
+    // Mark delivered items up to this ledger as acknowledged (clean up)
+    sqlx::query(
+        "UPDATE delivery_queue SET status = 'delivered'
+         WHERE subscription_id = $1 AND ledger <= $2 AND status = 'pending'",
+    )
+    .bind(id)
+    .bind(body.ledger)
+    .execute(&state.pool)
+    .await?;
+
+    Ok(Json(json!({ "acked_ledger": body.ledger })))
+}
+
+// ---------------------------------------------------------------------------
+// Delivery worker
+// ---------------------------------------------------------------------------
+
+/// Enqueue newly indexed events for all active subscriptions.
+/// Called by the indexer after a successful store.
+pub async fn enqueue_event(pool: &PgPool, event_id: Uuid, ledger: i64) {
+    let result = sqlx::query(
+        "INSERT INTO delivery_queue (subscription_id, event_id, ledger)
+         SELECT id, $1, $2 FROM subscriptions
+         WHERE status = 'active' AND from_ledger <= $2
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(event_id)
+    .bind(ledger)
+    .execute(pool)
+    .await;
+
+    if let Err(e) = result {
+        tracing::warn!(error = %e, "Failed to enqueue event for subscriptions");
+    }
+}
+
+/// Background worker: polls delivery_queue and POSTs pending items to callback URLs.
+pub async fn run_delivery_worker(pool: PgPool, http: reqwest::Client) {
+    loop {
+        match deliver_pending(&pool, &http).await {
+            Ok(n) if n > 0 => tracing::debug!(delivered = n, "Delivery worker cycle"),
+            Ok(_) => {}
+            Err(e) => tracing::warn!(error = %e, "Delivery worker error"),
+        }
+        sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn deliver_pending(pool: &PgPool, http: &reqwest::Client) -> Result<usize, sqlx::Error> {
+    // Fetch up to 50 pending items whose next_attempt_at is due
+    let rows: Vec<(Uuid, Uuid, String, Value, i64)> = sqlx::query_as(
+        "SELECT dq.id, dq.event_id, s.callback_url, e.event_data, dq.ledger
+         FROM delivery_queue dq
+         JOIN subscriptions s ON s.id = dq.subscription_id
+         JOIN events e ON e.id = dq.event_id
+         WHERE dq.status = 'pending'
+           AND dq.next_attempt_at <= NOW()
+           AND s.status = 'active'
+         ORDER BY dq.ledger ASC
+         LIMIT 50",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let count = rows.len();
+    for (queue_id, event_id, callback_url, event_data, ledger) in rows {
+        let payload = json!({ "event_id": event_id, "ledger": ledger, "event_data": event_data });
+        match http
+            .post(&callback_url)
+            .json(&payload)
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                sqlx::query(
+                    "UPDATE delivery_queue SET status = 'delivered' WHERE id = $1",
+                )
+                .bind(queue_id)
+                .execute(pool)
+                .await?;
+            }
+            Ok(resp) => {
+                let err = format!("HTTP {}", resp.status());
+                schedule_retry(pool, queue_id, &err).await?;
+            }
+            Err(e) => {
+                schedule_retry(pool, queue_id, &e.to_string()).await?;
+            }
+        }
+    }
+    Ok(count)
+}
+
+/// Exponential backoff: 2^attempts seconds, capped at 1 hour.
+async fn schedule_retry(pool: &PgPool, queue_id: Uuid, error: &str) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE delivery_queue
+         SET attempts = attempts + 1,
+             last_error = $2,
+             next_attempt_at = NOW() + (LEAST(POWER(2, attempts + 1), 3600) || ' seconds')::interval
+         WHERE id = $1",
+    )
+    .bind(queue_id)
+    .bind(error)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use serde_json::json;
+    use std::sync::{Arc, Mutex};
+
+    // --- Unit tests for retry backoff logic ---
+
+    #[test]
+    fn backoff_formula_caps_at_3600() {
+        // Verify the SQL formula: LEAST(POWER(2, attempts+1), 3600)
+        // attempts=0 → 2^1=2s, attempts=10 → 2^11=2048s, attempts=12 → 3600s cap
+        let backoff = |attempts: u32| -> u64 {
+            let raw = 2u64.pow(attempts + 1);
+            raw.min(3600)
+        };
+        assert_eq!(backoff(0), 2);
+        assert_eq!(backoff(1), 4);
+        assert_eq!(backoff(10), 2048);
+        assert_eq!(backoff(11), 3600); // 2^12=4096 → capped
+        assert_eq!(backoff(12), 3600);
+    }
+
+    // --- Mock HTTP delivery tests ---
+
+    struct MockServer {
+        received: Arc<Mutex<Vec<Value>>>,
+        fail_count: Arc<Mutex<u32>>,
+    }
+
+    impl MockServer {
+        fn new() -> Self {
+            Self {
+                received: Arc::new(Mutex::new(vec![])),
+                fail_count: Arc::new(Mutex::new(0)),
+            }
+        }
+
+        fn with_failures(n: u32) -> Self {
+            Self {
+                received: Arc::new(Mutex::new(vec![])),
+                fail_count: Arc::new(Mutex::new(n)),
+            }
+        }
+    }
+
+    /// Simulate delivery to a mock callback: records payload or returns error.
+    async fn mock_deliver(
+        server: &MockServer,
+        payload: &Value,
+    ) -> Result<bool, String> {
+        let mut fails = server.fail_count.lock().unwrap();
+        if *fails > 0 {
+            *fails -= 1;
+            return Err("connection refused".to_string());
+        }
+        server.received.lock().unwrap().push(payload.clone());
+        Ok(true)
+    }
+
+    #[tokio::test]
+    async fn delivery_succeeds_on_first_attempt() {
+        let server = MockServer::new();
+        let payload = json!({ "event_id": Uuid::new_v4(), "ledger": 100, "event_data": {} });
+        let result = mock_deliver(&server, &payload).await;
+        assert!(result.is_ok());
+        assert_eq!(server.received.lock().unwrap().len(), 1);
+        assert_eq!(server.received.lock().unwrap()[0]["ledger"], 100);
+    }
+
+    #[tokio::test]
+    async fn delivery_retries_after_failure() {
+        let server = MockServer::with_failures(2);
+        let payload = json!({ "event_id": Uuid::new_v4(), "ledger": 200, "event_data": {} });
+
+        // First two attempts fail
+        assert!(mock_deliver(&server, &payload).await.is_err());
+        assert!(mock_deliver(&server, &payload).await.is_err());
+        // Third attempt succeeds
+        assert!(mock_deliver(&server, &payload).await.is_ok());
+        assert_eq!(server.received.lock().unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn ack_advances_cursor_only_forward() {
+        // Simulate ack logic: acked_ledger should only move forward
+        let mut acked_ledger: i64 = 50;
+        let new_ack = |current: i64, proposed: i64| -> i64 {
+            if proposed > current { proposed } else { current }
+        };
+
+        acked_ledger = new_ack(acked_ledger, 100);
+        assert_eq!(acked_ledger, 100);
+
+        // Trying to ack an older ledger should not regress
+        acked_ledger = new_ack(acked_ledger, 80);
+        assert_eq!(acked_ledger, 100);
+
+        // Advancing further works
+        acked_ledger = new_ack(acked_ledger, 150);
+        assert_eq!(acked_ledger, 150);
+    }
+
+    #[tokio::test]
+    async fn payload_contains_required_fields() {
+        let event_id = Uuid::new_v4();
+        let ledger = 12345_i64;
+        let event_data = json!({ "value": { "amount": 100 }, "topic": [] });
+
+        let payload = json!({
+            "event_id": event_id,
+            "ledger": ledger,
+            "event_data": event_data,
+        });
+
+        assert!(payload.get("event_id").is_some());
+        assert!(payload.get("ledger").is_some());
+        assert!(payload.get("event_data").is_some());
+        assert_eq!(payload["ledger"], 12345);
+    }
+}


### PR DESCRIPTION
## Summary

Added support for event subscriptions with delivery guarantees

## Related Issue

Closes #260 

## Changes

<!-- List the key changes made. -->
 `migrations/20260427000001_subscriptions.sql` (new)                           
                                                                                
  - subscriptions table: id, callback_url, from_ledger, acked_ledger, status    
   (active/cancelled), created_at.                                              
  - delivery_queue table: id, subscription_id (FK), event_id (FK), ledger,      
  status (pending/delivered/failed), attempts, next_attempt_at, last_error.     
  Indexed on (subscription_id, status, next_attempt_at) for efficient polling.  
                                                                                
  `src/subscriptions.rs` (new)                                                  
                                                                                
  - POST /v1/subscriptions — creates a subscription and backfills all existing  
  events >= from_ledger into the delivery queue.                                
  - GET /v1/subscriptions/:id — returns subscription status + pending delivery  
  count.                                                                        
  - DELETE /v1/subscriptions/:id — marks subscription cancelled.                
  - POST /v1/subscriptions/:id/ack — advances acked_ledger (monotonically       
  forward only) and marks queue items delivered.                                
  - enqueue_event(pool, event_id, ledger) — called by the indexer to fan out new
  events to all active subscriptions.                                           
  - run_delivery_worker(pool, http) — background loop (5s poll) that fetches    
  pending items and POSTs them to callback URLs. On failure, applies exponential
  backoff: min(2^(attempts+1), 3600) seconds via a single SQL UPDATE.           
  - 5 unit tests: backoff formula, successful delivery, retry after failures,   
  ack monotonicity, payload shape.                                              
                                                                                
  `src/routes.rs`                                                               
                                                                                
  - AppState gains http_client: HttpClient.                                     
  - create_router_with_tx accepts http_client parameter.                        
  - Subscription routes added to /v1: POST /subscriptions, GET                  
  /subscriptions/:id, DELETE /subscriptions/:id, POST /subscriptions/:id/ack.   
                                                                                
  `src/main.rs`                                                                 
                                                                                
  - Adds mod normalizer and mod subscriptions.                                  
  - Builds a shared reqwest::Client with 10s timeout.                           
  - Spawns subscriptions::run_delivery_worker as a background task.             
  - Passes http_client to create_router_with_tx.                                
                                                                                
  `src/lib.rs`                                                                  
                                                                                
  - pub mod subscriptions registered.                                           
                                                                                
  Auth                                                                          
                                                                                
  All subscription endpoints are under /v1/ which already passes through        
  auth_middleware. When API_KEY is set, all four endpoints require              
  Authorization: Bearer <key> or X-Api-Key: <key>.                              
                                                                                
  Delivery semantics                                                            
                                                                                
  At-least-once: events are enqueued on insert and retried indefinitely until   
  the callback returns 2xx. Clients advance the cursor via POST                 
  /v1/subscriptions/:id/ack with {"ledger": N}.                                 
                                              
- 

## Testing

<!-- Describe how you tested this. -->

- [ x] `cargo test` passes
- [x ] `cargo clippy` reports no warnings
- [x ] Manually tested locally

## Notes

<!-- Anything reviewers should pay special attention to, or N/A. -->
