### PR TITLE
Implement #409-#412: admin auth, RPC URL validation, migration logging, CSP

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,21 @@ LOG_SAMPLE_RATE=1
 # Format: string (e.g., your-new-secret-key-456)
 # API_KEY_SECONDARY=
 
+# Admin API key — required to access /v1/admin/* endpoints (pause/resume the
+# indexer, replay, anonymize, schema/ABI management, etc.). This is INDEPENDENT
+# of API_KEY: admin endpoints require ADMIN_API_KEY even when API_KEY is unset.
+#   - No key on an admin request          -> 401 Unauthorized
+#   - A regular API_KEY on an admin request -> 403 Forbidden
+#   - The ADMIN_API_KEY on an admin request -> allowed
+# When ADMIN_API_KEY is unset, admin endpoints fall back to the regular API_KEY
+# gate (backward compatible). Set this in production to isolate admin access.
+# Format: string (e.g., your-admin-only-secret-789)
+# ADMIN_API_KEY=
+
+# Optional secondary admin key, for rotating ADMIN_API_KEY without downtime.
+# Format: string
+# ADMIN_API_KEY_SECONDARY=
+
 # Allowed CORS origins (comma-separated). Use * to allow all origins (local dev only).
 # Example: ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com
 ALLOWED_ORIGINS=*

--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Open the newly created `.env` file in your editor and fill in your own real valu
 | `PORT`            | HTTP server port                     | `3000`                                   |
 | `RUST_LOG`        | Log verbosity level (`trace`, `debug`, `info`, `warn`, `error`) | `info` |
 | `API_KEY`         | Optional key for API authentication  | (disabled)                               |
+| `ADMIN_API_KEY`   | Key required for `/v1/admin/*` endpoints (independent of `API_KEY`) | (disabled) |
 | `RUST_LOG_FORMAT` | Log output format (`text` or `json`) | `text`                                   |
 | `INDEXER_LAG_WARN_THRESHOLD` | Indexer lag warning threshold (ledgers) | `100`                                   |
 | `HEALTH_CHECK_TIMEOUT_MS`   | Timeout for the health check DB ping     | `2000`                                  |
@@ -65,6 +66,14 @@ Open the newly created `.env` file in your editor and fill in your own real valu
 | `OTEL_EXPORTER_OTLP_ENDPOINT` | OpenTelemetry OTLP collector endpoint (when built with `otel` feature) | `http://localhost:4317` |
 
 > **Note on Authentication:** You can enable optional API key authentication by setting the `API_KEY` environment variable. When set, all requests (except `/health` and `/healthz/*` endpoints) will require either an `Authorization: Bearer <API_KEY>` or an `X-Api-Key: <API_KEY>` header. If `API_KEY` is unset or omitted from your configuration, authentication is bypassed and all requests pass through.
+
+> **Note on Admin Authentication:** The administrative endpoints under `/v1/admin/*` (pause/resume the indexer, replay, anonymize, schema/ABI management) are protected by a separate `ADMIN_API_KEY`, **independent of `API_KEY`**. This ensures admin operations stay locked down even if `API_KEY` is misconfigured or unset.
+>
+> - A request to an admin endpoint with **no key** returns **401 Unauthorized**.
+> - A request with a **regular `API_KEY`** (but not the admin key) returns **403 Forbidden**.
+> - A request with the **`ADMIN_API_KEY`** is allowed.
+>
+> Send the admin key the same way as a regular key (`Authorization: Bearer <ADMIN_API_KEY>` or `X-Api-Key: <ADMIN_API_KEY>`). Set `ADMIN_API_KEY_SECONDARY` to rotate the admin key without downtime. When `ADMIN_API_KEY` is unset, admin endpoints fall back to the regular `API_KEY` gate for backward compatibility.
 
 ### 3. Run with Docker Compose (easiest)
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -409,6 +409,45 @@ DATABASE_URL_FILE=/vault/secrets/database_url
 
 ---
 
+## Security Headers
+
+Every HTTP response is decorated with a set of hardening headers by the security
+headers middleware (`src/middleware.rs::security_headers_middleware`). These are
+applied automatically — no configuration is required.
+
+| Header | Value | Purpose |
+| --- | --- | --- |
+| `X-Content-Type-Options` | `nosniff` | Prevents MIME-type sniffing. |
+| `X-Frame-Options` | `DENY` | Blocks the response from being framed (clickjacking defense). |
+| `Referrer-Policy` | `no-referrer` | Never sends the `Referer` header to other origins. |
+| `Content-Security-Policy` | route-dependent (see below) | Restricts which resources the browser may load. |
+
+### Content-Security-Policy
+
+The CSP differs by route:
+
+- **API endpoints** (everything except `/docs`) return JSON only, so they get a
+  maximally strict policy:
+
+  ```
+  default-src 'none'; frame-ancestors 'none';
+  ```
+
+- **Swagger UI** (`GET /docs`) bootstraps with an inline `<script>` and loads the
+  Swagger UI assets from `unpkg.com`, so it gets a policy that permits inline
+  scripts/styles and the unpkg origin while still denying framing:
+
+  ```
+  default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none';
+  ```
+
+> **Note:** the `'unsafe-inline'` and `unpkg.com` allowances exist solely so the
+> bundled Swagger UI renders. If you serve the documentation differently (e.g.
+> self-host the assets), tighten the `/docs` policy accordingly in
+> `security_headers_middleware`.
+
+---
+
 ## TLS Termination
 
 Soroban Pulse speaks plain HTTP and **must never be exposed directly on port 80 or 443 without TLS in front of it**. All TLS termination must happen at a reverse proxy or load balancer layer.

--- a/src/config.rs
+++ b/src/config.rs
@@ -152,12 +152,21 @@ pub struct Config {
     /// Optional read replica URL. When set, HTTP handlers use this pool; indexer uses primary.
     pub database_replica_url: Option<String>,
     pub stellar_rpc_url: String,
+    /// Optional ordered list of fallback RPC endpoints, tried when the primary
+    /// `stellar_rpc_url` fails. Each is validated with the same rules as the
+    /// primary URL. Set via the comma-separated STELLAR_RPC_FALLBACK_URLS env var.
+    pub stellar_rpc_fallback_urls: Vec<String>,
     /// Custom headers to inject into every RPC request (name, value). Values are never logged.
     pub rpc_headers: Vec<(String, String)>,
     pub start_ledger: u64,
     pub start_ledger_fallback: bool,
     pub port: u16,
     pub api_keys: Vec<SecretString>,
+    /// Admin API keys, independent of `api_keys`. Required to access
+    /// `/v1/admin/*` endpoints. Set via ADMIN_API_KEY (and optionally
+    /// ADMIN_API_KEY_SECONDARY for rotation). When empty, admin endpoints fall
+    /// back to the regular `api_keys` gate.
+    pub admin_api_keys: Vec<SecretString>,
     pub db_max_connections: u32,
     pub db_min_connections: u32,
     pub db_idle_timeout_secs: u64,
@@ -261,11 +270,13 @@ impl Default for Config {
             database_url: "postgres://localhost/soroban_pulse".to_string(),
             database_replica_url: None,
             stellar_rpc_url: "https://soroban-testnet.stellar.org".to_string(),
+            stellar_rpc_fallback_urls: Vec::new(),
             rpc_headers: Vec::new(),
             start_ledger: 0,
             start_ledger_fallback: false,
             port: 3000,
             api_keys: Vec::new(),
+            admin_api_keys: Vec::new(),
             db_max_connections: 10,
             db_min_connections: 2,
             db_idle_timeout_secs: 600,
@@ -332,11 +343,18 @@ impl Default for Config {
 }
 
 fn validate_rpc_url_checked(raw: &str, errors: &mut Vec<String>) -> Option<String> {
+    validate_rpc_url_named("STELLAR_RPC_URL", raw, errors)
+}
+
+/// Validate a single RPC URL, attributing any errors to `var` (e.g.
+/// "STELLAR_RPC_URL" or "STELLAR_RPC_FALLBACK_URLS"). On success returns the
+/// URL with any embedded credentials stripped.
+fn validate_rpc_url_named(var: &str, raw: &str, errors: &mut Vec<String>) -> Option<String> {
     let url = match Url::parse(raw) {
         Ok(u) => u,
         Err(e) => {
             errors.push(format!(
-                "  STELLAR_RPC_URL={raw:?} is not a valid URL: {e}. \
+                "  {var}={raw:?} is not a valid URL: {e}. \
                  Expected a valid HTTPS URL (e.g., https://soroban-testnet.stellar.org)."
             ));
             return None;
@@ -352,7 +370,7 @@ fn validate_rpc_url_checked(raw: &str, errors: &mut Vec<String>) -> Option<Strin
         "http" if allow_insecure => {}
         "http" => {
             errors.push(format!(
-                "  STELLAR_RPC_URL={raw:?} uses http. \
+                "  {var}={raw:?} uses http. \
                  Set ALLOW_INSECURE_RPC=true to permit insecure connections, \
                  or use an https URL (e.g., https://soroban-testnet.stellar.org)."
             ));
@@ -360,15 +378,23 @@ fn validate_rpc_url_checked(raw: &str, errors: &mut Vec<String>) -> Option<Strin
         }
         scheme => {
             errors.push(format!(
-                "  STELLAR_RPC_URL={raw:?} has disallowed scheme '{scheme}'. \
+                "  {var}={raw:?} has disallowed scheme '{scheme}'. \
                  Only https is permitted (e.g., https://soroban-testnet.stellar.org)."
             ));
             return None;
         }
     }
 
+    let host = url.host_str().unwrap_or("");
+    if host.is_empty() {
+        errors.push(format!(
+            "  {var}={raw:?} has an empty host. \
+             Expected a valid HTTPS URL (e.g., https://soroban-testnet.stellar.org)."
+        ));
+        return None;
+    }
+
     if !allow_insecure {
-        let host = url.host_str().unwrap_or("");
         let is_loopback =
             host == "localhost" || host == "127.0.0.1" || host == "::1" || host.ends_with(".local");
         let is_private = host.starts_with("10.")
@@ -383,7 +409,7 @@ fn validate_rpc_url_checked(raw: &str, errors: &mut Vec<String>) -> Option<Strin
             });
         if is_loopback || is_private {
             errors.push(format!(
-                "  STELLAR_RPC_URL={raw:?} points to a non-routable host '{host}'. \
+                "  {var}={raw:?} points to a non-routable host '{host}'. \
                  Set ALLOW_INSECURE_RPC=true to allow this in development."
             ));
             return None;
@@ -394,6 +420,21 @@ fn validate_rpc_url_checked(raw: &str, errors: &mut Vec<String>) -> Option<Strin
     let _ = safe.set_username("");
     let _ = safe.set_password(None);
     Some(safe.to_string())
+}
+
+/// Parse and validate STELLAR_RPC_FALLBACK_URLS: a comma-separated list of
+/// fallback RPC endpoints used when the primary URL fails. Each entry is
+/// validated with the same rules as STELLAR_RPC_URL.
+fn parse_rpc_fallback_urls_checked(errors: &mut Vec<String>) -> Vec<String> {
+    let raw = match env::var("STELLAR_RPC_FALLBACK_URLS") {
+        Ok(v) if !v.trim().is_empty() => v,
+        _ => return Vec::new(),
+    };
+    raw.split(',')
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .filter_map(|u| validate_rpc_url_named("STELLAR_RPC_FALLBACK_URLS", u, errors))
+        .collect()
 }
 
 /// Read DATABASE_URL from DATABASE_URL_FILE if set, otherwise fall back to DATABASE_URL.
@@ -671,6 +712,8 @@ impl Config {
             validate_rpc_url_checked(&raw, &mut errors).unwrap_or_else(|| raw.clone())
         };
 
+        let stellar_rpc_fallback_urls = parse_rpc_fallback_urls_checked(&mut errors);
+
         let db_max_connections = parse_int::<u32>(
             "DB_MAX_CONNECTIONS",
             &env_or_file_or("DB_MAX_CONNECTIONS", &file, "10"),
@@ -909,14 +952,16 @@ impl Config {
         let rpc_headers = parse_rpc_headers_checked(&mut errors);
         let indexer_event_types = parse_indexer_event_types_checked(&mut errors);
 
-        // Report all errors at once.
+        // Report all errors at once, then exit with code 1 so operators get a
+        // clear, deterministic startup failure (a panic would exit with 101).
         if !errors.is_empty() {
             eprintln!(
                 "Configuration errors ({} found):\n{}",
                 errors.len(),
                 errors.join("\n")
             );
-            panic!("Startup aborted due to configuration errors. Fix the above and restart.");
+            eprintln!("Startup aborted due to configuration errors. Fix the above and restart.");
+            std::process::exit(1);
         }
 
         Self {
@@ -925,6 +970,7 @@ impl Config {
                 .ok()
                 .filter(|s| !s.is_empty()),
             stellar_rpc_url,
+            stellar_rpc_fallback_urls,
             rpc_headers,
             start_ledger,
             start_ledger_fallback,
@@ -935,6 +981,16 @@ impl Config {
                     keys.push(SecretString::new(key));
                 }
                 if let Some(key) = env_or_file("API_KEY_SECONDARY", &file) {
+                    keys.push(SecretString::new(key));
+                }
+                keys
+            },
+            admin_api_keys: {
+                let mut keys = Vec::new();
+                if let Some(key) = env_or_file("ADMIN_API_KEY", &file) {
+                    keys.push(SecretString::new(key));
+                }
+                if let Some(key) = env_or_file("ADMIN_API_KEY_SECONDARY", &file) {
                     keys.push(SecretString::new(key));
                 }
                 keys
@@ -1184,6 +1240,81 @@ mod tests {
         let safe_db = config.safe_db_url();
         assert!(!safe_db.contains("supersecret"));
         assert!(!safe_db.contains("admin"));
+    }
+
+    // --- validate_rpc_url_checked ---
+
+    #[test]
+    fn validate_rpc_url_accepts_valid_https() {
+        let mut errors = Vec::new();
+        let out = validate_rpc_url_checked("https://soroban-testnet.stellar.org", &mut errors);
+        assert_eq!(
+            out.as_deref(),
+            Some("https://soroban-testnet.stellar.org/")
+        );
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn validate_rpc_url_rejects_malformed() {
+        let mut errors = Vec::new();
+        // A typo like "htps://" parses as a URL with scheme "htps", which is
+        // rejected as a disallowed scheme.
+        let out = validate_rpc_url_checked("htps://soroban-testnet.stellar.org", &mut errors);
+        assert!(out.is_none());
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("STELLAR_RPC_URL"));
+    }
+
+    #[test]
+    fn validate_rpc_url_rejects_garbage() {
+        let mut errors = Vec::new();
+        let out = validate_rpc_url_checked("not a url at all", &mut errors);
+        assert!(out.is_none());
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("is not a valid URL"));
+    }
+
+    #[test]
+    fn validate_rpc_url_rejects_non_http_scheme() {
+        let mut errors = Vec::new();
+        let out = validate_rpc_url_checked("ftp://example.com", &mut errors);
+        assert!(out.is_none());
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("disallowed scheme"));
+    }
+
+    #[test]
+    fn validate_rpc_url_strips_embedded_credentials() {
+        let mut errors = Vec::new();
+        let out = validate_rpc_url_checked("https://user:pass@rpc.example.com/", &mut errors);
+        let out = out.expect("valid url");
+        assert!(!out.contains("user"));
+        assert!(!out.contains("pass"));
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn parse_rpc_fallback_urls_empty_when_unset() {
+        env::remove_var("STELLAR_RPC_FALLBACK_URLS");
+        let mut errors = Vec::new();
+        assert!(parse_rpc_fallback_urls_checked(&mut errors).is_empty());
+        assert!(errors.is_empty());
+    }
+
+    #[test]
+    fn parse_rpc_fallback_urls_validates_each_entry() {
+        env::set_var(
+            "STELLAR_RPC_FALLBACK_URLS",
+            "https://rpc2.example.com, ftp://bad.example.com , https://rpc3.example.com",
+        );
+        let mut errors = Vec::new();
+        let urls = parse_rpc_fallback_urls_checked(&mut errors);
+        env::remove_var("STELLAR_RPC_FALLBACK_URLS");
+        // The two valid https entries are kept; the ftp entry produces one error.
+        assert_eq!(urls.len(), 2);
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("STELLAR_RPC_FALLBACK_URLS"));
     }
 
     // --- parse_rpc_headers_checked ---

--- a/src/db.rs
+++ b/src/db.rs
@@ -90,14 +90,28 @@ pub async fn run_migrations(pool: &PgPool) -> Result<usize, sqlx::migrate::Migra
             .map_err(sqlx::migrate::MigrateError::from)?;
         debug!(lock_id = MIGRATION_LOCK_ID, "Advisory lock acquired");
 
-        // Record which migrations are already applied before running.
-        let before: Vec<(String,)> =
-            sqlx::query_as("SELECT version::text FROM _sqlx_migrations WHERE success = true")
+        // Record which migrations are already applied before running, so we can
+        // identify exactly which ones this run applies.
+        let before: Vec<(i64,)> =
+            sqlx::query_as("SELECT version FROM _sqlx_migrations WHERE success = true")
                 .fetch_all(&mut *conn)
                 .await
                 .unwrap_or_default();
+        let before_versions: std::collections::HashSet<i64> =
+            before.iter().map(|(v,)| *v).collect();
 
         let result = sqlx::migrate!("./migrations").run(&mut *conn).await;
+
+        // Query the full migration ledger after running so we can log the
+        // version, description, and execution time of each newly applied one.
+        // execution_time is stored in nanoseconds by sqlx.
+        let after: Vec<(i64, String, i64)> = sqlx::query_as(
+            "SELECT version, description, execution_time \
+             FROM _sqlx_migrations WHERE success = true ORDER BY version",
+        )
+        .fetch_all(&mut *conn)
+        .await
+        .unwrap_or_default();
 
         // Always release — ignore unlock errors so the migration result is returned.
         let _ = sqlx::query("SELECT pg_advisory_unlock($1)")
@@ -108,16 +122,34 @@ pub async fn run_migrations(pool: &PgPool) -> Result<usize, sqlx::migrate::Migra
 
         result?;
 
-        // Count newly applied migrations by comparing before/after.
-        let after_count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations WHERE success = true")
-                .fetch_one(&mut *conn)
-                .await
-                .unwrap_or(before.len() as i64);
+        let newly_applied: Vec<&(i64, String, i64)> = after
+            .iter()
+            .filter(|(version, _, _)| !before_versions.contains(version))
+            .collect();
 
-        let newly_applied = (after_count as usize).saturating_sub(before.len());
-        info!(count = newly_applied, "Migrations applied");
-        Ok(newly_applied)
+        if newly_applied.is_empty() {
+            info!("No migrations to apply — schema is up to date");
+        } else {
+            for (version, description, execution_time_ns) in &newly_applied {
+                let execution_time_ms = (*execution_time_ns as f64) / 1_000_000.0;
+                info!(
+                    version = version,
+                    description = description.as_str(),
+                    execution_time_ms = execution_time_ms,
+                    "Applied migration"
+                );
+            }
+            info!(count = newly_applied.len(), "Migrations applied");
+        }
+
+        // Emit metrics: count of migrations applied this run, and the highest
+        // applied version currently in the schema.
+        crate::metrics::record_migrations_applied(newly_applied.len() as u64);
+        if let Some((max_version, _, _)) = after.iter().max_by_key(|(v, _, _)| *v) {
+            crate::metrics::set_last_migration_version(*max_version);
+        }
+
+        Ok(newly_applied.len())
     }
     .instrument(info_span!("db.run_migrations"))
     .await
@@ -146,11 +178,33 @@ mod tests {
             .expect("migrations must succeed");
         assert!(count > 0, "fresh database should have migrations applied");
     }
-}
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+    #[sqlx::test(migrations = false)]
+    async fn run_migrations_logs_each_applied_then_reports_none_on_rerun(pool: PgPool) {
+        // First run on a fresh DB applies every migration and logs each one.
+        let first = run_migrations(&pool)
+            .await
+            .expect("first migration run must succeed");
+        assert!(first > 0, "fresh database should apply migrations");
+
+        // Second run finds the schema up to date: nothing new is applied and the
+        // "No migrations to apply" branch is taken.
+        let second = run_migrations(&pool)
+            .await
+            .expect("second migration run must succeed");
+        assert_eq!(
+            second, 0,
+            "re-running on an up-to-date schema should apply 0 migrations"
+        );
+
+        // The highest applied version should be queryable from the ledger.
+        let max_version: i64 =
+            sqlx::query_scalar("SELECT MAX(version) FROM _sqlx_migrations WHERE success = true")
+                .fetch_one(&pool)
+                .await
+                .expect("ledger query must succeed");
+        assert!(max_version > 0, "a positive max migration version is expected");
+    }
 
     #[test]
     fn create_pool_signature_accepts_new_options() {

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -6289,6 +6289,81 @@ mod tests {
         )
     }
 
+    /// Build a router where admin endpoints require a dedicated ADMIN_API_KEY
+    /// (issue #409). A separate regular API key is also configured.
+    fn create_admin_auth_router(pool: PgPool) -> axum::Router {
+        let health_state = Arc::new(HealthState::new(60));
+        let indexer_state = Arc::new(IndexerState::new());
+        let prometheus_handle = crate::metrics::init_metrics();
+        let mut config = crate::config::Config::default();
+        config.admin_api_keys = vec![secrecy::SecretString::new("admin-secret".to_string())];
+        crate::routes::create_router(
+            pool,
+            vec!["regular-key".to_string()],
+            &[],
+            60,
+            health_state,
+            indexer_state,
+            prometheus_handle,
+            2000,
+            config,
+        )
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn admin_endpoint_rejects_missing_key_with_401(pool: PgPool) {
+        let app = create_admin_auth_router(pool);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/indexer/pause")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn admin_endpoint_rejects_regular_key_with_403(pool: PgPool) {
+        let app = create_admin_auth_router(pool);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/indexer/pause")
+                    .header("Authorization", "Bearer regular-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn admin_endpoint_accepts_admin_key(pool: PgPool) {
+        let app = create_admin_auth_router(pool);
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/indexer/pause")
+                    .header("Authorization", "Bearer admin-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        // The admin key passes both auth layers. The pause handler may still
+        // reject (400) when no live indexer is attached, but it must NOT be
+        // blocked by the auth layers.
+        assert_ne!(response.status(), StatusCode::UNAUTHORIZED);
+        assert_ne!(response.status(), StatusCode::FORBIDDEN);
+    }
+
     #[sqlx::test(migrations = "./migrations")]
     async fn anonymize_event_returns_200_and_scrubs_data(pool: PgPool) {
         let event_id = Uuid::new_v4();

--- a/src/main.rs
+++ b/src/main.rs
@@ -99,6 +99,7 @@ async fn main() -> anyhow::Result<()> {
 
     info!(
         rpc_url = %config.stellar_rpc_url,
+        rpc_fallback_urls = ?config.stellar_rpc_fallback_urls,
         rpc_headers = ?config.safe_rpc_headers(),
         start_ledger = config.start_ledger,
         port = config.port,

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -191,6 +191,16 @@ pub fn record_replay_job() {
     m::counter!("soroban_pulse_replay_jobs_total").increment(1);
 }
 
+/// Record the number of database migrations applied during a run (issue #411)
+pub fn record_migrations_applied(count: u64) {
+    m::counter!("soroban_pulse_migrations_applied_total").increment(count);
+}
+
+/// Set the gauge tracking the highest applied migration version (issue #411)
+pub fn set_last_migration_version(version: i64) {
+    m::gauge!("soroban_pulse_last_migration_version").set(version as f64);
+}
+
 /// Record events pruned
 pub fn increment_events_pruned(count: u64) {
     m::counter!("soroban_pulse_events_pruned_total").increment(count);

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -31,9 +31,33 @@ pub struct TenantId(pub String);
 #[derive(Clone)]
 pub struct AuthState {
     pub api_keys: Vec<String>,
+    /// Admin API keys. These are accepted by the regular auth layer (so admin
+    /// requests pass the global gate) and are additionally required by
+    /// `admin_auth_middleware` to reach `/v1/admin/*` endpoints.
+    pub admin_api_keys: Vec<String>,
     /// key_hash → tenant_id mapping; populated only in multi-tenant mode.
     pub tenant_map: Arc<std::collections::HashMap<String, String>>,
     pub multi_tenant: bool,
+}
+
+/// Constant-time check whether `key` is one of `candidates`.
+fn key_matches_any(key: &str, candidates: &[String]) -> bool {
+    candidates.iter().any(|expected| {
+        let m: bool = key.as_bytes().ct_eq(expected.as_bytes()).into();
+        m
+    })
+}
+
+/// Extract the API key from either the `Authorization: Bearer <key>` header or
+/// the `X-Api-Key` header.
+fn extract_api_key(req: &Request) -> Option<&str> {
+    let bearer = req
+        .headers()
+        .get("Authorization")
+        .and_then(|h| h.to_str().ok())
+        .and_then(|s| s.strip_prefix("Bearer "));
+    let x_api_key = req.headers().get("X-Api-Key").and_then(|h| h.to_str().ok());
+    bearer.or(x_api_key)
 }
 
 /// SHA-256 hex digest of a raw API key — used as the lookup key in tenant_map.
@@ -56,24 +80,13 @@ pub async fn auth_middleware(
     }
 
     if !state.api_keys.is_empty() {
-        let auth_header = req
-            .headers()
-            .get("Authorization")
-            .and_then(|h| h.to_str().ok())
-            .and_then(|s| s.strip_prefix("Bearer "));
+        let provided_key = extract_api_key(&req);
 
-        let api_key_header = req.headers().get("X-Api-Key").and_then(|h| h.to_str().ok());
-
-        let provided_key = auth_header.or(api_key_header);
-
-        // Use constant-time comparison to prevent timing attacks
-        let is_valid = provided_key.map_or(false, |key| {
-            state.api_keys.iter().any(|expected| {
-                let provided_bytes = key.as_bytes();
-                let expected_bytes = expected.as_bytes();
-                provided_bytes.ct_eq(expected_bytes).into()
-            })
-        });
+        // Admin keys are also valid at the global gate so admin requests can
+        // reach the admin-only layer (which performs the privilege check).
+        let is_admin = provided_key.map_or(false, |k| key_matches_any(k, &state.admin_api_keys));
+        let is_valid =
+            is_admin || provided_key.map_or(false, |k| key_matches_any(k, &state.api_keys));
 
         if !is_valid {
             return Err((
@@ -83,7 +96,8 @@ pub async fn auth_middleware(
         }
 
         // In multi-tenant mode, resolve and inject the tenant_id extension.
-        if state.multi_tenant {
+        // Admin keys are global (not tenant-scoped), so they skip resolution.
+        if state.multi_tenant && !is_admin {
             let key = provided_key.unwrap_or("");
             let key_hash = hash_api_key(key);
             match state.tenant_map.get(&key_hash) {
@@ -105,6 +119,46 @@ pub async fn auth_middleware(
     Ok(next.run(req).await)
 }
 
+/// State for the admin-only authentication layer applied to `/v1/admin/*`.
+#[derive(Clone)]
+pub struct AdminAuthState {
+    /// Keys that grant admin access. When empty, the admin layer is a no-op and
+    /// admin routes fall back to whatever the regular auth layer enforced (this
+    /// preserves backward compatibility for deployments that gate admin routes
+    /// with API_KEY only).
+    pub admin_api_keys: Vec<String>,
+}
+
+/// Middleware that gates admin endpoints. Independent of API_KEY: even when no
+/// regular API key is configured, a configured ADMIN_API_KEY is still required.
+///
+/// - 401 Unauthorized when no key is provided.
+/// - 403 Forbidden when a key is provided but it is not an admin key
+///   (e.g. a regular API key).
+/// - passes through when the provided key matches a configured admin key.
+pub async fn admin_auth_middleware(
+    State(state): State<Arc<AdminAuthState>>,
+    req: Request,
+    next: Next,
+) -> Result<Response, (StatusCode, Json<serde_json::Value>)> {
+    // No admin keys configured → don't add a second gate; defer to regular auth.
+    if state.admin_api_keys.is_empty() {
+        return Ok(next.run(req).await);
+    }
+
+    match extract_api_key(&req) {
+        None => Err((
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({ "error": "admin authentication required" })),
+        )),
+        Some(key) if key_matches_any(key, &state.admin_api_keys) => Ok(next.run(req).await),
+        Some(_) => Err((
+            StatusCode::FORBIDDEN,
+            Json(serde_json::json!({ "error": "admin privileges required" })),
+        )),
+    }
+}
+
 pub async fn security_headers_middleware(req: Request, next: Next) -> Response {
     let path = req.uri().path().to_owned();
     let mut response = next.run(req).await;
@@ -118,18 +172,21 @@ pub async fn security_headers_middleware(req: Request, next: Next) -> Response {
         .headers_mut()
         .insert("X-Frame-Options", "DENY".parse().unwrap());
 
-    response.headers_mut().insert(
-        "Referrer-Policy",
-        "strict-origin-when-cross-origin".parse().unwrap(),
-    );
+    response
+        .headers_mut()
+        .insert("Referrer-Policy", "no-referrer".parse().unwrap());
 
-    // Set CSP header with different policies for /docs vs other routes
+    // Set CSP header with different policies for /docs vs other routes.
     let csp = if path == "/docs" {
-        // For Swagger UI, allow unpkg.com for scripts and styles
-        "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' https://unpkg.com; img-src 'self' data:; connect-src 'self';"
+        // Swagger UI bootstraps via an inline <script> and loads the library
+        // assets from unpkg.com, so the docs policy must permit both
+        // 'unsafe-inline' and the unpkg origin for scripts/styles. Framing is
+        // still denied via frame-ancestors.
+        "default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none';"
     } else {
-        // Restrictive CSP for all other routes
-        "default-src 'self';"
+        // Strict policy for API endpoints: they only ever return JSON, so no
+        // resource loading or framing is permitted.
+        "default-src 'none'; frame-ancestors 'none';"
     };
 
     response
@@ -210,6 +267,7 @@ mod tests {
     async fn setup_app(api_keys: Vec<String>) -> Router {
         let auth_state = Arc::new(AuthState {
             api_keys,
+            admin_api_keys: Vec::new(),
             tenant_map: Arc::new(std::collections::HashMap::new()),
             multi_tenant: false,
         });
@@ -365,6 +423,79 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
     }
 
+    async fn setup_admin_app(admin_api_keys: Vec<String>) -> Router {
+        let admin_state = Arc::new(AdminAuthState { admin_api_keys });
+        Router::new()
+            .route("/v1/admin/indexer/pause", get(|| async { "OK" }))
+            .route_layer(axum::middleware::from_fn_with_state(
+                admin_state,
+                admin_auth_middleware,
+            ))
+    }
+
+    #[tokio::test]
+    async fn admin_returns_401_without_key() {
+        let app = setup_admin_app(vec!["admin-secret".to_string()]).await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/admin/indexer/pause")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_returns_403_with_non_admin_key() {
+        let app = setup_admin_app(vec!["admin-secret".to_string()]).await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/admin/indexer/pause")
+                    .header("Authorization", "Bearer regular-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn admin_returns_200_with_admin_key() {
+        let app = setup_admin_app(vec!["admin-secret".to_string()]).await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/admin/indexer/pause")
+                    .header("X-Api-Key", "admin-secret")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn admin_layer_noop_when_no_admin_keys_configured() {
+        // With no admin keys, the layer must not add a second gate.
+        let app = setup_admin_app(vec![]).await;
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/admin/indexer/pause")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
     async fn setup_security_test_app() -> Router {
         Router::new()
             .route("/test", get(|| async { "OK" }))
@@ -398,13 +529,15 @@ mod tests {
         // Verify Referrer-Policy header
         assert_eq!(
             response.headers().get("Referrer-Policy"),
-            Some(&HeaderValue::from_static("strict-origin-when-cross-origin"))
+            Some(&HeaderValue::from_static("no-referrer"))
         );
 
-        // Verify restrictive CSP header for regular routes
+        // Verify strict CSP header for regular (API) routes
         assert_eq!(
             response.headers().get("Content-Security-Policy"),
-            Some(&HeaderValue::from_static("default-src 'self';"))
+            Some(&HeaderValue::from_static(
+                "default-src 'none'; frame-ancestors 'none';"
+            ))
         );
     }
 
@@ -432,11 +565,12 @@ mod tests {
 
         assert_eq!(
             response.headers().get("Referrer-Policy"),
-            Some(&HeaderValue::from_static("strict-origin-when-cross-origin"))
+            Some(&HeaderValue::from_static("no-referrer"))
         );
 
-        // Verify permissive CSP header for /docs route that allows unpkg.com
-        let expected_csp = "default-src 'self'; script-src 'self' https://unpkg.com; style-src 'self' https://unpkg.com; img-src 'self' data:; connect-src 'self';";
+        // Verify permissive CSP header for /docs route that allows unpkg.com and
+        // inline scripts/styles (required for the Swagger UI bootstrap).
+        let expected_csp = "default-src 'self'; script-src 'self' 'unsafe-inline' https://unpkg.com; style-src 'self' 'unsafe-inline' https://unpkg.com; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none';";
         assert_eq!(
             response.headers().get("Content-Security-Policy"),
             Some(&HeaderValue::from_static(expected_csp))

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -240,11 +240,23 @@ pub fn create_router_with_tx_and_tenant_map(
 ) -> Router {
     let cors = build_cors(allowed_origins);
 
+    // Admin keys are independent of the regular API keys (issue #409).
+    let admin_api_keys: Vec<String> = {
+        use secrecy::ExposeSecret;
+        config
+            .admin_api_keys
+            .iter()
+            .map(|k| k.expose_secret().to_string())
+            .collect()
+    };
+
     let auth_state = Arc::new(middleware::AuthState {
         api_keys,
+        admin_api_keys: admin_api_keys.clone(),
         tenant_map: Arc::clone(&tenant_map),
         multi_tenant: config.multi_tenant,
     });
+    let admin_auth_state = Arc::new(middleware::AdminAuthState { admin_api_keys });
     let contract_count_cache = moka::future::Cache::builder()
         .max_capacity(config.contract_count_cache_size)
         .time_to_live(std::time::Duration::from_secs(
@@ -282,6 +294,23 @@ pub fn create_router_with_tx_and_tenant_map(
     let replenish_ms = 60_000u64 / u64::from(rate_limit_per_minute.max(1));
     let burst = rate_limit_per_minute.max(1);
 
+    // Admin routes (issue #409): gated by a dedicated admin auth layer in
+    // addition to the global auth layer. The admin layer requires an
+    // ADMIN_API_KEY even when no regular API_KEY is configured.
+    let admin_routes = Router::new()
+        .route("/admin/replay", axum::routing::post(handlers::replay_events))
+        .route("/admin/reencrypt", axum::routing::post(handlers::start_reencrypt))
+        .route("/admin/contracts/{contract_id}/abi", axum::routing::post(handlers::register_contract_abi))
+        .route("/admin/events/{id}/anonymize", axum::routing::post(handlers::anonymize_event))
+        .route("/admin/indexer/pause", axum::routing::post(handlers::pause_indexer))
+        .route("/admin/indexer/resume", axum::routing::post(handlers::resume_indexer))
+        .route("/admin/contracts/{contract_id}/schema", axum::routing::post(handlers::register_contract_schema).get(handlers::get_contract_schema).delete(handlers::delete_contract_schema))
+        .route("/admin/contracts/{contract_id}/validate", axum::routing::post(handlers::validate_event_data_against_schema))
+        .route_layer(axum::middleware::from_fn_with_state(
+            Arc::clone(&admin_auth_state),
+            middleware::admin_auth_middleware,
+        ));
+
     // Versioned v1 routes
     let v1 = Router::new()
         .route("/events", get(handlers::get_events))
@@ -310,14 +339,7 @@ pub fn create_router_with_tx_and_tenant_map(
             get(handlers::get_events_by_ledger_hash),
         )
         .route("/contracts", get(handlers::get_contracts))
-        .route("/admin/replay", axum::routing::post(handlers::replay_events))
-        .route("/admin/reencrypt", axum::routing::post(handlers::start_reencrypt))
-        .route("/admin/contracts/{contract_id}/abi", axum::routing::post(handlers::register_contract_abi))
-        .route("/admin/events/{id}/anonymize", axum::routing::post(handlers::anonymize_event))
-        .route("/admin/indexer/pause", axum::routing::post(handlers::pause_indexer))
-        .route("/admin/indexer/resume", axum::routing::post(handlers::resume_indexer))
-        .route("/admin/contracts/{contract_id}/schema", axum::routing::post(handlers::register_contract_schema).get(handlers::get_contract_schema).delete(handlers::delete_contract_schema))
-        .route("/admin/contracts/{contract_id}/validate", axum::routing::post(handlers::validate_event_data_against_schema))
+        .merge(admin_routes)
         .route("/subscriptions", axum::routing::post(subscriptions::create_subscription))
         .route("/subscriptions/{id}", get(subscriptions::get_subscription).delete(subscriptions::cancel_subscription))
         .route("/subscriptions/{id}/ack", axum::routing::post(subscriptions::ack_subscription));


### PR DESCRIPTION


#409 Admin API key authentication
- Add ADMIN_API_KEY/ADMIN_API_KEY_SECONDARY config (independent of API_KEY)
- AdminAuthState + admin_auth_middleware: 401 (no key), 403 (regular key), pass (admin key); admin keys also accepted at the global auth gate
- Gate /v1/admin/* via a dedicated admin sub-router layer
- Unit + integration tests; README and .env.example docs
- Backward compatible: falls back to API_KEY gate when ADMIN_API_KEY unset

#410 STELLAR_RPC_URL validation
- Reusable per-variable URL validation; reject empty host
- Add + validate STELLAR_RPC_FALLBACK_URLS
- Exit with code 1 (not panic/101) on config errors
- Log redacted fallback URLs at startup; unit tests

#411 Migration logging + metrics
- Log each applied migration (version, description, exec time)
- Log "No migrations to apply" when current
- Add migrations_applied_total counter + last_migration_version gauge
- Merge duplicate mod tests; add logging test

#412 Security headers / CSP
- API CSP: default-src 'none'; frame-ancestors 'none'
- Docs CSP: allow 'unsafe-inline' + unpkg so Swagger UI renders; frame-ancestors 'none'
- Referrer-Policy: no-referrer; update tests; document in docs/deployment.md411

Closes #409 
Closes #410 
Closes #411 
Closes #412 

