### PR TITLE
Features: 433 434 435 436

### DIFF
--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1385,6 +1385,10 @@ pub async fn get_events(
             conditions.push(format!("in_successful_call = ${bind_idx}"));
             bind_idx += 1;
         }
+        if params.schema_version.is_some() {
+            conditions.push(format!("schema_version = ${bind_idx}"));
+            bind_idx += 1;
+        }
         if params.topic_sym.is_some() {
             conditions.push(format!("topic_0_sym = ${bind_idx}"));
             bind_idx += 1;
@@ -1475,6 +1479,9 @@ pub async fn get_events(
         }
         if let Some(isc) = params.in_successful_call {
             q = q.bind(isc);
+        }
+        if let Some(sv) = params.schema_version {
+            q = q.bind(sv);
         }
         if let Some(ref ts) = params.topic_sym {
             q = q.bind(ts);
@@ -1618,6 +1625,10 @@ pub async fn get_events(
         conditions.push(format!("in_successful_call = ${bind_idx}"));
         bind_idx += 1;
     }
+    if params.schema_version.is_some() {
+        conditions.push(format!("schema_version = ${bind_idx}"));
+        bind_idx += 1;
+    }
     if params.topic_sym.is_some() {
         conditions.push(format!("topic_0_sym = ${bind_idx}"));
         bind_idx += 1;
@@ -1698,6 +1709,9 @@ pub async fn get_events(
     }
     if let Some(isc) = params.in_successful_call {
         q = q.bind(isc);
+    }
+    if let Some(sv) = params.schema_version {
+        q = q.bind(sv);
     }
     if let Some(ref ts) = params.topic_sym {
         q = q.bind(ts);

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2678,6 +2678,111 @@ pub async fn anonymize_event(
     Ok(Json(json!({ "id": id, "anonymized": true })))
 }
 
+/// Delete all events for a contract (GDPR right-to-erasure).
+/// Optionally anonymize instead of deleting with `anonymize_only=true`.
+/// Logs deletion request for audit purposes.
+#[utoipa::path(
+    delete,
+    path = "/v1/admin/events/contract/{contract_id}",
+    tag = "admin",
+    params(
+        ("contract_id" = String, Path, description = "Contract ID"),
+        ("anonymize_only" = Option<bool>, Query, description = "If true, anonymize instead of deleting (default: false)"),
+    ),
+    responses(
+        (status = 200, description = "Events deleted or anonymized"),
+        (status = 400, description = "Invalid contract_id", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+    )
+)]
+pub async fn delete_contract_events(
+    State(state): State<AppState>,
+    Path(contract_id): Path<String>,
+    axum::extract::Query(params): axum::extract::Query<std::collections::HashMap<String, String>>,
+    headers: axum::http::HeaderMap,
+) -> Result<Json<Value>, AppError> {
+    validate_contract_id(&contract_id)?;
+
+    let anonymize_only = params
+        .get("anonymize_only")
+        .and_then(|v| v.parse::<bool>().ok())
+        .unwrap_or(false);
+
+    let client_ip = headers
+        .get("x-forwarded-for")
+        .and_then(|h| h.to_str().ok())
+        .unwrap_or("unknown");
+
+    if anonymize_only {
+        // Anonymize: set anonymized=true and hash tx_hash
+        use sha2::{Digest, Sha256};
+
+        let rows = sqlx::query("SELECT id, tx_hash FROM events WHERE contract_id = $1 AND anonymized = FALSE")
+            .bind(&contract_id)
+            .fetch_all(&state.pool)
+            .await?;
+
+        let count = rows.len() as u64;
+
+        for row in rows {
+            let id: Uuid = row.try_get("id")?;
+            let tx_hash: String = row.try_get("tx_hash")?;
+            let hashed_tx = {
+                let mut h = Sha256::new();
+                h.update(tx_hash.as_bytes());
+                format!("{:x}", h.finalize())
+            };
+
+            sqlx::query("UPDATE events SET anonymized = TRUE, event_data = $1, tx_hash = $2 WHERE id = $3")
+                .bind(json!({"anonymized": true}))
+                .bind(&hashed_tx)
+                .bind(id)
+                .execute(&state.pool)
+                .await?;
+        }
+
+        tracing::info!(
+            contract_id = %contract_id,
+            count = count,
+            client_ip = client_ip,
+            timestamp = %chrono::Utc::now(),
+            "Events anonymized for contract (GDPR)"
+        );
+
+        crate::metrics::record_events_deleted(count);
+
+        Ok(Json(json!({
+            "contract_id": contract_id,
+            "action": "anonymized",
+            "count": count,
+        })))
+    } else {
+        // Hard delete
+        let result = sqlx::query("DELETE FROM events WHERE contract_id = $1")
+            .bind(&contract_id)
+            .execute(&state.pool)
+            .await?;
+
+        let count = result.rows_affected();
+
+        tracing::info!(
+            contract_id = %contract_id,
+            count = count,
+            client_ip = client_ip,
+            timestamp = %chrono::Utc::now(),
+            "Events deleted for contract (GDPR right-to-erasure)"
+        );
+
+        crate::metrics::record_events_deleted(count);
+
+        Ok(Json(json!({
+            "contract_id": contract_id,
+            "action": "deleted",
+            "count": count,
+        })))
+    }
+}
+
 /// Pause the indexer loop without stopping the HTTP server.
 #[utoipa::path(
     post,

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -2073,6 +2073,8 @@ pub struct RecentParams {
     pub limit: Option<i64>,
     pub event_type: Option<crate::models::EventType>,
     pub contract_id: Option<String>,
+    /// Cursor for pagination (opaque, URL-safe).
+    pub cursor: Option<String>,
     /// Not supported — returns 400 if provided.
     pub from_ledger: Option<i64>,
     /// Not supported — returns 400 if provided.
@@ -2087,6 +2089,7 @@ pub struct RecentParams {
         ("limit" = Option<i64>, Query, description = "Number of most-recent events to return, 1–100 (default: 20)"),
         ("event_type" = Option<crate::models::EventType>, Query, description = "Filter by event type: contract, diagnostic, system"),
         ("contract_id" = Option<String>, Query, description = "Filter by contract ID"),
+        ("cursor" = Option<String>, Query, description = "Cursor for pagination (opaque, URL-safe)"),
     ),
     responses(
         (status = 200, description = "Most recently indexed events in descending ledger order"),
@@ -2120,6 +2123,16 @@ pub async fn get_recent_events(
         bind_idx += 1;
     }
 
+    // Handle cursor-based pagination
+    if let Some(ref cursor_str) = params.cursor {
+        let (cursor_ledger, cursor_id) = decode_cursor(cursor_str)?;
+        conditions.push(format!(
+            "(ledger, id) < (${}, ${})",
+            bind_idx, bind_idx + 1
+        ));
+        bind_idx += 2;
+    }
+
     let where_clause = if conditions.is_empty() {
         String::new()
     } else {
@@ -2139,9 +2152,21 @@ pub async fn get_recent_events(
     if let Some(ref et) = params.event_type {
         q = q.bind(et);
     }
-    q = q.bind(limit);
+    if let Some(ref cursor_str) = params.cursor {
+        let (cursor_ledger, cursor_id) = decode_cursor(cursor_str)?;
+        q = q.bind(cursor_ledger);
+        q = q.bind(cursor_id);
+    }
+    q = q.bind(limit + 1); // Fetch one extra to determine if there's a next page
 
     let rows = q.fetch_all(&state.pool).await?;
+    let has_next = rows.len() > limit as usize;
+    let rows = if has_next {
+        &rows[..limit as usize]
+    } else {
+        &rows
+    };
+
     let events: Vec<Value> = rows
         .iter()
         .map(|e| {
@@ -2154,10 +2179,18 @@ pub async fn get_recent_events(
         })
         .collect();
 
-    Ok(Json(json!({
+    let mut response = json!({
         "data": events,
         "limit": limit,
-    })))
+    });
+
+    if has_next && !rows.is_empty() {
+        let last_event = &rows[rows.len() - 1];
+        let next_cursor = encode_cursor(last_event.ledger, last_event.id);
+        response["next_cursor"] = json!(next_cursor);
+    }
+
+    Ok(Json(response))
 }
 
 #[utoipa::path(

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -196,6 +196,11 @@ pub fn increment_events_pruned(count: u64) {
     m::counter!("soroban_pulse_events_pruned_total").increment(count);
 }
 
+/// Record events deleted (GDPR right-to-erasure)
+pub fn record_events_deleted(count: u64) {
+    m::counter!("soroban_pulse_events_deleted_total").increment(count);
+}
+
 /// Record HTTP request duration
 pub fn record_http_request_duration(
     duration: std::time::Duration,

--- a/src/models.rs
+++ b/src/models.rs
@@ -83,6 +83,8 @@ pub struct PaginationParams {
     /// Sort column: `ledger`, `timestamp`, or `created_at` (default: ledger)
     pub sort_by: Option<SortBy>,
     pub in_successful_call: Option<bool>,
+    /// Filter by Soroban protocol schema version.
+    pub schema_version: Option<i32>,
     /// Filter by the first topic symbol (uses topic_0_sym generated column index).
     pub topic_sym: Option<String>,
     /// Filter by topic array using JSONB containment (e.g., ?topic=["transfer"]).

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -314,6 +314,7 @@ pub fn create_router_with_tx_and_tenant_map(
         .route("/admin/reencrypt", axum::routing::post(handlers::start_reencrypt))
         .route("/admin/contracts/{contract_id}/abi", axum::routing::post(handlers::register_contract_abi))
         .route("/admin/events/{id}/anonymize", axum::routing::post(handlers::anonymize_event))
+        .route("/admin/events/contract/{contract_id}", axum::routing::delete(handlers::delete_contract_events))
         .route("/admin/indexer/pause", axum::routing::post(handlers::pause_indexer))
         .route("/admin/indexer/resume", axum::routing::post(handlers::resume_indexer))
         .route("/admin/contracts/{contract_id}/schema", axum::routing::post(handlers::register_contract_schema).get(handlers::get_contract_schema).delete(handlers::delete_contract_schema))


### PR DESCRIPTION
## Summary

This PR implements four enhancements to the SorobanPulse API for improved event filtering, pagination, and GDPR compliance.

## Changes

### Issue #433: Cursor-based Pagination for `/v1/events/recent`

**Problem:** The `/v1/events/recent` endpoint returned only the latest N events without pagination support, forcing clients needing more events to switch to the main `/v1/events` endpoint with different API contracts.

**Solution:**
- Added `cursor` parameter to `RecentParams` struct for opaque, URL-safe pagination
- Implemented cursor-based pagination using `(ledger, id)` tuple comparison for efficient keyset pagination
- Returns `next_cursor` field in response when additional results are available
- Fetches `limit+1` to determine if a next page exists without additional queries
- Updated OpenAPI documentation with cursor parameter

**Files Changed:**
- `src/handlers.rs`: Updated `RecentParams` struct and `get_recent_events` handler

### Issue #434: Filter Events by `in_successful_call` Field

**Status:** Already implemented. The filter was already present in the codebase:
- `in_successful_call: Option<bool>` field in `PaginationParams`
- Proper SQL filtering in both cursor-based and offset-based paths
- Correct parameter binding in `get_events` handler

This allows consumers to filter events from successful contract invocations, reducing response size and DB I/O by excluding diagnostic events from failed calls.

### Issue #435: Filter Events by `schema_version` Field

**Problem:** The `events` table has a `schema_version` column tracking the Soroban protocol version, but the API didn't expose a filter for this field. Consumers needing events from specific protocol versions had to filter client-side.

**Solution:**
- Added `schema_version: Option<i32>` field to `PaginationParams` struct
- Implemented SQL filtering in cursor-based pagination path with proper parameter binding
- Implemented SQL filtering in offset-based pagination path with proper parameter binding
- Field was already in the `ALLOWED_FIELDS` allowlist

**Files Changed:**
- `src/models.rs`: Added `schema_version` field to `PaginationParams`
- `src/handlers.rs`: Added filter conditions and parameter bindings in both pagination paths

### Issue #436: GDPR Right-to-Erasure Endpoint

**Problem:** While the service supported event anonymization, it lacked a hard deletion endpoint for GDPR Article 17 compliance. Data subjects requesting erasure required direct database access, bypassing audit logging.

**Solution:**
- Added `DELETE /v1/admin/events/contract/{contract_id}` endpoint
- Supports two deletion modes:
  - **Hard delete** (default): Permanently removes all events for the contract
  - **Soft delete** (`anonymize_only=true`): Sets `anonymized=true` and hashes `tx_hash` for privacy
- Comprehensive audit logging with:
  - Contract ID being deleted
  - Client IP address (from `x-forwarded-for` header)
  - Timestamp of deletion request
  - Action type (deleted vs anonymized)
- Added `soroban_pulse_events_deleted_total` counter metric for monitoring
- Contract ID validation before deletion
- JSON response includes action type and count of affected events

**Files Changed:**
- `src/handlers.rs`: Added `delete_contract_events` handler with audit logging
- `src/routes.rs`: Added DELETE route to v1 router
- `src/metrics.rs`: Added `record_events_deleted()` metric function

## API Endpoints

### New/Enhanced Endpoints

**GET /v1/events/recent** (Enhanced)

Query Parameters:
- limit: 1-100 (default: 20)
- event_type: contract|diagnostic|system
- contract_id: Filter by contract
- cursor: Pagination cursor (new)

Response:
{
 "data": [...],
 "limit": 20,
 "next_cursor": "opaque_cursor_string" // Present if more results available
}

**GET /v1/events** (Enhanced)

Query Parameters:
- schema_version: Filter by Soroban protocol version (new)
- in_successful_call: true|false (already supported)
- ... (other existing filters)

**DELETE /v1/admin/events/contract/{contract_id}** (New)

Query Parameters:
- anonymize_only: true|false (default: false)

Response:
{
 "contract_id": "CABC...",
 "action": "deleted" | "anonymized",
 "count": 1234
}

Audit Log Entry:
- contract_id
- action (deleted/anonymized)
- count of events affected
- client IP
- timestamp

## Testing

All changes maintain backward compatibility:
- Existing pagination parameters continue to work
- New filters are optional
- Deletion endpoint requires API key authentication (existing middleware)

## Metrics

New metric added:
- `soroban_pulse_events_deleted_total`: Counter for GDPR deletions/anonymizations

## Documentation

- OpenAPI spec updated with new parameters and endpoint
- Audit logging documented in code comments
- GDPR compliance procedure documented in handler

Closes #433
Closes #434
Closes #435
Closes #436
