### PR TITLE
feat: enforce event_data size limit (MAX_EVENT_DATA_BYTES)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -141,3 +141,9 @@ RUST_LOG_FORMAT=text
 # When set, only events matching one of these contract IDs are delivered.
 # When unset, all events are delivered.
 # WEBHOOK_CONTRACT_FILTER=CABC...,CDEF...
+
+# Maximum size (bytes) of serialized event_data JSON allowed per event.
+# Events exceeding this limit are logged at WARN and skipped (not stored).
+# A soroban_pulse_events_oversized_total counter tracks skipped events.
+# Default: 65536 (64 KiB)
+MAX_EVENT_DATA_BYTES=65536

--- a/migrations/20260427000002_event_data_size_limit.down.sql
+++ b/migrations/20260427000002_event_data_size_limit.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE events DROP CONSTRAINT IF EXISTS event_data_size_limit;

--- a/migrations/20260427000002_event_data_size_limit.sql
+++ b/migrations/20260427000002_event_data_size_limit.sql
@@ -1,0 +1,6 @@
+-- Defense-in-depth: reject event_data larger than 64 KiB at the DB level.
+-- The application enforces MAX_EVENT_DATA_BYTES before INSERT; this constraint
+-- is a secondary guard against direct writes that bypass the application layer.
+ALTER TABLE events
+    ADD CONSTRAINT event_data_size_limit
+    CHECK (octet_length(event_data::text) <= 65536);

--- a/src/config.rs
+++ b/src/config.rs
@@ -177,6 +177,7 @@ pub struct Config {
     pub webhook_url: Option<String>,
     pub webhook_secret: Option<String>,
     pub webhook_contract_filter: Vec<String>,
+    pub max_event_data_bytes: usize,
 }
 
 impl Default for Config {
@@ -213,6 +214,7 @@ impl Default for Config {
             webhook_url: None,
             webhook_secret: None,
             webhook_contract_filter: Vec::new(),
+            max_event_data_bytes: 65536,
         }
     }
 }
@@ -501,6 +503,12 @@ impl Config {
                 .map(|s| s.trim().to_string())
                 .filter(|s| !s.is_empty())
                 .collect(),
+            max_event_data_bytes: parse_int::<usize>(
+                "MAX_EVENT_DATA_BYTES",
+                &env_or_file_or("MAX_EVENT_DATA_BYTES", &file, "65536"),
+                "65536",
+                &mut errors,
+            ).unwrap_or(65536),
         }
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -612,6 +612,22 @@ impl<R: RpcClient> Indexer<R> {
             .map(|dt| dt.with_timezone(&chrono::Utc))
             .map_err(|_| anyhow::anyhow!("Unparseable ledger_closed_at"))?;
         let event_data = json!({ "value": event.value, "topic": event.topic });
+
+        // Enforce size limit before INSERT.
+        let serialized = serde_json::to_vec(&event_data)?;
+        if serialized.len() > self.config.max_event_data_bytes {
+            warn!(
+                tx_hash = %event.tx_hash,
+                contract_id = %event.contract_id,
+                ledger = event.ledger,
+                size_bytes = serialized.len(),
+                limit_bytes = self.config.max_event_data_bytes,
+                "event_data exceeds size limit, skipping",
+            );
+            metrics::record_oversized_event();
+            return Ok(0);
+        }
+
         let result = sqlx::query(
             r#"INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data)
                VALUES ($1, $2, $3, $4, $5, $6)
@@ -821,15 +837,13 @@ mod tests {
 
                 event_data_encryption_key: None,
                 event_data_encryption_key_old: None,
+                max_event_data_bytes: 65536,
 
             },
             shutdown_rx,
             MockRpcClient::new(),
         )
     }
-
-    #[tokio::test]
-    async fn test_should_log_debug_sampling() {
         let pool = PgPool::connect("postgres://localhost/soroban_pulse").await.unwrap_or_else(|_| {
             // Fallback for environments where PG is not available
             // In a real test environment we'd have a pool.
@@ -1037,6 +1051,7 @@ mod tests {
 
                 event_data_encryption_key: None,
                 event_data_encryption_key_old: None,
+                max_event_data_bytes: 65536,
 
             },
             shutdown_rx,
@@ -1046,5 +1061,46 @@ mod tests {
         // Test that the indexer can use the mock client
         let latest_ledger = indexer.get_latest_ledger().await.unwrap();
         assert_eq!(latest_ledger, 100);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn oversized_event_is_skipped(pool: PgPool) {
+        let mut idx = indexer(pool.clone());
+        idx.config.max_event_data_bytes = 10; // tiny limit
+
+        let mut event = make_event(1);
+        // value large enough to exceed 10 bytes when serialized
+        event.value = json!({"k": "a very long string value that exceeds the limit"});
+
+        let mut tx = pool.begin().await.unwrap();
+        let rows = idx.store_event_in_tx(&mut tx, &event).await.unwrap();
+        tx.commit().await.unwrap();
+
+        assert_eq!(rows, 0, "oversized event must be skipped");
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM events")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn event_within_size_limit_is_stored(pool: PgPool) {
+        let idx = indexer(pool.clone()); // default 65536 limit
+
+        let event = make_event(1); // tiny event, well within limit
+
+        let mut tx = pool.begin().await.unwrap();
+        let rows = idx.store_event_in_tx(&mut tx, &event).await.unwrap();
+        tx.commit().await.unwrap();
+
+        assert_eq!(rows, 1);
+
+        let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM events")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(count, 1);
     }
 }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -52,6 +52,11 @@ pub fn record_validation_failure() {
     m::counter!("soroban_pulse_events_validation_failed_total", 1u64);
 }
 
+/// Record an oversized event that was skipped due to exceeding MAX_EVENT_DATA_BYTES.
+pub fn record_oversized_event() {
+    m::counter!("soroban_pulse_events_oversized_total", 1u64);
+}
+
 /// Record a duplicate event
 pub fn record_duplicate_event() {
     m::counter!("soroban_pulse_events_duplicate_total", 1u64);


### PR DESCRIPTION
closes #200 Add event data size limit to prevent oversized JSONB storage