### PR TITLE
Issue #425: Add structured log summary at end of each poll cycle

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -253,6 +253,8 @@ pub struct Config {
     pub sse_replay_limit: u64,
     // Issue #396: Indexer checkpoint persistence
     pub indexer_ignore_checkpoint: bool,
+    // Issue #426: Maximum events per RPC page
+    pub rpc_max_events_per_page: usize,
 }
 
 impl Default for Config {
@@ -327,6 +329,7 @@ impl Default for Config {
             pruning_interval_hours: 24,
             sse_replay_limit: 500,
             indexer_ignore_checkpoint: false,
+            rpc_max_events_per_page: 200,
         }
     }
 }
@@ -1055,6 +1058,16 @@ impl Config {
                 &mut errors,
             )
             .unwrap_or(100_000),
+            indexer_ignore_checkpoint: env_or_file("INDEXER_IGNORE_CHECKPOINT", &file)
+                .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "y"))
+                .unwrap_or(false),
+            rpc_max_events_per_page: parse_int::<usize>(
+                "RPC_MAX_EVENTS_PER_PAGE",
+                &env_or_file_or("RPC_MAX_EVENTS_PER_PAGE", &file, "200"),
+                "200",
+                &mut errors,
+            )
+            .unwrap_or(200),
         }
     }
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -449,6 +449,7 @@ impl<R: RpcClient> Indexer<R> {
         let retry_interval = Duration::from_secs(self.config.indexer_lock_retry_secs.max(1));
         let mut interval = tokio::time::interval(retry_interval);
         interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let lock_wait_start = std::time::Instant::now();
 
         loop {
             // Respect shutdown signal while waiting to acquire the lock.
@@ -471,16 +472,36 @@ impl<R: RpcClient> Indexer<R> {
                 .unwrap_or(false);
 
             if acquired {
-                info!("Indexer lock acquired, starting indexing");
+                info!(
+                    lock_key = INDEXER_LOCK_KEY,
+                    "Indexer lock acquired, starting indexing"
+                );
                 if let Some(ref s) = self.indexer_state {
                     s.is_active_indexer.store(true, Ordering::Relaxed);
                 }
                 metrics::record_indexer_is_leader(true);
+                metrics::update_indexer_lock_wait_duration(0.0);
                 break;
             }
 
+            // Issue #427: Query pg_locks to find current lock holder's PID
+            let lock_holder_pid: Option<i32> = sqlx::query_scalar(
+                "SELECT pid FROM pg_locks WHERE locktype = 'advisory' AND database = (SELECT oid FROM pg_database WHERE datname = current_database()) AND objid = $1 LIMIT 1"
+            )
+            .bind(INDEXER_LOCK_KEY as i32)
+            .fetch_optional(&self.pool)
+            .await
+            .ok()
+            .flatten();
+
+            let lock_wait_secs = lock_wait_start.elapsed().as_secs_f64();
+            metrics::update_indexer_lock_wait_duration(lock_wait_secs);
+
             warn!(
+                lock_key = INDEXER_LOCK_KEY,
+                lock_holder_pid = lock_holder_pid,
                 retry_secs = self.config.indexer_lock_retry_secs,
+                wait_secs = lock_wait_secs,
                 "Indexer lock not acquired, running in standby mode — will retry"
             );
             if let Some(ref s) = self.indexer_state {
@@ -725,7 +746,9 @@ impl<R: RpcClient> Indexer<R> {
         let mut latest_ledger = start_ledger;
         let mut total_fetched = 0;
         let mut total_inserted = 0;
-        let mut total_skipped = 0;
+        let mut total_skipped_duplicate = 0;
+        let mut total_skipped_validation = 0;
+        let mut total_skipped_out_of_order = 0;
         let mut total_pages = 0u32;
         let mut total_rpc_ms = 0u128;
         let mut total_db_ms = 0u128;
@@ -740,7 +763,7 @@ impl<R: RpcClient> Indexer<R> {
 
         loop {
             let rpc_start = std::time::Instant::now();
-            let result = match self
+            let mut result = match self
                 .rpc_client
                 .get_events(
                     &self.config.stellar_rpc_url,
@@ -760,6 +783,18 @@ impl<R: RpcClient> Indexer<R> {
             total_rpc_ms += rpc_start.elapsed().as_millis();
             total_pages += 1;
 
+            // Issue #426: Validate RPC response doesn't exceed max page size
+            let requested_limit = self.config.rpc_max_events_per_page;
+            if result.events.len() > requested_limit {
+                warn!(
+                    actual = result.events.len(),
+                    expected = requested_limit,
+                    "RPC response exceeded requested page size, truncating"
+                );
+                metrics::record_oversized_rpc_response();
+                result.events.truncate(requested_limit);
+            }
+
             latest_ledger = result.latest_ledger;
             let current_count = result.events.len();
             total_fetched += current_count;
@@ -770,6 +805,20 @@ impl<R: RpcClient> Indexer<R> {
             let mut db_tx = self.pool.begin().await?;
             let db_start = std::time::Instant::now();
             for event in result.events {
+                // Issue #428: Validate ledger sequence is monotonically increasing
+                if event.ledger < start_ledger {
+                    warn!(
+                        event_ledger = event.ledger,
+                        current_cursor = start_ledger,
+                        tx_hash = %event.tx_hash,
+                        contract_id = %event.contract_id,
+                        "Out-of-order event: ledger sequence below current cursor, skipping"
+                    );
+                    metrics::record_out_of_order_events(1);
+                    total_skipped_out_of_order += 1;
+                    continue;
+                }
+
                 // Apply Lua transformation if configured
                 #[cfg(feature = "lua")]
                 let event = if let Some(ref transformer) = self.lua_transformer {
@@ -777,7 +826,7 @@ impl<R: RpcClient> Indexer<R> {
                         Ok(Some(transformed)) => transformed,
                         Ok(None) => {
                             // Script returned nil, skip this event
-                            total_skipped += 1;
+                            total_skipped_validation += 1;
                             continue;
                         }
                         Err(e) => {
@@ -785,7 +834,7 @@ impl<R: RpcClient> Indexer<R> {
                                 error = %e,
                                 "Lua transformation failed, skipping event"
                             );
-                            total_skipped += 1;
+                            total_skipped_validation += 1;
                             continue;
                         }
                     }
@@ -800,7 +849,7 @@ impl<R: RpcClient> Indexer<R> {
                     Ok(rows) => {
                         total_inserted += rows;
                         if rows == 0 {
-                            total_skipped += 1;
+                            total_skipped_duplicate += 1;
                             // duplicate — skipped via ON CONFLICT DO NOTHING
                         } else {
                             if let Some(ref tx) = self.event_tx {
@@ -859,43 +908,30 @@ impl<R: RpcClient> Indexer<R> {
             }
         }
 
-        let cycle_ms = cycle_start.elapsed().as_millis();
-        if total_inserted > 0 {
-            info!(
-                fetched = total_fetched,
-                inserted = total_inserted,
-                start_ledger = start_ledger_for_log,
-                end_ledger = latest_ledger,
-                pages = total_pages,
-                cycle_ms = cycle_ms,
-                rpc_ms = total_rpc_ms,
-                db_ms = total_db_ms,
-                "Indexed ledger range",
-            );
-        } else {
-            tracing::debug!(
-                fetched = total_fetched,
-                inserted = total_inserted,
-                start_ledger = start_ledger_for_log,
-                end_ledger = latest_ledger,
-                pages = total_pages,
-                cycle_ms = cycle_ms,
-                rpc_ms = total_rpc_ms,
-                db_ms = total_db_ms,
-                "Indexed ledger range (no new events)",
-            );
-        }
-        metrics::record_events_indexed(total_inserted as u64);
+        let cycle_duration_secs = cycle_start.elapsed().as_secs_f64();
+        let cycle_ms = (cycle_duration_secs * 1000.0) as u128;
+        let lag_ledgers = latest_ledger.saturating_sub(start_ledger);
 
-        if total_fetched > 0 {
-            let duplicate_rate = (total_skipped as f64 / total_fetched as f64) * 100.0;
-            tracing::debug!(
-                duplicates = total_skipped,
-                total_fetched = total_fetched,
-                duplicate_rate = duplicate_rate,
-                "Event deduplication stats"
-            );
-        }
+        // Issue #425: Emit structured summary log at end of cycle
+        info!(
+            ledger = latest_ledger,
+            events_fetched = total_fetched,
+            events_inserted = total_inserted,
+            events_skipped_duplicate = total_skipped_duplicate,
+            events_skipped_validation = total_skipped_validation,
+            events_skipped_out_of_order = total_skipped_out_of_order,
+            cycle_duration_ms = cycle_ms,
+            lag_ledgers = lag_ledgers,
+            pages = total_pages,
+            rpc_ms = total_rpc_ms,
+            db_ms = total_db_ms,
+            "Indexer poll cycle completed"
+        );
+
+        // Issue #425: Record cycle duration and events per cycle metrics
+        metrics::record_indexer_cycle_duration(cycle_duration_secs);
+        metrics::record_indexer_events_per_cycle(total_inserted as u64);
+        metrics::record_events_indexed(total_inserted as u64);
 
         let next_ledger = if latest_ledger > start_ledger {
             latest_ledger + 1

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -191,6 +191,31 @@ pub fn record_replay_job() {
     m::counter!("soroban_pulse_replay_jobs_total").increment(1);
 }
 
+/// Record indexer cycle duration (seconds)
+pub fn record_indexer_cycle_duration(duration_secs: f64) {
+    m::histogram!("soroban_pulse_indexer_cycle_duration_seconds").record(duration_secs);
+}
+
+/// Record events per cycle
+pub fn record_indexer_events_per_cycle(count: u64) {
+    m::histogram!("soroban_pulse_indexer_events_per_cycle").record(count as f64);
+}
+
+/// Record out-of-order events (ledger sequence < current cursor)
+pub fn record_out_of_order_events(count: u64) {
+    m::counter!("soroban_pulse_indexer_out_of_order_events_total").increment(count);
+}
+
+/// Record oversized RPC response
+pub fn record_oversized_rpc_response() {
+    m::counter!("soroban_pulse_rpc_oversized_response_total").increment(1);
+}
+
+/// Update indexer lock wait duration (seconds)
+pub fn update_indexer_lock_wait_duration(duration_secs: f64) {
+    m::gauge!("soroban_pulse_indexer_lock_wait_seconds").set(duration_secs);
+}
+
 /// Record events pruned
 pub fn increment_events_pruned(count: u64) {
     m::counter!("soroban_pulse_events_pruned_total").increment(count);


### PR DESCRIPTION
# Indexer Observability Improvements: Structured Logging & Validation

## Overview
This PR implements comprehensive observability enhancements to the Soroban Pulse indexer, addressing four critical issues related to monitoring, debugging, and data integrity. The changes enable operators to easily track indexer health, diagnose lock contention, detect RPC anomalies, and prevent data corruption from out-of-order ledger sequences.

## Issues Addressed
Closes #425
Closes #426
Closes #427
Closes #428

## Changes Implemented

### Issue #425: Structured Poll Cycle Summary Logging
**Problem**: Operators cannot easily determine indexer throughput and health without parsing multiple individual log lines.

**Solution**:
- Added structured `info!` log at the end of each poll cycle with comprehensive metrics:
  - `ledger` - Latest ledger processed
  - `events_fetched` - Total events fetched from RPC
  - `events_inserted` - Events successfully inserted into database
  - `events_skipped_duplicate` - Duplicate events skipped via ON CONFLICT
  - `events_skipped_validation` - Events failed validation or transformation
  - `events_skipped_out_of_order` - Events with ledger < current cursor
  - `cycle_duration_ms` - Total cycle execution time
  - `lag_ledgers` - Current indexer lag (latest_ledger - current_ledger)
  - `pages` - Number of RPC pages fetched
  - `rpc_ms` - Total RPC request time
  - `db_ms` - Total database transaction time

- Added two new Prometheus histogram metrics:
  - `soroban_pulse_indexer_cycle_duration_seconds` - Tracks cycle execution time distribution
  - `soroban_pulse_indexer_events_per_cycle` - Tracks events processed per cycle

**Impact**: Operators can now monitor indexer health with a single log line per cycle and use histogram metrics for performance analysis.

---

### Issue #426: RPC Response Size Validation
**Problem**: If the RPC returns more events than requested (due to bug or protocol change), the indexer processes all without warning, potentially causing stalls and accumulating lag.

**Solution**:
- Added `RPC_MAX_EVENTS_PER_PAGE` environment variable (default: 200)
- Validates RPC response `events.len() <= requested_limit` after each fetch
- Logs warning with actual vs. expected counts when exceeded
- Truncates response to configured maximum
- Added counter metric: `soroban_pulse_rpc_oversized_response_total`

**Configuration**:
bash
RPC_MAX_EVENTS_PER_PAGE=200  # Default, adjust based on RPC behavior

**Impact**: Prevents indexer stalls from unexpectedly large RPC responses and provides visibility into RPC anomalies.

---

### Issue #427: Advisory Lock Acquisition Debugging
**Problem**: In multi-replica deployments, standby replicas log generic lock failure messages without context, making it difficult to diagnose split-brain scenarios or stuck lock holders.

**Solution**:
- Enhanced lock acquisition logging with:
  - `lock_key` - The advisory lock key value (0x536f726f62616e50)
  - `lock_holder_pid` - Current lock holder's process ID (queried from pg_locks)
  - `wait_secs` - Duration standby has been waiting for lock
  - `retry_secs` - Configured retry interval

- Added gauge metric: `soroban_pulse_indexer_lock_wait_seconds`
  - Tracks how long current replica has been waiting for lock
  - Reset to 0.0 when lock is successfully acquired
  - Useful for alerting on stuck lock scenarios

**Impact**: Operators can quickly identify which replica holds the lock and diagnose lock contention issues.

---

### Issue #428: Monotonic Ledger Sequence Validation
**Problem**: If the RPC returns events from a ledger ≤ current cursor (due to node rollback or bug), the indexer re-processes events and may advance the cursor incorrectly, causing duplicate inserts and incorrect lag metrics.

**Solution**:
- Added validation: `event.ledger >= current_cursor` before processing each event
- Events with `ledger < current_cursor` are:
  - Skipped with warning log including event details
  - Counted separately in cycle summary
  - Tracked via counter metric

- Added counter metric: `soroban_pulse_indexer_out_of_order_events_total`
- Separate tracking in cycle summary: `events_skipped_out_of_order`

**Impact**: Prevents duplicate event insertion and incorrect cursor advancement from RPC anomalies.

---

## Technical Details

### Configuration Changes
- **src/config.rs**:
  - Added `rpc_max_events_per_page: usize` field (default: 200)
  - Added `RPC_MAX_EVENTS_PER_PAGE` environment variable parsing
  - Added `INDEXER_IGNORE_CHECKPOINT` environment variable parsing

### Indexer Changes
- **src/indexer.rs**:
  - Enhanced `fetch_and_store_events()`:
    - Separated skip tracking: `total_skipped_duplicate`, `total_skipped_validation`, `total_skipped_out_of_order`
    - Added RPC response size validation (Issue #426)
    - Added monotonic ledger sequence validation (Issue #428)
    - Added comprehensive cycle summary log (Issue #425)
    - Records cycle duration and events-per-cycle metrics
  
  - Enhanced `run()` method:
    - Added lock wait duration tracking
    - Query pg_locks to find lock holder's PID
    - Enhanced lock acquisition logging with lock_key and wait_secs (Issue #427)
    - Reset lock wait gauge to 0.0 on successful acquisition

### Metrics Changes
- **src/metrics.rs** - Added 5 new metric functions:
  - `record_indexer_cycle_duration(duration_secs: f64)` - Histogram
  - `record_indexer_events_per_cycle(count: u64)` - Histogram
  - `record_out_of_order_events(count: u64)` - Counter
  - `record_oversized_rpc_response()` - Counter
  - `update_indexer_lock_wait_duration(duration_secs: f64)` - Gauge

## Metrics Exposed

### New Prometheus Metrics

# Cycle performance
soroban_pulse_indexer_cycle_duration_seconds{} - Histogram (seconds)
soroban_pulse_indexer_events_per_cycle{} - Histogram (count)

# Data integrity
soroban_pulse_indexer_out_of_order_events_total{} - Counter
soroban_pulse_rpc_oversized_response_total{} - Counter

# Lock contention
soroban_pulse_indexer_lock_wait_seconds{} - Gauge (seconds)

## Logging Examples

### Cycle Summary Log (Issue #425)
json
{
 "timestamp": "2026-05-29T09:54:00Z",
 "level": "INFO",
 "message": "Indexer poll cycle completed",
 "ledger": 1234567,
 "events_fetched": 150,
 "events_inserted": 145,
 "events_skipped_duplicate": 5,
 "events_skipped_validation": 0,
 "events_skipped_out_of_order": 0,
 "cycle_duration_ms": 1250,
 "lag_ledgers": 42,
 "pages": 1,
 "rpc_ms": 850,
 "db_ms": 350
}

### Lock Acquisition Failure (Issue #427)

WARN: Indexer lock not acquired, running in standby mode — will retry
 lock_key: 6140399220265033296
 lock_holder_pid: 12345
 retry_secs: 30
 wait_secs: 120.5

### Out-of-Order Event (Issue #428)

WARN: Out-of-order event: ledger sequence below current cursor, skipping
 event_ledger: 1234500
 current_cursor: 1234567
 tx_hash: abc123...
 contract_id: CABC...

### Oversized RPC Response (Issue #426)

WARN: RPC response exceeded requested page size, truncating
 actual: 250
 expected: 200

## Testing
- All existing tests pass
- Changes are backward compatible
- Default configuration values maintain existing behavior
- New metrics are optional and don't affect core functionality

## Deployment Notes
- No database migrations required
- No breaking changes to API or configuration
- New environment variables are optional with sensible defaults
- Existing deployments will automatically benefit from improved logging and metrics

## Acceptance Criteria Met
✅ Issue #425: Structured summary log with all required fields emitted at end of cycle
✅ Issue #425: Cycle duration and events-per-cycle histograms visible in `/metrics`
✅ Issue #426: RPC response validation with warning and truncation
✅ Issue #426: Oversized response counter metric
✅ Issue #426: `RPC_MAX_EVENTS_PER_PAGE` configuration variable
✅ Issue #427: Lock key and holder PID logged on acquisition failure
✅ Issue #427: Lock wait duration gauge metric
✅ Issue #427: Enhanced lock acquisition logging
✅ Issue #428: Out-of-order event validation and skipping
✅ Issue #428: Out-of-order events counter metric
✅ Issue #428: Separate tracking in cycle summary
