### PR TITLE
Add event history, ABI decoding, and tx correlation

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -343,6 +343,175 @@
         }
       }
     },
+    "/v1/admin/contracts/{contract_id}/abi": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "operationId": "get_contract_abi",
+        "parameters": [
+          {
+            "name": "contract_id",
+            "in": "path",
+            "description": "Stellar contract ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Registered ABI"
+          },
+          "404": {
+            "description": "ABI not found"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "operationId": "register_contract_abi",
+        "parameters": [
+          {
+            "name": "contract_id",
+            "in": "path",
+            "description": "Stellar contract ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "ABI JSON array",
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "ABI registered and existing events queued for decoding"
+          },
+          "400": {
+            "description": "Invalid contract_id or ABI"
+          }
+        }
+      }
+    },
+    "/v1/contracts/{contract_id}/stats/history": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "operationId": "get_contract_stats_history",
+        "parameters": [
+          {
+            "name": "contract_id",
+            "in": "path",
+            "description": "Stellar contract ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "bucket",
+            "in": "query",
+            "description": "Aggregation bucket. Currently only 1d is supported",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "description": "Number of daily buckets to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": true
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Start date, YYYY-MM-DD",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "description": "End date, YYYY-MM-DD",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of {date, event_count, unique_tx_count} objects"
+          },
+          "400": {
+            "description": "Invalid contract_id, bucket, or date range"
+          }
+        }
+      }
+    },
+    "/v1/events/tx/{tx_hash}/related": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "operationId": "get_related_events_by_tx",
+        "parameters": [
+          {
+            "name": "tx_hash",
+            "in": "path",
+            "description": "Root transaction hash (64 hex chars)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "depth",
+            "in": "query",
+            "description": "Reference traversal depth, default 1, max 3",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0,
+              "maximum": 3,
+              "nullable": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Events from transactions referenced by event_data"
+          },
+          "400": {
+            "description": "Invalid tx_hash or depth"
+          }
+        }
+      }
+    },
     "/v1/events/tx/{tx_hash}": {
       "get": {
         "tags": [
@@ -569,6 +738,10 @@
     {
       "name": "system",
       "description": "Health and observability endpoints"
+    },
+    {
+      "name": "admin",
+      "description": "Administrative endpoints"
     }
   ]
 }

--- a/migrations/20260428000003_matview_contract_summary.sql
+++ b/migrations/20260428000003_matview_contract_summary.sql
@@ -8,3 +8,15 @@ GROUP BY contract_id;
 
 CREATE UNIQUE INDEX IF NOT EXISTS idx_events_contract_summary_unique
     ON events_contract_summary (contract_id);
+
+CREATE MATERIALIZED VIEW IF NOT EXISTS mv_contract_summary AS
+SELECT
+    contract_id,
+    timestamp::date AS event_date,
+    COUNT(*) AS event_count,
+    COUNT(DISTINCT tx_hash) AS unique_tx_count
+FROM events
+GROUP BY contract_id, timestamp::date;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_mv_contract_summary_unique
+    ON mv_contract_summary (contract_id, event_date);

--- a/openapi.json
+++ b/openapi.json
@@ -345,6 +345,175 @@
         }
       }
     },
+    "/v1/admin/contracts/{contract_id}/abi": {
+      "get": {
+        "tags": [
+          "admin"
+        ],
+        "operationId": "get_contract_abi",
+        "parameters": [
+          {
+            "name": "contract_id",
+            "in": "path",
+            "description": "Stellar contract ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Registered ABI"
+          },
+          "404": {
+            "description": "ABI not found"
+          }
+        }
+      },
+      "post": {
+        "tags": [
+          "admin"
+        ],
+        "operationId": "register_contract_abi",
+        "parameters": [
+          {
+            "name": "contract_id",
+            "in": "path",
+            "description": "Stellar contract ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          }
+        ],
+        "requestBody": {
+          "description": "ABI JSON array",
+          "content": {
+            "application/json": {
+              "schema": {}
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "ABI registered and existing events queued for decoding"
+          },
+          "400": {
+            "description": "Invalid contract_id or ABI"
+          }
+        }
+      }
+    },
+    "/v1/contracts/{contract_id}/stats/history": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "operationId": "get_contract_stats_history",
+        "parameters": [
+          {
+            "name": "contract_id",
+            "in": "path",
+            "description": "Stellar contract ID",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "bucket",
+            "in": "query",
+            "description": "Aggregation bucket. Currently only 1d is supported",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "days",
+            "in": "query",
+            "description": "Number of daily buckets to return",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int64",
+              "nullable": true
+            }
+          },
+          {
+            "name": "from",
+            "in": "query",
+            "description": "Start date, YYYY-MM-DD",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          },
+          {
+            "name": "to",
+            "in": "query",
+            "description": "End date, YYYY-MM-DD",
+            "required": false,
+            "schema": {
+              "type": "string",
+              "nullable": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Array of {date, event_count, unique_tx_count} objects"
+          },
+          "400": {
+            "description": "Invalid contract_id, bucket, or date range"
+          }
+        }
+      }
+    },
+    "/v1/events/tx/{tx_hash}/related": {
+      "get": {
+        "tags": [
+          "events"
+        ],
+        "operationId": "get_related_events_by_tx",
+        "parameters": [
+          {
+            "name": "tx_hash",
+            "in": "path",
+            "description": "Root transaction hash (64 hex chars)",
+            "required": true,
+            "schema": {
+              "type": "string"
+            }
+          },
+          {
+            "name": "depth",
+            "in": "query",
+            "description": "Reference traversal depth, default 1, max 3",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0,
+              "maximum": 3,
+              "nullable": true
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Events from transactions referenced by event_data"
+          },
+          "400": {
+            "description": "Invalid tx_hash or depth"
+          }
+        }
+      }
+    },
     "/v1/events/tx/{tx_hash}": {
       "get": {
         "tags": [
@@ -487,7 +656,7 @@
             "type": "integer",
             "format": "int64",
             "nullable": true
-          }
+          },
            "sort": {
              "type": "string",
              "nullable": true,
@@ -510,6 +679,10 @@
     {
       "name": "system",
       "description": "Health and observability endpoints"
+    },
+    {
+      "name": "admin",
+      "description": "Administrative endpoints"
     }
   ]
 }

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -1,0 +1,159 @@
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use stellar_xdr::curr::ScVal;
+
+pub fn decode_event_data(abi: &Value, event_data: &Value) -> Option<Value> {
+    let event_name = event_name_from_topic(event_data.get("topic")?)?;
+    let def = abi
+        .as_array()?
+        .iter()
+        .find(|e| e.get("name").and_then(Value::as_str) == Some(event_name))?;
+    let inputs = def.get("inputs")?.as_array()?;
+    let values = decode_values(event_data.get("value")?);
+
+    let mut decoded = serde_json::Map::new();
+    decoded.insert("event".to_string(), Value::String(event_name.to_string()));
+    for (i, input) in inputs.iter().enumerate() {
+        let name = input
+            .get("name")
+            .and_then(Value::as_str)
+            .map(str::to_string)
+            .unwrap_or_else(|| format!("field_{i}"));
+        let value = values
+            .get(&name)
+            .or_else(|| values.get(&i.to_string()))
+            .cloned()
+            .unwrap_or(Value::Null);
+        decoded.insert(name, value);
+    }
+
+    Some(Value::Object(decoded))
+}
+
+pub async fn decode_event_with_registered_abi(
+    pool: &PgPool,
+    contract_id: &str,
+    event_data: &Value,
+) -> Option<Value> {
+    let abi: Value = sqlx::query_scalar("SELECT abi FROM contract_abis WHERE contract_id = $1")
+        .bind(contract_id)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten()?;
+    decode_event_data(&abi, event_data)
+}
+
+pub async fn decode_existing_events(pool: PgPool, contract_id: String, abi: Value) {
+    let rows = match sqlx::query("SELECT id, event_data FROM events WHERE contract_id = $1")
+        .bind(&contract_id)
+        .fetch_all(&pool)
+        .await
+    {
+        Ok(rows) => rows,
+        Err(e) => {
+            tracing::error!(contract_id = %contract_id, error = %e, "failed to load events for ABI backfill");
+            return;
+        }
+    };
+
+    for row in rows {
+        use sqlx::Row;
+        let id: uuid::Uuid = match row.try_get("id") {
+            Ok(id) => id,
+            Err(_) => continue,
+        };
+        let event_data: Value = match row.try_get("event_data") {
+            Ok(event_data) => event_data,
+            Err(_) => continue,
+        };
+        let Some(decoded) = decode_event_data(&abi, &event_data) else {
+            continue;
+        };
+        if let Err(e) = sqlx::query("UPDATE events SET event_data_decoded = $1 WHERE id = $2")
+            .bind(decoded)
+            .bind(id)
+            .execute(&pool)
+            .await
+        {
+            tracing::error!(event_id = %id, error = %e, "failed to backfill decoded event data");
+        }
+    }
+}
+
+fn event_name_from_topic(topic: &Value) -> Option<&str> {
+    let first = topic.as_array()?.first()?;
+    first
+        .as_str()
+        .or_else(|| first.get("symbol").and_then(Value::as_str))
+        .or_else(|| first.get("string").and_then(Value::as_str))
+}
+
+fn decode_values(value: &Value) -> serde_json::Map<String, Value> {
+    if let Some(obj) = value.as_object() {
+        if obj.contains_key("vec") {
+            if let Ok(ScVal::Vec(Some(vec))) = serde_json::from_value::<ScVal>(value.clone()) {
+                return vec
+                    .0
+                    .to_vec()
+                    .into_iter()
+                    .enumerate()
+                    .map(|(i, val)| (i.to_string(), scval_to_json(val)))
+                    .collect();
+            }
+        }
+        return obj.clone();
+    }
+
+    let mut map = serde_json::Map::new();
+    map.insert("0".to_string(), decode_scalar(value));
+    map
+}
+
+fn decode_scalar(value: &Value) -> Value {
+    serde_json::from_value::<ScVal>(value.clone())
+        .map(scval_to_json)
+        .unwrap_or_else(|_| value.clone())
+}
+
+fn scval_to_json(value: ScVal) -> Value {
+    match value {
+        ScVal::Bool(v) => json!(v),
+        ScVal::Void => Value::Null,
+        ScVal::U32(v) => json!(v),
+        ScVal::I32(v) => json!(v),
+        ScVal::U64(v) => json!(v.to_string()),
+        ScVal::I64(v) => json!(v.to_string()),
+        ScVal::Symbol(v) => json!(v.to_string()),
+        ScVal::String(v) => json!(v.to_string()),
+        ScVal::Vec(Some(values)) => {
+            Value::Array(values.0.to_vec().into_iter().map(scval_to_json).collect())
+        }
+        ScVal::Vec(None) => Value::Array(Vec::new()),
+        other => serde_json::to_value(other).unwrap_or(Value::Null),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decodes_named_fields_from_registered_abi() {
+        let abi = json!([
+            {"name": "transfer", "inputs": [
+                {"name": "from", "type": "address"},
+                {"name": "to", "type": "address"},
+                {"name": "amount", "type": "i128"}
+            ]}
+        ]);
+        let event_data = json!({
+            "topic": ["transfer"],
+            "value": {"from": "GABC", "to": "GDEF", "amount": "1000"}
+        });
+
+        let decoded = decode_event_data(&abi, &event_data).unwrap();
+        assert_eq!(decoded["event"], "transfer");
+        assert_eq!(decoded["amount"], "1000");
+    }
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -608,6 +608,96 @@ pub async fn get_event_stats(State(state): State<AppState>) -> Result<impl IntoR
     Ok((headers, Json(stats_json)))
 }
 
+#[derive(Debug, serde::Deserialize, utoipa::ToSchema)]
+pub struct ContractHistoryParams {
+    pub bucket: Option<String>,
+    pub days: Option<i64>,
+    pub from: Option<String>,
+    pub to: Option<String>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/contracts/{contract_id}/stats/history",
+    tag = "events",
+    params(
+        ("contract_id" = String, Path, description = "Stellar contract ID"),
+        ("bucket" = Option<String>, Query, description = "Aggregation bucket. Currently only 1d is supported"),
+        ("days" = Option<i64>, Query, description = "Number of daily buckets to return"),
+        ("from" = Option<String>, Query, description = "Start date, YYYY-MM-DD"),
+        ("to" = Option<String>, Query, description = "End date, YYYY-MM-DD"),
+    ),
+    responses(
+        (status = 200, description = "Daily contract event and unique transaction history", body = serde_json::Value),
+        (status = 400, description = "Invalid contract_id, bucket, or date range", body = ErrorResponse),
+    )
+)]
+pub async fn get_contract_stats_history(
+    State(state): State<AppState>,
+    Path(contract_id): Path<String>,
+    Query(params): Query<ContractHistoryParams>,
+) -> Result<Json<Value>, AppError> {
+    validate_contract_id(&contract_id)?;
+    let bucket = params.bucket.as_deref().unwrap_or("1d");
+    if bucket != "1d" {
+        return Err(AppError::Validation("unsupported bucket: only bucket=1d is supported".to_string()));
+    }
+
+    let today = Utc::now().date_naive();
+    let (start_date, end_date) = if params.from.is_some() || params.to.is_some() {
+        let from = params.from.as_deref().ok_or_else(|| AppError::Validation("from is required when to is provided".to_string()))?;
+        let to = params.to.as_deref().ok_or_else(|| AppError::Validation("to is required when from is provided".to_string()))?;
+        let start = chrono::NaiveDate::parse_from_str(from, "%Y-%m-%d")
+            .map_err(|_| AppError::Validation("from must be YYYY-MM-DD".to_string()))?;
+        let end = chrono::NaiveDate::parse_from_str(to, "%Y-%m-%d")
+            .map_err(|_| AppError::Validation("to must be YYYY-MM-DD".to_string()))?;
+        (start, end)
+    } else {
+        let days = params.days.unwrap_or(30);
+        if !(1..=366).contains(&days) {
+            return Err(AppError::Validation("days must be between 1 and 366".to_string()));
+        }
+        (today - chrono::Duration::days(days - 1), today)
+    };
+    if start_date > end_date {
+        return Err(AppError::Validation("from must be <= to".to_string()));
+    }
+    if (end_date - start_date).num_days() + 1 > 366 {
+        return Err(AppError::Validation("date range cannot exceed 366 daily buckets".to_string()));
+    }
+
+    let start = std::time::Instant::now();
+    let rows = sqlx::query(
+        r#"
+        SELECT d::date AS date,
+               COALESCE(m.event_count, 0)::bigint AS event_count,
+               COALESCE(m.unique_tx_count, 0)::bigint AS unique_tx_count
+        FROM generate_series($2::date, $3::date, interval '1 day') AS d
+        LEFT JOIN mv_contract_summary m
+          ON m.contract_id = $1 AND m.event_date = d::date
+        ORDER BY d::date ASC
+        "#,
+    )
+    .bind(&contract_id)
+    .bind(start_date)
+    .bind(end_date)
+    .fetch_all(&state.read_pool)
+    .await?;
+    crate::metrics::record_contract_history_query_duration(start.elapsed());
+
+    let data = rows
+        .into_iter()
+        .map(|row| {
+            let date: chrono::NaiveDate = row.try_get("date")?;
+            let event_count: i64 = row.try_get("event_count")?;
+            let unique_tx_count: i64 = row.try_get("unique_tx_count")?;
+            Ok(json!({ "date": date, "event_count": event_count, "unique_tx_count": unique_tx_count }))
+        })
+        .collect::<Result<Vec<_>, sqlx::Error>>()?;
+
+    Ok(Json(json!({ "contract_id": contract_id, "bucket": bucket, "data": data })))
+}
+
 pub async fn metrics(State(state): State<AppState>) -> impl IntoResponse {
     crate::metrics::update_db_pool_metrics(&state.pool);
     state.prometheus_handle.render()
@@ -2639,6 +2729,113 @@ pub async fn get_events_by_tx(
     })))
 }
 
+#[derive(Debug, serde::Deserialize, utoipa::ToSchema)]
+pub struct RelatedTxParams {
+    pub depth: Option<u8>,
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/events/tx/{tx_hash}/related",
+    tag = "events",
+    params(
+        ("tx_hash" = String, Path, description = "Root transaction hash (64 hex chars)"),
+        ("depth" = Option<u8>, Query, description = "Reference traversal depth, default 1, max 3"),
+    ),
+    responses(
+        (status = 200, description = "Events from transactions referenced by event_data", body = serde_json::Value),
+        (status = 400, description = "Invalid tx_hash or depth", body = ErrorResponse),
+    )
+)]
+pub async fn get_related_events_by_tx(
+    State(state): State<AppState>,
+    Path(tx_hash): Path<String>,
+    Query(params): Query<RelatedTxParams>,
+) -> Result<Json<Value>, AppError> {
+    let root_tx_hash = tx_hash.to_lowercase();
+    validate_tx_hash(&root_tx_hash)?;
+    let max_depth = params.depth.unwrap_or(1);
+    if max_depth > 3 {
+        return Err(AppError::Validation("depth must be between 0 and 3".to_string()));
+    }
+
+    let mut seen = std::collections::HashSet::from([root_tx_hash.clone()]);
+    let mut frontier = vec![root_tx_hash.clone()];
+    let mut all_events = Vec::new();
+
+    for depth in 0..=max_depth {
+        if frontier.is_empty() {
+            break;
+        }
+        let rows = sqlx::query(
+            "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data, event_data_decoded, created_at, schema_version, 0::bigint AS total_count
+             FROM events WHERE tx_hash = ANY($1) ORDER BY ledger DESC, id DESC",
+        )
+        .bind(&frontier)
+        .fetch_all(&state.read_pool)
+        .await?;
+
+        let mut next = Vec::new();
+        for row in rows {
+            let event_data: Value = row.try_get("event_data")?;
+            collect_tx_refs(&event_data, &mut next);
+            all_events.push(row_to_event_json(&row)?);
+        }
+        if depth == max_depth {
+            break;
+        }
+        frontier = next
+            .into_iter()
+            .map(|h| h.to_lowercase())
+            .filter(|h| validate_tx_hash(h).is_ok())
+            .filter(|h| seen.insert(h.clone()))
+            .collect();
+    }
+
+    let total = all_events.len();
+    Ok(Json(json!({ "tx_hash": root_tx_hash, "depth": max_depth, "data": all_events, "total": total })))
+}
+
+fn collect_tx_refs(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            for (key, value) in map {
+                if is_tx_ref_key(key) {
+                    if let Some(tx_hash) = value.as_str() {
+                        out.push(tx_hash.to_string());
+                    }
+                }
+                collect_tx_refs(value, out);
+            }
+        }
+        Value::Array(values) => {
+            for value in values {
+                collect_tx_refs(value, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn is_tx_ref_key(key: &str) -> bool {
+    matches!(key, "tx_hash" | "transaction_hash" | "related_tx_hash" | "parent_tx_hash" | "child_tx_hash")
+}
+
+fn row_to_event_json(row: &sqlx::postgres::PgRow) -> Result<Value, AppError> {
+    Ok(json!({
+        "id": row.try_get::<Uuid, _>("id")?,
+        "contract_id": row.try_get::<String, _>("contract_id")?,
+        "event_type": row.try_get::<String, _>("event_type")?,
+        "tx_hash": row.try_get::<String, _>("tx_hash")?,
+        "ledger": row.try_get::<i64, _>("ledger")?,
+        "timestamp": row.try_get::<DateTime<Utc>, _>("timestamp")?,
+        "event_data": row.try_get::<Value, _>("event_data")?,
+        "event_data_decoded": row.try_get::<Option<Value>, _>("event_data_decoded")?,
+        "created_at": row.try_get::<DateTime<Utc>, _>("created_at")?,
+        "schema_version": row.try_get::<i32, _>("schema_version")?,
+    }))
+}
+
 #[utoipa::path(
     post,
     path = "/v1/events/tx/batch",
@@ -2920,9 +3117,47 @@ pub async fn register_contract_abi(
     .execute(&state.pool)
     .await?;
 
+    let pool = state.pool.clone();
+    let backfill_contract_id = contract_id.clone();
+    let backfill_abi = abi.clone();
+    tokio::spawn(async move {
+        crate::abi::decode_existing_events(pool, backfill_contract_id, backfill_abi).await;
+    });
+
     Ok(Json(
         json!({ "contract_id": contract_id, "status": "registered" }),
     ))
+}
+
+#[utoipa::path(
+    get,
+    path = "/v1/admin/contracts/{contract_id}/abi",
+    tag = "admin",
+    params(
+        ("contract_id" = String, Path, description = "Stellar contract ID"),
+    ),
+    responses(
+        (status = 200, description = "Registered ABI", body = serde_json::Value),
+        (status = 400, description = "Invalid contract_id", body = ErrorResponse),
+        (status = 404, description = "ABI not found", body = ErrorResponse),
+        (status = 401, description = "Unauthorized", body = ErrorResponse),
+    )
+)]
+pub async fn get_contract_abi(
+    State(state): State<AppState>,
+    Path(contract_id): Path<String>,
+) -> Result<Json<Value>, AppError> {
+    validate_contract_id(&contract_id)?;
+    let row = sqlx::query("SELECT abi, created_at, updated_at FROM contract_abis WHERE contract_id = $1")
+        .bind(&contract_id)
+        .fetch_optional(&state.read_pool)
+        .await?
+        .ok_or(AppError::NotFound)?;
+
+    let abi: Value = row.try_get("abi")?;
+    let created_at: DateTime<Utc> = row.try_get("created_at")?;
+    let updated_at: DateTime<Utc> = row.try_get("updated_at")?;
+    Ok(Json(json!({ "contract_id": contract_id, "abi": abi, "created_at": created_at, "updated_at": updated_at })))
 }
 
 /// Anonymize a specific event for GDPR compliance.

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -129,38 +129,30 @@ impl RpcClient for SorobanRpcClient {
             "method": "getLatestLedger"
         });
 
-        let span = span!(Level::INFO, "rpc_get_latest_ledger", url = %rpc_url);
-        let _enter = span.enter();
+        let mut last_err = String::new();
+        let n = self.urls.len();
+        let start = self.active_idx.load(Ordering::Relaxed);
 
-        let resp: RpcResponse<LatestLedgerResult> = self
-            .client
-            .post(rpc_url)
-            .headers(self.headers.clone())
-            .json(&body)
-            .send()
-            .await
-            .map_err(|e| {
-                if e.is_timeout() {
-                    warn!("RPC request timeout");
-                }
-                metrics::record_rpc_error();
-                e.to_string()
-            })?
-            .json()
-            .await
-            .map_err(|e| e.to_string())?;
-
-        match resp.result {
-            Some(r) => {
-                metrics::update_latest_ledger(r.sequence);
-                Ok(r.sequence)
-            }
-            None => {
-                if let Some(err) = resp.error {
-                    warn!(code = err.code, error = %err.message, "RPC error");
-                    metrics::record_rpc_error();
-                    e.to_string()
-                });
+        for attempt in 0..n {
+            let idx = (start + attempt) % n;
+            let url = self.urls[idx].clone();
+            let span = span!(Level::INFO, "rpc_get_latest_ledger", url = %url);
+            let send_result = {
+                let _enter = span.enter();
+                self.client
+                    .post(&url)
+                    .headers(self.headers.clone())
+                    .json(&body)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        if e.is_timeout() {
+                            warn!("RPC request timeout");
+                        }
+                        metrics::record_rpc_error();
+                        e.to_string()
+                    })
+            };
 
             match send_result {
                 Err(e) => {
@@ -240,15 +232,23 @@ impl RpcClient for SorobanRpcClient {
         for attempt in 0..n {
             let idx = (start + attempt) % n;
             let url = self.urls[idx].clone(); // clone to avoid holding &self borrow across await
-
-        match resp.result {
-            Some(r) => Ok(r),
-            None => {
-                if let Some(err) = resp.error {
-                    warn!(code = err.code, error = %err.message, "RPC error");
-                    metrics::record_rpc_error();
-                    e.to_string()
-                });
+            let span = span!(Level::INFO, "rpc_get_events", url = %url);
+            let result = {
+                let _enter = span.enter();
+                self.client
+                    .post(&url)
+                    .headers(self.headers.clone())
+                    .json(&body)
+                    .send()
+                    .await
+                    .map_err(|e| {
+                        if e.is_timeout() {
+                            warn!("RPC request timeout");
+                        }
+                        metrics::record_rpc_error();
+                        e.to_string()
+                    })
+            };
 
             match result {
                 Err(e) => {
@@ -287,57 +287,6 @@ impl RpcClient for SorobanRpcClient {
 
         Err(last_err)
     }
-}
-
-/// Attempt to decode event_data using a registered ABI for the contract.
-/// Returns `Some(decoded)` if an ABI is found and decoding succeeds, `None` otherwise.
-async fn decode_event_with_abi(
-    pool: &PgPool,
-    contract_id: &str,
-    event_data: &serde_json::Value,
-) -> Option<serde_json::Value> {
-    let abi: serde_json::Value =
-        sqlx::query_scalar("SELECT abi FROM contract_abis WHERE contract_id = $1")
-            .bind(contract_id)
-            .fetch_optional(pool)
-            .await
-            .ok()
-            .flatten()?;
-
-    // The ABI is a JSON array of event definitions: [{name, inputs:[{name,type},...]}]
-    // We match on the first topic (event name) and map positional values to named fields.
-    let topic = event_data.get("topic")?.as_array()?;
-    let event_name = topic.first()?.as_str()?;
-
-    let events = abi.as_array()?;
-    let def = events
-        .iter()
-        .find(|e| e.get("name").and_then(|n| n.as_str()) == Some(event_name))?;
-    let inputs = def.get("inputs")?.as_array()?;
-
-    let values = event_data.get("value")?.as_object()?;
-    // Build decoded object: map input names to corresponding values
-    let mut decoded = serde_json::Map::new();
-    decoded.insert(
-        "event".to_string(),
-        serde_json::Value::String(event_name.to_string()),
-    );
-    for (i, input) in inputs.iter().enumerate() {
-        let field_name = input
-            .get("name")
-            .and_then(|n| n.as_str())
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| format!("field_{i}"));
-        let field_name = field_name.as_str();
-        // Values may be keyed by index or by name in the raw data
-        let val = values
-            .get(field_name)
-            .or_else(|| values.get(&i.to_string()))
-            .cloned()
-            .unwrap_or(serde_json::Value::Null);
-        decoded.insert(field_name.to_string(), val);
-    }
-    Some(serde_json::Value::Object(decoded))
 }
 
 pub struct Indexer<R: RpcClient> {
@@ -1121,7 +1070,7 @@ impl<R: RpcClient> Indexer<R> {
 
         // Look up ABI for this contract and decode event_data if available.
         let event_data_decoded =
-            decode_event_with_abi(&self.pool, &event.contract_id, &event_data).await;
+            crate::abi::decode_event_with_registered_abi(&self.pool, &event.contract_id, &event_data).await;
         // Enforce size limit before INSERT.
         let serialized = serde_json::to_vec(&event_data)?;
         if serialized.len() > self.config.max_event_data_bytes {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod abi;
 pub mod bloom_filter;
 pub mod config;
 pub mod db;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -260,6 +260,12 @@ pub fn record_timeseries_query_duration(duration: std::time::Duration) {
         .record(duration.as_secs_f64());
 }
 
+/// Record contract history query duration
+pub fn record_contract_history_query_duration(duration: std::time::Duration) {
+    m::histogram!("soroban_pulse_contract_history_query_duration_seconds")
+        .record(duration.as_secs_f64());
+}
+
 /// Record SSE multi-stream contract IDs per connection (histogram)
 pub fn record_sse_multi_contract_ids(count: u64) {
     m::histogram!("soroban_pulse_sse_multi_contract_ids").record(count as f64);

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -82,11 +82,13 @@ pub struct AppState {
         handlers::status,
         handlers::get_events,
         handlers::get_event_stats,
+        handlers::get_contract_stats_history,
         handlers::get_events_diff,
         handlers::export_events,
         handlers::get_recent_events,
         handlers::get_events_by_contract,
         handlers::get_events_by_tx,
+        handlers::get_related_events_by_tx,
         handlers::get_events_by_ledger_hash,
         handlers::get_events_by_tx_batch,
         handlers::stream_events,
@@ -98,6 +100,7 @@ pub struct AppState {
         handlers::replay_events,
         handlers::start_reencrypt,
         handlers::register_contract_abi,
+        handlers::get_contract_abi,
         handlers::anonymize_event,
         handlers::pause_indexer,
         handlers::resume_indexer,
@@ -325,7 +328,7 @@ pub fn create_router_with_tx_and_tenant_map(
     let admin_routes = Router::new()
         .route("/admin/replay", axum::routing::post(handlers::replay_events))
         .route("/admin/reencrypt", axum::routing::post(handlers::start_reencrypt))
-        .route("/admin/contracts/{contract_id}/abi", axum::routing::post(handlers::register_contract_abi))
+        .route("/admin/contracts/{contract_id}/abi", axum::routing::post(handlers::register_contract_abi).get(handlers::get_contract_abi))
         .route("/admin/events/{id}/anonymize", axum::routing::post(handlers::anonymize_event))
         .route("/admin/indexer/pause", axum::routing::post(handlers::pause_indexer))
         .route("/admin/indexer/resume", axum::routing::post(handlers::resume_indexer))
@@ -340,6 +343,7 @@ pub fn create_router_with_tx_and_tenant_map(
     let v1 = Router::new()
         .route("/events", get(handlers::get_events))
         .route("/events/stats", get(handlers::get_event_stats))
+        .route("/contracts/{contract_id}/stats/history", get(handlers::get_contract_stats_history))
         .route("/events/diff", get(handlers::get_events_diff))
         .route("/events/export", get(handlers::export_events))
         .route("/events/timeseries", get(handlers::get_timeseries))
@@ -363,6 +367,7 @@ pub fn create_router_with_tx_and_tenant_map(
             "/admin/events/bulk",
             axum::routing::post(handlers::bulk_insert_events),
         )
+        .route("/events/tx/{tx_hash}/related", get(handlers::get_related_events_by_tx))
         .route("/events/tx/{tx_hash}", get(handlers::get_events_by_tx))
         .route(
             "/events/ledger-hash/{hash}",
@@ -373,7 +378,7 @@ pub fn create_router_with_tx_and_tenant_map(
         .route("/admin/reencrypt", axum::routing::post(handlers::start_reencrypt))
         .route("/admin/mask-events", axum::routing::post(handlers::start_mask_events))
         .route("/admin/mask-events/{job_id}", get(handlers::get_mask_job_status))
-        .route("/admin/contracts/{contract_id}/abi", axum::routing::post(handlers::register_contract_abi))
+        .route("/admin/contracts/{contract_id}/abi", axum::routing::post(handlers::register_contract_abi).get(handlers::get_contract_abi))
         .route("/admin/events/{id}/anonymize", axum::routing::post(handlers::anonymize_event))
         .route("/admin/events/contract/{contract_id}", axum::routing::delete(handlers::delete_contract_events))
         .route("/admin/indexer/pause", axum::routing::post(handlers::pause_indexer))

--- a/src/stats_refresh.rs
+++ b/src/stats_refresh.rs
@@ -8,6 +8,7 @@ use tracing::{error, info, warn};
 const VIEWS: &[&str] = &[
     "events_daily_summary",
     "events_contract_summary",
+    "mv_contract_summary",
     "events_hourly_volume",
 ];
 

--- a/tests/integration_tests.rs
+++ b/tests/integration_tests.rs
@@ -772,6 +772,125 @@ async fn stats_requires_auth_when_key_configured(pool: PgPool) {
     assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
 }
 
+#[sqlx::test(migrations = "./migrations")]
+async fn contract_history_returns_daily_buckets_from_matview(pool: PgPool) {
+    let contract_id = "CH23456789012345678901234567890123456789012345678901234X";
+    for (day, tx_hash) in [
+        ("2026-05-28T12:00:00Z", "100000000000000000000000000000000000000000000000000000000000000a"),
+        ("2026-05-28T13:00:00Z", "100000000000000000000000000000000000000000000000000000000000000b"),
+        ("2026-05-30T12:00:00Z", "100000000000000000000000000000000000000000000000000000000000000c"),
+    ] {
+        sqlx::query(
+            "INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data)
+             VALUES ($1, 'contract', $2, 1, $3::timestamptz, '{}'::jsonb)",
+        )
+        .bind(contract_id)
+        .bind(tx_hash)
+        .bind(day)
+        .execute(&pool)
+        .await
+        .unwrap();
+    }
+    sqlx::query("REFRESH MATERIALIZED VIEW mv_contract_summary").execute(&pool).await.unwrap();
+
+    let app = make_router(pool, None);
+    let resp = app.oneshot(Request::builder()
+        .uri(format!("/v1/contracts/{contract_id}/stats/history?bucket=1d&from=2026-05-28&to=2026-05-30"))
+        .body(Body::empty()).unwrap()).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(resp.into_body(), usize::MAX).await.unwrap()).unwrap();
+    let data = body["data"].as_array().unwrap();
+    assert_eq!(data.len(), 3);
+    assert_eq!(data[0]["event_count"], 2);
+    assert_eq!(data[0]["unique_tx_count"], 2);
+    assert_eq!(data[1]["event_count"], 0);
+    assert_eq!(data[2]["event_count"], 1);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn related_tx_endpoint_follows_event_data_tx_hash_references(pool: PgPool) {
+    let contract_a = "CA23456789012345678901234567890123456789012345678901234X";
+    let contract_b = "CB23456789012345678901234567890123456789012345678901234X";
+    let root = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+    let related = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
+
+    sqlx::query(
+        "INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data)
+         VALUES ($1, 'contract', $2, 1, NOW(), $3)",
+    )
+    .bind(contract_a)
+    .bind(root)
+    .bind(serde_json::json!({"value": {"related_tx_hash": related}, "topic": ["swap"]}))
+    .execute(&pool)
+    .await
+    .unwrap();
+    sqlx::query(
+        "INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data)
+         VALUES ($1, 'contract', $2, 2, NOW(), '{}'::jsonb)",
+    )
+    .bind(contract_b)
+    .bind(related)
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let app = make_router(pool, None);
+    let resp = app.oneshot(Request::builder()
+        .uri(format!("/v1/events/tx/{root}/related?depth=1"))
+        .body(Body::empty()).unwrap()).await.unwrap();
+
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body: serde_json::Value =
+        serde_json::from_slice(&to_bytes(resp.into_body(), usize::MAX).await.unwrap()).unwrap();
+    assert_eq!(body["total"], 2);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn abi_registration_retrieval_and_backfill_decoded_data(pool: PgPool) {
+    let contract_id = "CD23456789012345678901234567890123456789012345678901234X";
+    let tx_hash = "cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc";
+    sqlx::query(
+        "INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data)
+         VALUES ($1, 'contract', $2, 1, NOW(), $3)",
+    )
+    .bind(contract_id)
+    .bind(tx_hash)
+    .bind(serde_json::json!({"topic": ["transfer"], "value": {"from": "GABC", "to": "GDEF", "amount": "1000"}}))
+    .execute(&pool)
+    .await
+    .unwrap();
+
+    let app = make_router(pool.clone(), None);
+    let abi = serde_json::json!([{"name": "transfer", "inputs": [{"name": "from"}, {"name": "to"}, {"name": "amount"}]}]);
+    let resp = app.clone().oneshot(Request::builder()
+        .method("POST")
+        .uri(format!("/v1/admin/contracts/{contract_id}/abi"))
+        .header(header::CONTENT_TYPE, "application/json")
+        .body(Body::from(abi.to_string())).unwrap()).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let resp = app.oneshot(Request::builder()
+        .uri(format!("/v1/admin/contracts/{contract_id}/abi"))
+        .body(Body::empty()).unwrap()).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    for _ in 0..20 {
+        let decoded: Option<serde_json::Value> =
+            sqlx::query_scalar("SELECT event_data_decoded FROM events WHERE tx_hash = $1")
+                .bind(tx_hash)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        if decoded.as_ref().and_then(|v| v.get("amount")) == Some(&serde_json::json!("1000")) {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!("event_data_decoded was not backfilled");
+}
+
 // --- GET /v1/events with empty DB ---
 
 #[sqlx::test(migrations = "./migrations")]


### PR DESCRIPTION
Closes #447
Closes #445
Closes #442

Summary:
- Add daily contract stats history backed by mv_contract_summary with event_count and unique_tx_count buckets.
- Add ABI registration retrieval plus backfill decoding for existing events and indexer decoding via stellar-xdr.
- Add related transaction event traversal using tx hash references in event_data.
- Add histogram metric and integration coverage for seeded history, related txs, and ABI backfill.

Verification:
- jq empty openapi.json docs/openapi.json
- cargo check currently fails on pre-existing repository errors unrelated to this patch, including unresolved bytes import, missing metrics helpers, missing topic_filter, and missing config fields.