### PR TITLE
feat: add Kafka producer integration (#263)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,3 +141,22 @@ RUST_LOG_FORMAT=text
 # When set, only events matching one of these contract IDs are delivered.
 # When unset, all events are delivered.
 # WEBHOOK_CONTRACT_FILTER=CABC...,CDEF...
+
+# --- Apache Kafka event streaming (optional, requires kafka feature flag) ---
+# When KAFKA_BROKERS and KAFKA_TOPIC are both set, each newly indexed event is
+# published to the Kafka topic as a JSON message. The event's contract_id is
+# used as the message key, ensuring events from the same contract are ordered
+# within a partition. Build with: cargo build --features kafka
+#
+# Comma-separated list of broker addresses.
+# KAFKA_BROKERS=localhost:9092
+#
+# Topic to publish events to.
+# KAFKA_TOPIC=soroban-events
+#
+# Producer batch size in bytes (default: 16384).
+# KAFKA_BATCH_SIZE=16384
+#
+# Producer linger time in milliseconds — how long to wait for more messages
+# before sending a batch (default: 5).
+# KAFKA_LINGER_MS=5

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,10 +35,12 @@ base64 = "0.22"
 sha2 = "0.10"
 hmac = "0.12"
 hex = "0.4"
+rdkafka = { version = "0.36", optional = true, features = ["cmake-build"] }
 
 [features]
 otel = ["tracing-opentelemetry", "opentelemetry", "opentelemetry-otlp"]
 encryption = ["aes-gcm", "rand"]
+kafka = ["rdkafka"]
 
 [dev-dependencies]
 sqlx = { version = "0.8", features = ["postgres", "runtime-tokio-rustls", "chrono", "uuid", "json", "migrate"] }

--- a/src/config.rs
+++ b/src/config.rs
@@ -177,6 +177,18 @@ pub struct Config {
     pub webhook_url: Option<String>,
     pub webhook_secret: Option<String>,
     pub webhook_contract_filter: Vec<String>,
+    /// Kafka broker list (e.g. "localhost:9092"). None disables Kafka publishing.
+    #[cfg(feature = "kafka")]
+    pub kafka_brokers: Option<String>,
+    /// Kafka topic to publish events to.
+    #[cfg(feature = "kafka")]
+    pub kafka_topic: Option<String>,
+    /// Kafka producer batch size in bytes (default: 16384).
+    #[cfg(feature = "kafka")]
+    pub kafka_batch_size: usize,
+    /// Kafka producer linger time in milliseconds (default: 5).
+    #[cfg(feature = "kafka")]
+    pub kafka_linger_ms: u64,
 }
 
 impl Default for Config {
@@ -213,6 +225,14 @@ impl Default for Config {
             webhook_url: None,
             webhook_secret: None,
             webhook_contract_filter: Vec::new(),
+            #[cfg(feature = "kafka")]
+            kafka_brokers: None,
+            #[cfg(feature = "kafka")]
+            kafka_topic: None,
+            #[cfg(feature = "kafka")]
+            kafka_batch_size: 16384,
+            #[cfg(feature = "kafka")]
+            kafka_linger_ms: 5,
         }
     }
 }
@@ -501,6 +521,18 @@ impl Config {
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
                 .collect(),
+            #[cfg(feature = "kafka")]
+            kafka_brokers: env_or_file("KAFKA_BROKERS", &file),
+            #[cfg(feature = "kafka")]
+            kafka_topic: env_or_file("KAFKA_TOPIC", &file),
+            #[cfg(feature = "kafka")]
+            kafka_batch_size: env_or_file_or("KAFKA_BATCH_SIZE", &file, "16384")
+                .parse()
+                .expect("KAFKA_BATCH_SIZE must be a number"),
+            #[cfg(feature = "kafka")]
+            kafka_linger_ms: env_or_file_or("KAFKA_LINGER_MS", &file, "5")
+                .parse()
+                .expect("KAFKA_LINGER_MS must be a number"),
         }
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -184,6 +184,10 @@ pub struct Indexer<R: RpcClient> {
     indexer_state: Option<Arc<IndexerState>>,
     event_tx: Option<broadcast::Sender<SorobanEvent>>,
     event_counter: AtomicU64,
+    #[cfg(feature = "kafka")]
+    kafka_publisher: Option<Arc<dyn crate::kafka::KafkaPublisher>>,
+    #[cfg(feature = "kafka")]
+    kafka_topic: Option<String>,
 }
 
 impl<R: RpcClient> Indexer<R> {
@@ -197,6 +201,10 @@ impl<R: RpcClient> Indexer<R> {
             indexer_state: None,
             event_tx: None,
             event_counter: AtomicU64::new(0),
+            #[cfg(feature = "kafka")]
+            kafka_publisher: None,
+            #[cfg(feature = "kafka")]
+            kafka_topic: None,
         }
     }
 
@@ -213,6 +221,17 @@ impl<R: RpcClient> Indexer<R> {
     /// Set the broadcast sender for real-time SSE streaming.
     pub fn set_event_tx(&mut self, event_tx: broadcast::Sender<SorobanEvent>) {
         self.event_tx = Some(event_tx);
+    }
+
+    /// Set the Kafka publisher and topic for event streaming.
+    #[cfg(feature = "kafka")]
+    pub fn set_kafka_publisher(
+        &mut self,
+        publisher: Arc<dyn crate::kafka::KafkaPublisher>,
+        topic: String,
+    ) {
+        self.kafka_publisher = Some(publisher);
+        self.kafka_topic = Some(topic);
     }
 
     pub async fn run(&self) {
@@ -426,8 +445,19 @@ impl<R: RpcClient> Indexer<R> {
                         if rows == 0 {
                             total_skipped += 1;
                             // duplicate — skipped via ON CONFLICT DO NOTHING
-                        } else if let Some(ref tx) = self.event_tx {
-                            let _ = tx.send(event);
+                        } else {
+                            if let Some(ref tx) = self.event_tx {
+                                let _ = tx.send(event.clone());
+                            }
+                            #[cfg(feature = "kafka")]
+                            if let (Some(ref publisher), Some(ref topic)) =
+                                (&self.kafka_publisher, &self.kafka_topic)
+                            {
+                                if let Err(e) = publisher.publish(topic, &event).await {
+                                    tracing::warn!(error = %e, contract_id = %event.contract_id, "Kafka publish failed");
+                                    crate::metrics::record_kafka_publish_error();
+                                }
+                            }
                         }
                     }
                     Err(e) => {
@@ -822,6 +852,14 @@ mod tests {
                 event_data_encryption_key: None,
                 event_data_encryption_key_old: None,
 
+                #[cfg(feature = "kafka")]
+                kafka_brokers: None,
+                #[cfg(feature = "kafka")]
+                kafka_topic: None,
+                #[cfg(feature = "kafka")]
+                kafka_batch_size: 16384,
+                #[cfg(feature = "kafka")]
+                kafka_linger_ms: 5,
             },
             shutdown_rx,
             MockRpcClient::new(),
@@ -830,17 +868,57 @@ mod tests {
 
     #[tokio::test]
     async fn test_should_log_debug_sampling() {
-        let pool = PgPool::connect("postgres://localhost/soroban_pulse").await.unwrap_or_else(|_| {
-            // Fallback for environments where PG is not available
-            // In a real test environment we'd have a pool.
-            // Since this is specifically testing business logic in Indexer, 
-            // we can just use an uninitialized pool or skip if needed.
-            // But Indexer::new needs a pool.
-            // Actually, we can use the same pattern as in `indexer` helper.
-            return;
-        });
-
-        let mut indexer = indexer(pool);
+        let (_, shutdown_rx) = watch::channel(false);
+        // Use a lazy pool that won't actually connect for this logic-only test.
+        let pool = sqlx::postgres::PgPoolOptions::new()
+            .connect_lazy("postgres://localhost/soroban_pulse")
+            .unwrap();
+        let mut indexer = Indexer::new(
+            pool,
+            Config {
+                database_url: String::new(),
+                database_replica_url: None,
+                stellar_rpc_url: String::new(),
+                rpc_headers: Vec::new(),
+                start_ledger: 0,
+                port: 3000,
+                behind_proxy: false,
+                start_ledger_fallback: true,
+                indexer_lag_warn_threshold: 1000,
+                rpc_connect_timeout_secs: 30,
+                rpc_request_timeout_secs: 60,
+                api_keys: Vec::new(),
+                db_max_connections: 10,
+                db_min_connections: 2,
+                db_idle_timeout_secs: 600,
+                db_max_lifetime_secs: 1800,
+                db_test_before_acquire: true,
+                allowed_origins: vec!["*".to_string()],
+                rate_limit_per_minute: 60,
+                indexer_stall_timeout_secs: 60,
+                db_statement_timeout_ms: 5000,
+                indexer_poll_interval_ms: 5000,
+                indexer_error_backoff_ms: 10000,
+                sse_keepalive_interval_ms: 15000,
+                sse_max_connections: 1000,
+                environment: crate::config::Environment::Development,
+                max_body_size_bytes: 1024 * 1024,
+                log_sample_rate: 1,
+                indexer_event_types: Vec::new(),
+                event_data_encryption_key: None,
+                event_data_encryption_key_old: None,
+                #[cfg(feature = "kafka")]
+                kafka_brokers: None,
+                #[cfg(feature = "kafka")]
+                kafka_topic: None,
+                #[cfg(feature = "kafka")]
+                kafka_batch_size: 16384,
+                #[cfg(feature = "kafka")]
+                kafka_linger_ms: 5,
+            },
+            shutdown_rx,
+            MockRpcClient::new(),
+        );
         
         // Test with sample_rate = 1 (should log everything)
         indexer.config.log_sample_rate = 1;
@@ -1046,5 +1124,147 @@ mod tests {
         // Test that the indexer can use the mock client
         let latest_ledger = indexer.get_latest_ledger().await.unwrap();
         assert_eq!(latest_ledger, 100);
+    }
+
+    #[cfg(feature = "kafka")]
+    #[sqlx::test(migrations = "./migrations")]
+    async fn kafka_publisher_called_on_new_event(pool: PgPool) {
+        use crate::kafka::tests::MockKafkaPublisher;
+        use std::sync::Arc;
+
+        // Kafka publish happens in fetch_and_store_events, not store_event_in_tx.
+        // Test via fetch_and_store_events with a mock RPC that returns one event.
+        let mock_rpc = MockRpcClient::with_get_events_responses(vec![Ok(GetEventsResult {
+            events: vec![make_event(1)],
+            latest_ledger: 1,
+            rpc_cursor: None,
+        })]);
+        let (_, shutdown_rx) = watch::channel(false);
+        let mut idx = Indexer::new(
+            pool.clone(),
+            Config {
+                database_url: String::new(),
+                database_replica_url: None,
+                stellar_rpc_url: String::new(),
+                rpc_headers: Vec::new(),
+                start_ledger: 1,
+                port: 3000,
+                behind_proxy: false,
+                start_ledger_fallback: true,
+                indexer_lag_warn_threshold: 1000,
+                rpc_connect_timeout_secs: 30,
+                rpc_request_timeout_secs: 60,
+                api_keys: Vec::new(),
+                db_max_connections: 10,
+                db_min_connections: 2,
+                db_idle_timeout_secs: 600,
+                db_max_lifetime_secs: 1800,
+                db_test_before_acquire: true,
+                allowed_origins: vec!["*".to_string()],
+                rate_limit_per_minute: 60,
+                indexer_stall_timeout_secs: 60,
+                db_statement_timeout_ms: 5000,
+                indexer_poll_interval_ms: 5000,
+                indexer_error_backoff_ms: 10000,
+                sse_keepalive_interval_ms: 15000,
+                sse_max_connections: 1000,
+                environment: crate::config::Environment::Development,
+                max_body_size_bytes: 1024 * 1024,
+                log_sample_rate: 1,
+                indexer_event_types: Vec::new(),
+                event_data_encryption_key: None,
+                event_data_encryption_key_old: None,
+                kafka_brokers: None,
+                kafka_topic: None,
+                kafka_batch_size: 16384,
+                kafka_linger_ms: 5,
+            },
+            shutdown_rx,
+            mock_rpc,
+        );
+
+        let mock_kafka = MockKafkaPublisher::default();
+        let published = mock_kafka.published.clone();
+        idx.set_kafka_publisher(Arc::new(mock_kafka), "test-topic".to_string());
+
+        idx.fetch_and_store_events(1).await.unwrap();
+
+        let msgs = published.lock().unwrap();
+        assert_eq!(msgs.len(), 1, "expected one Kafka message for the new event");
+        assert_eq!(msgs[0].0, "test-topic");
+        assert_eq!(msgs[0].1.ledger, 1);
+    }
+
+    #[cfg(feature = "kafka")]
+    #[sqlx::test(migrations = "./migrations")]
+    async fn kafka_not_called_for_duplicate_event(pool: PgPool) {
+        use crate::kafka::tests::MockKafkaPublisher;
+        use std::sync::Arc;
+
+        // Insert the event once so the second fetch sees a duplicate.
+        let idx = indexer(pool.clone());
+        let mut tx = pool.begin().await.unwrap();
+        idx.store_event_in_tx(&mut tx, &make_event(1)).await.unwrap();
+        tx.commit().await.unwrap();
+
+        let mock_rpc = MockRpcClient::with_get_events_responses(vec![Ok(GetEventsResult {
+            events: vec![make_event(1)], // same event — duplicate
+            latest_ledger: 1,
+            rpc_cursor: None,
+        })]);
+        let (_, shutdown_rx) = watch::channel(false);
+        let mut idx2 = Indexer::new(
+            pool.clone(),
+            Config {
+                database_url: String::new(),
+                database_replica_url: None,
+                stellar_rpc_url: String::new(),
+                rpc_headers: Vec::new(),
+                start_ledger: 1,
+                port: 3000,
+                behind_proxy: false,
+                start_ledger_fallback: true,
+                indexer_lag_warn_threshold: 1000,
+                rpc_connect_timeout_secs: 30,
+                rpc_request_timeout_secs: 60,
+                api_keys: Vec::new(),
+                db_max_connections: 10,
+                db_min_connections: 2,
+                db_idle_timeout_secs: 600,
+                db_max_lifetime_secs: 1800,
+                db_test_before_acquire: true,
+                allowed_origins: vec!["*".to_string()],
+                rate_limit_per_minute: 60,
+                indexer_stall_timeout_secs: 60,
+                db_statement_timeout_ms: 5000,
+                indexer_poll_interval_ms: 5000,
+                indexer_error_backoff_ms: 10000,
+                sse_keepalive_interval_ms: 15000,
+                sse_max_connections: 1000,
+                environment: crate::config::Environment::Development,
+                max_body_size_bytes: 1024 * 1024,
+                log_sample_rate: 1,
+                indexer_event_types: Vec::new(),
+                event_data_encryption_key: None,
+                event_data_encryption_key_old: None,
+                kafka_brokers: None,
+                kafka_topic: None,
+                kafka_batch_size: 16384,
+                kafka_linger_ms: 5,
+            },
+            shutdown_rx,
+            mock_rpc,
+        );
+
+        let mock_kafka = MockKafkaPublisher::default();
+        let published = mock_kafka.published.clone();
+        idx2.set_kafka_publisher(Arc::new(mock_kafka), "test-topic".to_string());
+
+        idx2.fetch_and_store_events(1).await.unwrap();
+
+        assert!(
+            published.lock().unwrap().is_empty(),
+            "Kafka must not be called for duplicate events"
+        );
     }
 }

--- a/src/kafka.rs
+++ b/src/kafka.rs
@@ -1,0 +1,165 @@
+//! Kafka producer integration (feature = "kafka").
+//!
+//! Defines a `KafkaPublisher` trait so the indexer can be tested with a mock
+//! without pulling in the real rdkafka machinery.
+
+use crate::models::SorobanEvent;
+use async_trait::async_trait;
+
+/// Publish a single event to Kafka.
+#[async_trait]
+pub trait KafkaPublisher: Send + Sync {
+    async fn publish(&self, topic: &str, event: &SorobanEvent) -> Result<(), String>;
+}
+
+// ── Real producer (only compiled when the kafka feature is active) ────────────
+
+#[cfg(feature = "kafka")]
+pub use real::RdKafkaProducer;
+
+#[cfg(feature = "kafka")]
+mod real {
+    use super::*;
+    use rdkafka::config::ClientConfig;
+    use rdkafka::producer::{FutureProducer, FutureRecord};
+    use std::time::Duration;
+
+    pub struct RdKafkaProducer {
+        inner: FutureProducer,
+    }
+
+    impl RdKafkaProducer {
+        /// Build a producer from the application config.
+        pub fn new(brokers: &str, batch_size: usize, linger_ms: u64) -> Result<Self, String> {
+            let producer: FutureProducer = ClientConfig::new()
+                .set("bootstrap.servers", brokers)
+                .set("batch.size", batch_size.to_string())
+                .set("linger.ms", linger_ms.to_string())
+                // Async delivery: fire-and-forget with acks=1 for throughput.
+                .set("acks", "1")
+                .create()
+                .map_err(|e| format!("Failed to create Kafka producer: {e}"))?;
+            Ok(Self { inner: producer })
+        }
+    }
+
+    #[async_trait]
+    impl super::KafkaPublisher for RdKafkaProducer {
+        async fn publish(&self, topic: &str, event: &SorobanEvent) -> Result<(), String> {
+            let payload = serde_json::to_string(event)
+                .map_err(|e| format!("Failed to serialize event: {e}"))?;
+            let key = event.contract_id.as_str();
+
+            self.inner
+                .send(
+                    FutureRecord::to(topic).key(key).payload(&payload),
+                    Duration::from_secs(5),
+                )
+                .await
+                .map(|_| ())
+                .map_err(|(e, _)| format!("Kafka delivery failed: {e}"))
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use serde_json::Value;
+    use std::sync::{Arc, Mutex};
+
+    /// Mock publisher that records every (topic, event) pair it receives.
+    #[derive(Clone, Default)]
+    pub struct MockKafkaPublisher {
+        pub published: Arc<Mutex<Vec<(String, SorobanEvent)>>>,
+        /// When set, every publish call returns this error.
+        pub fail_with: Arc<Mutex<Option<String>>>,
+    }
+
+    #[async_trait]
+    impl KafkaPublisher for MockKafkaPublisher {
+        async fn publish(&self, topic: &str, event: &SorobanEvent) -> Result<(), String> {
+            if let Some(ref msg) = *self.fail_with.lock().unwrap() {
+                return Err(msg.clone());
+            }
+            self.published
+                .lock()
+                .unwrap()
+                .push((topic.to_string(), event.clone()));
+            Ok(())
+        }
+    }
+
+    fn make_event(contract_id: &str) -> SorobanEvent {
+        SorobanEvent {
+            contract_id: contract_id.to_string(),
+            event_type: "contract".to_string(),
+            tx_hash: "abc123".to_string(),
+            ledger: 42,
+            ledger_closed_at: "2026-03-14T00:00:00Z".to_string(),
+            value: Value::Null,
+            topic: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_records_published_events() {
+        let publisher = MockKafkaPublisher::default();
+        let event = make_event("CABC");
+
+        publisher.publish("events", &event).await.unwrap();
+
+        let published = publisher.published.lock().unwrap();
+        assert_eq!(published.len(), 1);
+        assert_eq!(published[0].0, "events");
+        assert_eq!(published[0].1.contract_id, "CABC");
+    }
+
+    #[tokio::test]
+    async fn mock_uses_contract_id_as_key() {
+        // The real producer uses contract_id as the Kafka message key.
+        // Verify the mock stores the event with the correct contract_id so
+        // downstream assertions can confirm key routing.
+        let publisher = MockKafkaPublisher::default();
+        let e1 = make_event("CONTRACT_A");
+        let e2 = make_event("CONTRACT_B");
+
+        publisher.publish("events", &e1).await.unwrap();
+        publisher.publish("events", &e2).await.unwrap();
+
+        let published = publisher.published.lock().unwrap();
+        assert_eq!(published[0].1.contract_id, "CONTRACT_A");
+        assert_eq!(published[1].1.contract_id, "CONTRACT_B");
+    }
+
+    #[tokio::test]
+    async fn mock_returns_error_when_configured() {
+        let publisher = MockKafkaPublisher::default();
+        *publisher.fail_with.lock().unwrap() = Some("broker unavailable".to_string());
+
+        let result = publisher.publish("events", &make_event("CABC")).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("broker unavailable"));
+    }
+
+    #[tokio::test]
+    async fn failed_publish_does_not_record_event() {
+        let publisher = MockKafkaPublisher::default();
+        *publisher.fail_with.lock().unwrap() = Some("timeout".to_string());
+
+        let _ = publisher.publish("events", &make_event("CABC")).await;
+        assert!(publisher.published.lock().unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn multiple_events_same_topic_all_recorded() {
+        let publisher = MockKafkaPublisher::default();
+        for i in 0..5 {
+            let event = make_event(&format!("CONTRACT_{i}"));
+            publisher.publish("my-topic", &event).await.unwrap();
+        }
+        assert_eq!(publisher.published.lock().unwrap().len(), 5);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod error;
 mod handlers;
 mod index_monitor;
 mod indexer;
+mod kafka;
 mod metrics;
 mod middleware;
 mod models;
@@ -203,6 +204,18 @@ async fn main() -> anyhow::Result<()> {
     indexer.set_health_state(health_state.clone());
     indexer.set_indexer_state(indexer_state.clone());
     indexer.set_event_tx(event_tx.clone());
+    #[cfg(feature = "kafka")]
+    if let (Some(brokers), Some(topic)) = (&config.kafka_brokers, &config.kafka_topic) {
+        match crate::kafka::RdKafkaProducer::new(brokers, config.kafka_batch_size, config.kafka_linger_ms) {
+            Ok(producer) => {
+                info!(brokers = %brokers, topic = %topic, "Kafka publishing enabled");
+                indexer.set_kafka_publisher(std::sync::Arc::new(producer), topic.clone());
+            }
+            Err(e) => {
+                tracing::error!(error = %e, "Failed to create Kafka producer — Kafka publishing disabled");
+            }
+        }
+    }
     let indexer_handle = tokio::spawn(async move {
         indexer.run().await;
     });

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -62,6 +62,11 @@ pub fn record_webhook_failure() {
     m::counter!("soroban_pulse_webhook_failures_total", 1u64);
 }
 
+/// Record a Kafka publish failure.
+pub fn record_kafka_publish_error() {
+    m::counter!("soroban_pulse_kafka_publish_errors_total", 1u64);
+}
+
 /// Record HTTP request duration
 pub fn record_http_request_duration(duration: std::time::Duration, method: &str, route: &str, status: &str) {
     m::histogram!("soroban_pulse_http_request_duration_seconds", duration.as_secs_f64(), "method" => method.to_string(), "route" => route.to_string(), "status" => status.to_string());


### PR DESCRIPTION
## Summary

Adds a native Apache Kafka producer integration behind an optional `kafka` feature flag, closing #263.

## Changes

- **`Cargo.toml`** — `rdkafka = { version = "0.36", optional = true }` and `kafka = ["rdkafka"]` feature flag
- **`src/kafka.rs`** (new) — `KafkaPublisher` trait, `RdKafkaProducer` (real impl, cfg-gated), `MockKafkaPublisher` for tests
- **`src/config.rs`** — `kafka_brokers`, `kafka_topic`, `kafka_batch_size` (default 16384), `kafka_linger_ms` (default 5), all cfg-gated
- **`src/indexer.rs`** — producer field on `Indexer`, publish call after each new (non-duplicate) insert with `contract_id` as message key; failed publishes are logged and metered
- **`src/metrics.rs`** — `soroban_pulse_kafka_publish_errors_total` counter
- **`src/main.rs`** — startup wiring: builds `RdKafkaProducer` when `KAFKA_BROKERS` + `KAFKA_TOPIC` are set
- **`.env.example`** — documents `KAFKA_BROKERS`, `KAFKA_TOPIC`, `KAFKA_BATCH_SIZE`, `KAFKA_LINGER_MS`

## Usage

```bash
cargo build --features kafka
export KAFKA_BROKERS=localhost:9092
export KAFKA_TOPIC=soroban-events
cargo run --features kafka
```

## Tests

- `src/kafka.rs` — 5 unit tests on `MockKafkaPublisher` (happy path, error path, no-record-on-failure)
- `src/indexer.rs` — 2 integration tests: publisher called for new events, not called for duplicates