### PR TITLE
fix: resolve OpenAPI drift, CI caching, K8s resource limits, and SDK retry logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
@@ -50,14 +53,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - run: cargo clippy -- -D warnings
 
   test:
@@ -79,14 +77,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - uses: actions/cache@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          path: .sqlx
+          key: ${{ runner.os }}-sqlx-${{ hashFiles('.sqlx/**') }}
+          restore-keys: ${{ runner.os }}-sqlx-
       - run: sudo apt-get install -y libpq-dev pkg-config libssl-dev
       - run: cargo test
 
@@ -109,14 +107,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - uses: actions/cache@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          path: .sqlx
+          key: ${{ runner.os }}-sqlx-${{ hashFiles('.sqlx/**') }}
+          restore-keys: ${{ runner.os }}-sqlx-
       - run: sudo apt-get install -y libpq-dev pkg-config libssl-dev
       - run: cargo test --test integration_tests
 
@@ -139,14 +137,14 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - uses: actions/cache@v4
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          path: .sqlx
+          key: ${{ runner.os }}-sqlx-${{ hashFiles('.sqlx/**') }}
+          restore-keys: ${{ runner.os }}-sqlx-
       - run: sudo apt-get install -y libpq-dev pkg-config libssl-dev
       - run: cargo test --test resilience
 
@@ -157,14 +155,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - run: cargo bench
 
   fuzz:
@@ -174,14 +167,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@nightly
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-fuzz-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-fuzz-
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - run: cargo install cargo-fuzz
       - run: cargo fuzz run fuzz_validate_contract_id -- -max_total_time=30
         working-directory: fuzz
@@ -196,14 +184,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-release-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-release-
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - run: sudo apt-get install -y pkg-config libssl-dev
       - run: cargo build --release
 
@@ -236,14 +219,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: ${{ runner.os }}-cargo-
+          save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
       - run: sudo apt-get install -y pkg-config libssl-dev
       - name: Generate OpenAPI spec
         run: cargo run --bin gen_openapi > /tmp/openapi-generated.json

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,21 +245,18 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: ${{ runner.os }}-cargo-
       - run: sudo apt-get install -y pkg-config libssl-dev
-      # Build the spec-dump binary and generate the spec
-      - run: cargo build --bin dump_openapi
-      - run: ./target/debug/dump_openapi > /tmp/openapi-generated.json
-      # Validate the generated spec against OpenAPI 3.0 schema using spectral@6.11.1
+      - name: Generate OpenAPI spec
+        run: cargo run --bin gen_openapi > /tmp/openapi-generated.json
+      - name: Check openapi.json is up to date
+        run: |
+          if ! diff -q openapi.json /tmp/openapi-generated.json > /dev/null 2>&1; then
+            echo "OpenAPI spec is out of date — run make gen-openapi and commit the result"
+            diff openapi.json /tmp/openapi-generated.json
+            exit 1
+          fi
+      - name: Copy spec to docs for Swagger UI
+        run: cp openapi.json docs/openapi.json
       - name: Install Spectral
         run: npm install -g @stoplight/spectral-cli@6.11.1
       - name: Validate OpenAPI spec
-        run: spectral lint /tmp/openapi-generated.json --ruleset https://unpkg.com/@stoplight/spectral-openapi/dist/ruleset.js
-      # Verify the committed docs/openapi.json matches the generated spec
-      - name: Check committed spec is up to date
-        run: |
-          ./target/debug/dump_openapi > /tmp/openapi-fresh.json
-          if ! diff -q docs/openapi.json /tmp/openapi-fresh.json > /dev/null 2>&1; then
-            echo "docs/openapi.json is out of date. Run './target/debug/dump_openapi > docs/openapi.json' and commit the result."
-            diff docs/openapi.json /tmp/openapi-fresh.json
-            exit 1
-          fi
-          echo "docs/openapi.json is up to date."
+        run: spectral lint openapi.json --ruleset https://unpkg.com/@stoplight/spectral-openapi/dist/ruleset.js

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build test test-db lint fmt run docker-up docker-down migrate clean
+.PHONY: help build test test-db lint fmt run docker-up docker-down migrate clean gen-openapi
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*##"}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
@@ -43,6 +43,10 @@ migrate-down: ## Rollback the most recent migration
 clean: ## Remove build artifacts
 	cargo clean
 	rm -f openapi.json
+
+gen-openapi: ## Regenerate openapi.json from handler signatures and sync docs/openapi.json
+	cargo run --bin gen_openapi > openapi.json
+	cp openapi.json docs/openapi.json
 
 generate-sdk: ## Generate TypeScript and Python SDKs from OpenAPI spec
 	cargo run --bin gen_openapi > openapi.json

--- a/docs/alerts.yml
+++ b/docs/alerts.yml
@@ -108,3 +108,13 @@ groups:
         annotations:
           summary: "Soroban Pulse HTTP p95 request latency is high"
           description: "p95 request latency is {{ $value | humanizeDuration }}. Consider scaling or investigating database performance."
+
+      - alert: PodMemoryNearLimit
+        expr: soroban_pulse_process_memory_bytes / (512 * 1024 * 1024) > 0.9
+        for: 5m
+        labels:
+          severity: warning
+          component: resource
+        annotations:
+          summary: "Soroban Pulse pod memory is approaching the 512Mi limit"
+          description: "Process memory is {{ $value | humanizeBytes }} ({{ $value | humanizePercentage }} of the 512Mi limit). OOM kill risk if usage continues to grow. Consider increasing the memory limit or investigating leaks."

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -1,5 +1,40 @@
 # Deployment Guide
 
+## Resource Sizing
+
+### Recommended defaults
+
+| Resource | Request | Limit |
+| -------- | ------- | ----- |
+| CPU | `100m` | `1000m` |
+| Memory | `256Mi` | `512Mi` |
+
+These values are set in both `k8s/deployment.yaml` and `helm/soroban-pulse/values.yaml`. The Helm chart exposes the full `resources` block in `values.yaml` so you can override it without editing the template:
+
+```bash
+helm upgrade soroban-pulse ./helm/soroban-pulse \
+  --set resources.requests.memory=512Mi \
+  --set resources.limits.memory=1Gi \
+  --set resources.limits.cpu=2000m
+```
+
+### Tuning guidance
+
+- **CPU request (`100m`)** — the scheduler guarantee. Raise this if pods are consistently throttled (check `container_cpu_throttled_seconds_total`).
+- **CPU limit (`1000m`)** — caps one full core per pod. Increase for CPU-bound workloads (e.g. high event compression activity).
+- **Memory request (`256Mi`)** — raise to match observed steady-state RSS. Under-requesting causes the scheduler to place pods on nodes that later OOM.
+- **Memory limit (`512Mi`)** — pods that exceed this are OOM-killed. The `PodMemoryNearLimit` Prometheus alert (see `docs/alerts.yml`) fires when usage crosses 90% of this limit, giving you time to act before a kill occurs.
+
+### Memory alert
+
+The `PodMemoryNearLimit` alert in `docs/alerts.yml` fires when `soroban_pulse_process_memory_bytes` exceeds 90% of the 512 MiB limit for more than 5 minutes. Respond by:
+
+1. Checking for a memory leak (`kubectl top pod`, heap profiling).
+2. Increasing the limit and request if usage is legitimately growing with load.
+3. Scaling horizontally (`replicaCount` / HPA) to spread the load.
+
+---
+
 ## Healthcheck Configuration
 
 The `app` service in `docker-compose.yml` includes a Docker healthcheck that polls `GET /healthz/ready` every 10 seconds. The check is configured with:

--- a/helm/soroban-pulse/values.yaml
+++ b/helm/soroban-pulse/values.yaml
@@ -13,9 +13,9 @@ service:
 resources:
   requests:
     cpu: "100m"
-    memory: "128Mi"
+    memory: "256Mi"
   limits:
-    cpu: "500m"
+    cpu: "1000m"
     memory: "512Mi"
 
 env:

--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -23,9 +23,9 @@ spec:
           resources:
             requests:
               cpu: "100m"
-              memory: "128Mi"
+              memory: "256Mi"
             limits:
-              cpu: "500m"
+              cpu: "1000m"
               memory: "512Mi"
           envFrom:
             - configMapRef:

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,3 +9,6 @@ pre-commit:
     clippy:
       run: cargo clippy -- -D warnings
       glob: "*.rs"
+    gen-openapi:
+      run: cargo run --bin gen_openapi > openapi.json && cp openapi.json docs/openapi.json && git add openapi.json docs/openapi.json
+      glob: "*.rs"

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -77,6 +77,64 @@ async with openapi_client.ApiClient(configuration) as api_client:
 
 ```
 
+## Retry Configuration
+
+The client automatically retries requests that fail with transient server errors. By default it retries up to **3 times** with exponential backoff and jitter on HTTP status codes `429`, `500`, `502`, `503`, and `504`.
+
+### Default behaviour
+
+```python
+import openapi_client
+
+configuration = openapi_client.Configuration(
+    host="https://api.example.com",
+    # max_retries=3 and retry_on_status=[429,500,502,503,504] are the defaults
+)
+```
+
+### Custom retry settings
+
+```python
+import openapi_client
+
+configuration = openapi_client.Configuration(
+    host="https://api.example.com",
+    max_retries=5,
+    retry_on_status=[429, 503],
+)
+```
+
+### Disabling retries
+
+```python
+configuration = openapi_client.Configuration(
+    host="https://api.example.com",
+    max_retries=0,
+)
+```
+
+### Retry-After support
+
+When the server responds with a `Retry-After` header (e.g. `Retry-After: 5`), the client waits exactly that many seconds before the next attempt instead of using exponential backoff.
+
+### Backoff formula
+
+For attempt *n* (0-indexed) without a `Retry-After` header:
+
+```
+delay = 2^n + random(0, 1)  seconds
+```
+
+| Attempt | Base delay |
+| ------- | ---------- |
+| 1st retry | 1 s + jitter |
+| 2nd retry | 2 s + jitter |
+| 3rd retry | 4 s + jitter |
+
+After exhausting all retries the last server response is returned to the caller.
+
+---
+
 ## Documentation for API Endpoints
 
 All URIs are relative to *http://localhost*

--- a/sdk/python/openapi_client/configuration.py
+++ b/sdk/python/openapi_client/configuration.py
@@ -207,6 +207,8 @@ class Configuration:
         socket_options: Optional[Any]=None,
         datetime_format: str="%Y-%m-%dT%H:%M:%S.%f%z",
         date_format: str="%Y-%m-%d",
+        max_retries: int=3,
+        retry_on_status: Optional[List[int]]=None,
         *,
         debug: Optional[bool] = None,
     ) -> None:
@@ -331,6 +333,14 @@ class Configuration:
 
         self.date_format = date_format
         """date format
+        """
+
+        self.max_retries = max_retries
+        """Maximum number of retries for transient server errors (5xx, 429).
+        """
+
+        self.retry_on_status = retry_on_status if retry_on_status is not None else [429, 500, 502, 503, 504]
+        """HTTP status codes that trigger a retry.
         """
 
     def __deepcopy__(self, memo:  Dict[int, Any]) -> Self:

--- a/sdk/python/openapi_client/rest.py
+++ b/sdk/python/openapi_client/rest.py
@@ -12,8 +12,10 @@
 """  # noqa: E501
 
 
+import asyncio
 import io
 import json
+import random
 import re
 import ssl
 from typing import Optional, Union
@@ -57,6 +59,8 @@ class RESTClientObject:
 
         # maxsize is number of requests to host that are allowed in parallel
         self.maxsize = configuration.connection_pool_maxsize
+        self.max_retries = configuration.max_retries
+        self.retry_on_status = configuration.retry_on_status
 
         self.ssl_context = ssl.create_default_context(
             cafile=configuration.ssl_ca_cert,
@@ -178,8 +182,23 @@ class RESTClientObject:
         if self.pool_manager is None:
             self.pool_manager = self._create_pool_manager()
 
-        r = await self.pool_manager.request(**args)
-        return RESTResponse(r)
+        for attempt in range(self.max_retries + 1):
+            r = await self.pool_manager.request(**args)
+            if r.status_code not in self.retry_on_status or attempt >= self.max_retries:
+                return RESTResponse(r)
+
+            retry_after = r.headers.get("retry-after") or r.headers.get("Retry-After")
+            if retry_after is not None:
+                try:
+                    delay = float(retry_after)
+                except ValueError:
+                    delay = (2 ** attempt) + random.uniform(0, 1)
+            else:
+                delay = (2 ** attempt) + random.uniform(0, 1)
+
+            await asyncio.sleep(delay)
+
+        return RESTResponse(r)  # unreachable; satisfies type checker
 
     def _create_pool_manager(self) -> httpx.AsyncClient:
         limits = httpx.Limits(max_connections=self.maxsize)

--- a/sdk/python/test/test_retry_logic.py
+++ b/sdk/python/test/test_retry_logic.py
@@ -1,0 +1,135 @@
+# coding: utf-8
+
+import asyncio
+import unittest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from openapi_client.configuration import Configuration
+from openapi_client.rest import RESTClientObject
+
+
+def _make_response(status_code: int, headers: dict | None = None):
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.reason_phrase = "Test"
+    resp.headers = headers or {}
+    return resp
+
+
+class TestRetryLogic(unittest.IsolatedAsyncioTestCase):
+
+    def _make_client(self, max_retries=3, retry_on_status=None):
+        cfg = Configuration()
+        cfg.max_retries = max_retries
+        if retry_on_status is not None:
+            cfg.retry_on_status = retry_on_status
+        return RESTClientObject(cfg)
+
+    async def test_no_retry_on_success(self):
+        client = self._make_client()
+        ok_response = _make_response(200)
+        client.pool_manager = MagicMock()
+        client.pool_manager.request = AsyncMock(return_value=ok_response)
+
+        result = await client.request("GET", "http://example.com/")
+
+        self.assertEqual(result.status, 200)
+        self.assertEqual(client.pool_manager.request.call_count, 1)
+
+    async def test_retries_on_503_then_succeeds(self):
+        client = self._make_client(max_retries=3)
+        responses = [
+            _make_response(503),
+            _make_response(503),
+            _make_response(200),
+        ]
+        client.pool_manager = MagicMock()
+        client.pool_manager.request = AsyncMock(side_effect=responses)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await client.request("GET", "http://example.com/")
+
+        self.assertEqual(result.status, 200)
+        self.assertEqual(client.pool_manager.request.call_count, 3)
+        self.assertEqual(mock_sleep.call_count, 2)
+
+    async def test_exhausts_retries_and_returns_last_response(self):
+        client = self._make_client(max_retries=2)
+        client.pool_manager = MagicMock()
+        client.pool_manager.request = AsyncMock(return_value=_make_response(503))
+
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await client.request("GET", "http://example.com/")
+
+        self.assertEqual(result.status, 503)
+        self.assertEqual(client.pool_manager.request.call_count, 3)  # initial + 2 retries
+
+    async def test_retry_after_header_respected(self):
+        client = self._make_client(max_retries=1)
+        responses = [
+            _make_response(503, headers={"retry-after": "5"}),
+            _make_response(200),
+        ]
+        client.pool_manager = MagicMock()
+        client.pool_manager.request = AsyncMock(side_effect=responses)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await client.request("GET", "http://example.com/")
+
+        mock_sleep.assert_awaited_once_with(5.0)
+
+    async def test_retry_after_invalid_value_falls_back_to_backoff(self):
+        client = self._make_client(max_retries=1)
+        responses = [
+            _make_response(429, headers={"retry-after": "not-a-number"}),
+            _make_response(200),
+        ]
+        client.pool_manager = MagicMock()
+        client.pool_manager.request = AsyncMock(side_effect=responses)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            await client.request("GET", "http://example.com/")
+
+        delay = mock_sleep.call_args[0][0]
+        self.assertGreaterEqual(delay, 1.0)  # 2^0 + jitter >= 1
+
+    async def test_no_retry_on_non_retryable_status(self):
+        client = self._make_client(max_retries=3)
+        client.pool_manager = MagicMock()
+        client.pool_manager.request = AsyncMock(return_value=_make_response(404))
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await client.request("GET", "http://example.com/")
+
+        self.assertEqual(result.status, 404)
+        self.assertEqual(client.pool_manager.request.call_count, 1)
+        mock_sleep.assert_not_called()
+
+    async def test_custom_retry_on_status(self):
+        client = self._make_client(max_retries=2, retry_on_status=[503])
+        responses = [_make_response(502), _make_response(200)]
+        client.pool_manager = MagicMock()
+        client.pool_manager.request = AsyncMock(side_effect=responses)
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await client.request("GET", "http://example.com/")
+
+        # 502 is not in retry_on_status=[503], so no retry
+        self.assertEqual(result.status, 502)
+        mock_sleep.assert_not_called()
+
+    async def test_zero_retries(self):
+        client = self._make_client(max_retries=0)
+        client.pool_manager = MagicMock()
+        client.pool_manager.request = AsyncMock(return_value=_make_response(503))
+
+        with patch("asyncio.sleep", new_callable=AsyncMock) as mock_sleep:
+            result = await client.request("GET", "http://example.com/")
+
+        self.assertEqual(result.status, 503)
+        self.assertEqual(client.pool_manager.request.call_count, 1)
+        mock_sleep.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sdk/typescript/runtime.ts
+++ b/sdk/typescript/runtime.ts
@@ -26,6 +26,8 @@ export interface ConfigurationParameters {
     accessToken?: string | Promise<string> | ((name?: string, scopes?: string[]) => string | Promise<string>); // parameter for oauth2 security
     headers?: HTTPHeaders; //header params we want to use on every request
     credentials?: RequestCredentials; //value for the credentials param we want to use on each request
+    maxRetries?: number; // maximum number of retries for transient server errors (default: 3)
+    retryOnStatus?: number[]; // HTTP status codes that trigger a retry (default: [429, 500, 502, 503, 504])
 }
 
 export class Configuration {
@@ -82,6 +84,14 @@ export class Configuration {
     get credentials(): RequestCredentials | undefined {
         return this.configuration.credentials;
     }
+
+    get maxRetries(): number {
+        return this.configuration.maxRetries ?? 3;
+    }
+
+    get retryOnStatus(): number[] {
+        return this.configuration.retryOnStatus ?? [429, 500, 502, 503, 504];
+    }
 }
 
 export const DefaultConfig = new Configuration();
@@ -133,11 +143,32 @@ export class BaseAPI {
 
     protected async request(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction): Promise<Response> {
         const { url, init } = await this.createFetchParams(context, initOverrides);
-        const response = await this.fetchApi(url, init);
-        if (response && (response.status >= 200 && response.status < 300)) {
-            return response;
+        const maxRetries = this.configuration.maxRetries;
+        const retryOnStatus = this.configuration.retryOnStatus;
+
+        let response: Response | undefined;
+        for (let attempt = 0; attempt <= maxRetries; attempt++) {
+            response = await this.fetchApi(url, init);
+            if (response && response.status >= 200 && response.status < 300) {
+                return response;
+            }
+            if (response && retryOnStatus.includes(response.status) && attempt < maxRetries) {
+                const retryAfterHeader = response.headers.get('retry-after');
+                let delayMs: number;
+                if (retryAfterHeader !== null) {
+                    const parsed = parseFloat(retryAfterHeader);
+                    delayMs = isNaN(parsed)
+                        ? (Math.pow(2, attempt) + Math.random()) * 1000
+                        : parsed * 1000;
+                } else {
+                    delayMs = (Math.pow(2, attempt) + Math.random()) * 1000;
+                }
+                await new Promise<void>(resolve => setTimeout(resolve, delayMs));
+                continue;
+            }
+            throw new ResponseError(response, 'Response returned an error code');
         }
-        throw new ResponseError(response, 'Response returned an error code');
+        throw new ResponseError(response!, 'Response returned an error code');
     }
 
     private async createFetchParams(context: RequestOpts, initOverrides?: RequestInit | InitOverrideFunction) {


### PR DESCRIPTION
## Summary

This PR closes four independent issues across CI, infrastructure, and SDK layers.

---

### #382 — K8s resource requests and limits

**Files changed:** `k8s/deployment.yaml`, `helm/soroban-pulse/values.yaml`, `docs/alerts.yml`, `docs/deployment.md`

- Updated resource requests and limits to the recommended conservative defaults:
  - `requests.memory`: `128Mi` → `256Mi`
  - `limits.cpu`: `500m` → `1000m`
  - `limits.memory`: `512Mi` (unchanged)
  - `requests.cpu`: `100m` (unchanged)
- Applied the same values to the Helm chart `values.yaml` (the Helm deployment template already reads from `values.yaml` via `{{- toYaml .Values.resources | nindent 12 }}`).
- Added a `PodMemoryNearLimit` Prometheus alert rule to `docs/alerts.yml` that fires when `soroban_pulse_process_memory_bytes` exceeds 90% of the 512 MiB limit for more than 5 minutes.
- Added a **Resource Sizing** section to `docs/deployment.md` documenting the defaults, tuning guidance, and how to override via Helm.

---

### #384 — OpenAPI spec drift

**Files changed:** `Makefile`, `lefthook.yml`, `.github/workflows/ci.yml`

- Added a `make gen-openapi` Makefile target that runs `cargo run --bin gen_openapi > openapi.json` and copies the result to `docs/openapi.json`, establishing `openapi.json` at the repo root as the single source of truth.
- Updated the CI `openapi` job to:
  - Run `cargo run --bin gen_openapi` and diff its output against the committed `openapi.json`.
  - Fail with the exact message: `"OpenAPI spec is out of date — run make gen-openapi and commit the result"` if they diverge.
  - Copy `openapi.json` to `docs/openapi.json` in CI so the Swagger UI always gets a fresh copy from the root.
- Added a `gen-openapi` command to the `pre-commit` block in `lefthook.yml` that automatically regenerates `openapi.json` and `docs/openapi.json` and stages both files before each commit touching a `.rs` file.

---

### #383 — CI Rust build caching

**Files changed:** `.github/workflows/ci.yml`

- Replaced all manual `actions/cache@v4` Cargo blocks (registry, git, target) with `Swatinem/rust-cache@v2` across every job that compiles Rust code: `validate-sdk`, `clippy`, `test`, `integration-tests`, `resilience-tests`, `bench`, `fuzz`, `build`, and `openapi`.
- `Swatinem/rust-cache@v2` automatically keys the cache on OS + toolchain + `Cargo.lock` hash, so the cache is invalidated whenever `Cargo.lock` changes.
- Added a dedicated `actions/cache@v4` step for the `.sqlx/` offline query data directory in the three database-backed test jobs (`test`, `integration-tests`, `resilience-tests`).
- All cache save steps are gated with `save-if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}` so fork PRs cannot write to the shared cache.

---

### #385 — Python and TypeScript SDK retry logic

**Files changed:** `sdk/python/openapi_client/configuration.py`, `sdk/python/openapi_client/rest.py`, `sdk/python/test/test_retry_logic.py`, `sdk/python/README.md`, `sdk/typescript/runtime.ts`

**Python SDK:**
- Added `max_retries: int = 3` and `retry_on_status: Optional[List[int]] = None` (defaults to `[429, 500, 502, 503, 504]`) parameters to `Configuration.__init__`.
- Implemented a retry loop in `RESTClientObject.request`:
  - Retries up to `max_retries` times on any status code in `retry_on_status`.
  - Uses exponential backoff with random jitter: `delay = 2^attempt + random(0, 1)` seconds.
  - Respects the `Retry-After` response header — if present and numeric, waits exactly that many seconds; falls back to backoff if the value is non-numeric.
  - After exhausting all retries, returns the last server response to the caller.
- Added `test/test_retry_logic.py` with 8 unit tests using `unittest.mock` and `IsolatedAsyncioTestCase`, covering: success (no retry), 503→succeed, retry exhaustion, `Retry-After` header, invalid `Retry-After` fallback, non-retryable status, custom status list, and zero retries. All 8 tests pass.
- Updated `sdk/python/README.md` with a **Retry Configuration** section documenting defaults, custom settings, disabling retries, `Retry-After` behaviour, and the backoff formula.

**TypeScript SDK:**
- Added `maxRetries?: number` and `retryOnStatus?: number[]` to `ConfigurationParameters`.
- Added `get maxRetries()` and `get retryOnStatus()` getters to `Configuration` (defaults: `3` and `[429, 500, 502, 503, 504]`).
- Rewrote `BaseAPI.request` to loop up to `maxRetries` times, applying the same exponential backoff + jitter + `Retry-After` logic as the Python SDK.

## Test plan

- [ ] `make gen-openapi` regenerates both `openapi.json` and `docs/openapi.json`
- [ ] CI `openapi` job fails on a deliberately stale `openapi.json`
- [ ] `kubectl apply --dry-run=client -f k8s/deployment.yaml` succeeds (verified locally; no live cluster in CI)
- [ ] `helm template ./helm/soroban-pulse` renders correct resource values
- [ ] Python retry tests: `cd sdk/python && pytest test/test_retry_logic.py -v` → 8 passed
- [ ] CI passes on this branch

Closes #382
Closes #383
Closes #384
Closes #385

🤖 Generated with [Claude Code](https://claude.com/claude-code)