### PR TITLE
feat: topic filter params (#444) and Lua preview endpoint (#446)

### DIFF
--- a/docs/lua-transformation.md
+++ b/docs/lua-transformation.md
@@ -278,6 +278,86 @@ See `examples/transform_example.lua` for a comprehensive example demonstrating:
 - Limited to synchronous operations
 - Cannot modify the event schema (add/remove top-level fields)
 
+---
+
+## Preview Endpoint
+
+Before deploying a new Lua script to production, you can test it against real
+events using the preview endpoint. The script runs in memory — **no database
+writes occur**.
+
+### `POST /v1/admin/lua/preview`
+
+**Authentication:** `Authorization: Bearer <ADMIN_API_KEY>`
+
+**Request body:**
+
+```json
+{
+  "script": "function transform_event(e)\n  e.value.tag = 'preview'\n  return e\nend",
+  "event_ids": [
+    "11111111-1111-1111-1111-111111111111",
+    "22222222-2222-2222-2222-222222222222"
+  ]
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `script` | string | Full Lua script text. Must define `transform_event(event)`. |
+| `event_ids` | UUID[] | IDs of existing events to test against. Maximum **20**. |
+
+**Response:**
+
+```json
+{
+  "results": [
+    {
+      "event_id": "11111111-1111-1111-1111-111111111111",
+      "original":    { "contractId": "CABC...", "value": { "amount": 100 } },
+      "transformed": { "contractId": "CABC...", "value": { "amount": 100, "tag": "preview" } },
+      "error": null
+    },
+    {
+      "event_id": "22222222-2222-2222-2222-222222222222",
+      "original":    { "contractId": "CDEF...", "value": {} },
+      "transformed": null,
+      "error": "Instruction limit exceeded"
+    }
+  ]
+}
+```
+
+| Field | Description |
+|-------|-------------|
+| `original` | The event data as it exists in the database. |
+| `transformed` | The event data after the script ran. `null` when the script returned `nil` (event would be skipped) or an error occurred. |
+| `error` | Per-event error message (script compilation failure, timeout, instruction/memory limit). `null` on success. |
+
+### Resource limits during preview
+
+The preview applies the same limits as the production transformer:
+
+| Limit | Value |
+|-------|-------|
+| CPU instructions | 1 000 000 per event |
+| Memory | 64 MB per event |
+| Timeout | `EVENT_TRANSFORM_TIMEOUT_MS` (default 100 ms) |
+
+### cURL example
+
+```bash
+curl -X POST https://your-host/v1/admin/lua/preview \
+  -H "Authorization: Bearer $ADMIN_API_KEY" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "script": "function transform_event(e)\n  if e.value.amount then\n    e.value.amount = e.value.amount * 2\n  end\n  return e\nend",
+    "event_ids": ["YOUR-EVENT-UUID"]
+  }'
+```
+
+---
+
 ## Future Enhancements
 
 Potential future improvements:

--- a/migrations/20260530000000_topic_1_2_3_gin.sql
+++ b/migrations/20260530000000_topic_1_2_3_gin.sql
@@ -1,0 +1,15 @@
+-- GIN indexes for topic[1], topic[2], topic[3] to support server-side
+-- filtering by individual topic position without a full table scan.
+--
+-- topic[0] is already covered by the generated column topic_0_sym and its
+-- btree index (migration 20260428000000_topic_0_sym.sql).
+-- These GIN expressions use jsonb containment (@>) which leverages the index.
+
+CREATE INDEX IF NOT EXISTS idx_events_topic_1_gin
+    ON events USING GIN ((event_data->'topic'->1) jsonb_path_ops);
+
+CREATE INDEX IF NOT EXISTS idx_events_topic_2_gin
+    ON events USING GIN ((event_data->'topic'->2) jsonb_path_ops);
+
+CREATE INDEX IF NOT EXISTS idx_events_topic_3_gin
+    ON events USING GIN ((event_data->'topic'->3) jsonb_path_ops);

--- a/src/config.rs
+++ b/src/config.rs
@@ -270,6 +270,10 @@ pub struct Config {
     pub max_ledger_range: u64,
     /// Queries exceeding this duration (ms) are logged at WARN level (issue #421).
     pub slow_query_threshold_ms: u64,
+    /// Path to Lua event transformation script (lua feature only).
+    pub event_transform_script: Option<String>,
+    /// Execution timeout for Lua scripts in milliseconds (default: 100).
+    pub event_transform_timeout_ms: u64,
 }
 
 impl Default for Config {
@@ -350,6 +354,8 @@ impl Default for Config {
             rpc_max_events_per_page: 200,
             max_ledger_range: 100_000,
             slow_query_threshold_ms: 1000,
+            event_transform_script: None,
+            event_transform_timeout_ms: 100,
         }
     }
 }
@@ -1143,6 +1149,14 @@ impl Config {
                 &mut errors,
             )
             .unwrap_or(1000),
+            event_transform_script: std::env::var("EVENT_TRANSFORM_SCRIPT").ok(),
+            event_transform_timeout_ms: parse_int::<u64>(
+                "EVENT_TRANSFORM_TIMEOUT_MS",
+                &env_or_file_or("EVENT_TRANSFORM_TIMEOUT_MS", &file, "100"),
+                "100",
+                &mut errors,
+            )
+            .unwrap_or(100),
         }
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -1300,6 +1300,10 @@ fn ndjson_response(events: impl Iterator<Item = Value>) -> Response<Body> {
         ("sort" = Option<String>, Query, description = "Sort order: asc (oldest first) or desc (newest first, default)"),
         ("sort_by" = Option<crate::models::SortBy>, Query, description = "Sort column: ledger (default), timestamp, or created_at"),
         ("topic_sym" = Option<String>, Query, description = "Filter by first topic symbol (uses topic_0_sym generated column index)"),
+        ("topic_0" = Option<String>, Query, description = "Filter by exact value of topic[0] (e.g. 'transfer'). Uses the topic_0_sym generated-column index for O(log n) lookups."),
+        ("topic_1" = Option<String>, Query, description = "Filter by exact value of topic[1]. Uses GIN index on event_data->'topic'."),
+        ("topic_2" = Option<String>, Query, description = "Filter by exact value of topic[2]. Uses GIN index on event_data->'topic'."),
+        ("topic_3" = Option<String>, Query, description = "Filter by exact value of topic[3]. Uses GIN index on event_data->'topic'."),
         ("search" = Option<String>, Query, description = "Full-text search query for event_data (searches all string values in the JSON)"),
         ("compact" = Option<bool>, Query, description = "Return event_data as a base64-encoded gzip-compressed JSON string instead of the full JSON object. Clients that need the full data can decode it; clients that only need metadata can ignore it. Default: false."),
     ),
@@ -1456,6 +1460,24 @@ pub async fn get_events(
             conditions.push(format!("event_data->'topic' @> ${bind_idx}::jsonb"));
             bind_idx += 1;
         }
+        // topic_0 uses the generated topic_0_sym column index for efficiency
+        if params.topic_0.is_some() {
+            conditions.push(format!("topic_0_sym = ${bind_idx}"));
+            bind_idx += 1;
+        }
+        // topic_1/2/3 use GIN index on event_data->'topic'
+        if params.topic_1.is_some() {
+            conditions.push(format!("event_data->'topic'->1 @> ${bind_idx}::jsonb"));
+            bind_idx += 1;
+        }
+        if params.topic_2.is_some() {
+            conditions.push(format!("event_data->'topic'->2 @> ${bind_idx}::jsonb"));
+            bind_idx += 1;
+        }
+        if params.topic_3.is_some() {
+            conditions.push(format!("event_data->'topic'->3 @> ${bind_idx}::jsonb"));
+            bind_idx += 1;
+        }
         if params.search.is_some() {
             conditions.push(format!(
                 "event_data_tsv @@ plainto_tsquery('english', ${bind_idx})"
@@ -1547,6 +1569,18 @@ pub async fn get_events(
         }
         if let Some(ref tf) = topic_filter {
             q = q.bind(tf.to_string());
+        }
+        if let Some(ref t0) = params.topic_0 {
+            q = q.bind(t0);
+        }
+        if let Some(ref t1) = params.topic_1 {
+            q = q.bind(serde_json::json!(t1).to_string());
+        }
+        if let Some(ref t2) = params.topic_2 {
+            q = q.bind(serde_json::json!(t2).to_string());
+        }
+        if let Some(ref t3) = params.topic_3 {
+            q = q.bind(serde_json::json!(t3).to_string());
         }
         if let Some(ref search) = params.search {
             q = q.bind(search);
@@ -3382,6 +3416,90 @@ async fn get_indexed_ledger_range(
         (status = 403, description = "Forbidden - not the active indexer"),
     )
 )]
+/// Preview how a Lua transformation script would affect a set of events
+/// without writing any changes to the database.
+///
+/// Applies the same CPU instruction limit, memory limit, and timeout as the
+/// production transformer so operator can verify safety before deploying.
+#[utoipa::path(
+    post,
+    path = "/v1/admin/lua/preview",
+    tag = "admin",
+    request_body = models::LuaPreviewRequest,
+    params(
+        ("X-Admin-API-Key" = String, Header, description = "Admin API key"),
+    ),
+    responses(
+        (status = 200, description = "Preview results — original and transformed event data side-by-side",
+            body = models::LuaPreviewResponse),
+        (status = 400, description = "Invalid request — too many event_ids or empty script"),
+        (status = 401, description = "Unauthorized"),
+        (status = 404, description = "One or more event_ids not found"),
+    )
+)]
+pub async fn lua_preview(
+    State(state): State<AppState>,
+    Json(req): Json<models::LuaPreviewRequest>,
+) -> Result<Json<models::LuaPreviewResponse>, AppError> {
+    const MAX_PREVIEW_EVENTS: usize = 20;
+
+    if req.script.trim().is_empty() {
+        return Err(AppError::Validation("script must not be empty".into()));
+    }
+    if req.event_ids.is_empty() {
+        return Err(AppError::Validation("event_ids must not be empty".into()));
+    }
+    if req.event_ids.len() > MAX_PREVIEW_EVENTS {
+        return Err(AppError::Validation(format!(
+            "event_ids must contain at most {MAX_PREVIEW_EVENTS} entries"
+        )));
+    }
+
+    // Fetch the requested events from the DB (read-only)
+    let ids: Vec<uuid::Uuid> = req.event_ids.clone();
+    let rows = sqlx::query_as::<_, crate::models::Event>(
+        "SELECT * FROM events WHERE id = ANY($1) LIMIT 20",
+    )
+    .bind(&ids)
+    .fetch_all(&state.read_pool)
+    .await?;
+
+    if rows.is_empty() {
+        return Err(AppError::NotFound);
+    }
+
+    // Map Event → SorobanEvent for the transformer
+    let events: Vec<crate::models::SorobanEvent> = rows
+        .into_iter()
+        .map(|r| crate::models::SorobanEvent {
+            contract_id: r.contract_id,
+            event_type: format!("{:?}", r.event_type).to_lowercase(),
+            tx_hash: r.tx_hash,
+            ledger: r.ledger as u64,
+            ledger_closed_at: r.timestamp.to_rfc3339(),
+            ledger_hash: r.ledger_hash,
+            in_successful_call: r.in_successful_call,
+            value: r.event_data.clone(),
+            topic: r.event_data
+                .get("topic")
+                .and_then(|t| t.as_array())
+                .cloned(),
+        })
+        .collect();
+
+    let timeout_ms = state.config.event_transform_timeout_ms;
+
+    let mut results =
+        crate::lua_transform::LuaTransformer::preview_events(req.script, events, timeout_ms).await;
+
+    // Re-attach the caller-supplied UUIDs so the response matches the request
+    for (item, id) in results.iter_mut().zip(req.event_ids.iter()) {
+        item.event_id = *id;
+    }
+
+    Ok(Json(models::LuaPreviewResponse { results }))
+}
+
 pub async fn replay_events(
     State(state): State<AppState>,
     Json(request): Json<models::ReplayRequest>,
@@ -7998,6 +8116,246 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // -----------------------------------------------------------------------
+    // #444 — Topic filter tests
+    // -----------------------------------------------------------------------
+
+    /// Helper: insert an event with a known topic[0] sym value.
+    async fn insert_event_with_topic(pool: &PgPool, contract_id: &str, topic_sym: &str) -> Uuid {
+        let id = Uuid::new_v4();
+        let event_data = json!({ "topic": [{ "sym": topic_sym }], "value": {} });
+        sqlx::query(
+            "INSERT INTO events (id, contract_id, event_type, tx_hash, ledger, timestamp, event_data)
+             VALUES ($1, $2, 'contract', $3, $4, NOW(), $5)",
+        )
+        .bind(id)
+        .bind(contract_id)
+        .bind(format!("{id}"))
+        .bind(1_i64)
+        .bind(&event_data)
+        .execute(pool)
+        .await
+        .unwrap();
+        id
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn topic_0_filter_returns_matching_events(pool: PgPool) {
+        let cid = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0000";
+        insert_event_with_topic(&pool, cid, "transfer").await;
+        insert_event_with_topic(&pool, cid, "mint").await;
+
+        let app = create_test_router(pool);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/events?topic_0=transfer")
+                    .header("Authorization", "Bearer test-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        let events = v["events"].as_array().unwrap();
+        assert_eq!(events.len(), 1, "only the 'transfer' event should be returned");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn topic_0_filter_returns_empty_when_no_match(pool: PgPool) {
+        let cid = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0001";
+        insert_event_with_topic(&pool, cid, "mint").await;
+
+        let app = create_test_router(pool);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v1/events?topic_0=transfer")
+                    .header("Authorization", "Bearer test-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = to_bytes(resp.into_body(), usize::MAX).await.unwrap();
+        let v: Value = serde_json::from_slice(&body).unwrap();
+        let events = v["events"].as_array().unwrap();
+        assert!(events.is_empty());
+    }
+
+    // -----------------------------------------------------------------------
+    // #446 — Lua preview endpoint tests
+    // -----------------------------------------------------------------------
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn lua_preview_rejects_empty_script(pool: PgPool) {
+        let app = create_admin_router(pool);
+        let body = serde_json::to_string(&json!({
+            "script": "",
+            "event_ids": [Uuid::new_v4()]
+        }))
+        .unwrap();
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/lua/preview")
+                    .header("Authorization", "Bearer admin-key")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn lua_preview_rejects_too_many_event_ids(pool: PgPool) {
+        let ids: Vec<_> = (0..21).map(|_| Uuid::new_v4()).collect();
+        let app = create_admin_router(pool);
+        let body = serde_json::to_string(&json!({
+            "script": "function transform_event(e) return e end",
+            "event_ids": ids
+        }))
+        .unwrap();
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/lua/preview")
+                    .header("Authorization", "Bearer admin-key")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn lua_preview_returns_404_when_events_not_found(pool: PgPool) {
+        let app = create_admin_router(pool);
+        let body = serde_json::to_string(&json!({
+            "script": "function transform_event(e) return e end",
+            "event_ids": [Uuid::new_v4()]
+        }))
+        .unwrap();
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/lua/preview")
+                    .header("Authorization", "Bearer admin-key")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn lua_preview_does_not_modify_database(pool: PgPool) {
+        let event_id = Uuid::new_v4();
+        sqlx::query(
+            "INSERT INTO events (id, contract_id, event_type, tx_hash, ledger, timestamp, event_data)
+             VALUES ($1, 'CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA0002',
+                     'contract', $2, 1, NOW(), $3)",
+        )
+        .bind(event_id)
+        .bind(format!("{event_id}"))
+        .bind(json!({"value": 42, "topic": []}))
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let app = create_admin_router(pool.clone());
+        // Script that would change the value field
+        let body = serde_json::to_string(&json!({
+            "script": "function transform_event(e) e.value = {value=999} return e end",
+            "event_ids": [event_id]
+        }))
+        .unwrap();
+
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/lua/preview")
+                    .header("Authorization", "Bearer admin-key")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Preview must succeed
+        assert_eq!(resp.status(), StatusCode::OK);
+
+        // DB must be unchanged
+        let row: Value = sqlx::query_scalar("SELECT event_data FROM events WHERE id = $1")
+            .bind(event_id)
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(row["value"], 42, "database must not be modified by preview");
+    }
+
+    #[sqlx::test(migrations = "./migrations")]
+    async fn lua_preview_requires_admin_key(pool: PgPool) {
+        let app = create_admin_auth_router(pool);
+        let body = serde_json::to_string(&json!({
+            "script": "function transform_event(e) return e end",
+            "event_ids": [Uuid::new_v4()]
+        }))
+        .unwrap();
+
+        // No auth
+        let resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/lua/preview")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body.clone()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+
+        // Regular API key (not admin)
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v1/admin/lua/preview")
+                    .header("Authorization", "Bearer regular-key")
+                    .header("Content-Type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
     }
 }
 

--- a/src/lua_transform.rs
+++ b/src/lua_transform.rs
@@ -4,7 +4,7 @@
 //! before they are stored in the database. Scripts can modify event data or
 //! return nil to skip events entirely.
 
-use crate::models::SorobanEvent;
+use crate::models::{LuaPreviewItem, SorobanEvent};
 use crate::metrics;
 use anyhow::{Context, Result};
 use mlua::{Lua, Table, Value as LuaValue};
@@ -280,6 +280,88 @@ impl LuaTransformer {
                 value.type_name()
             )),
         }
+    }
+
+    /// Preview a Lua script against a list of events **without writing to the DB**.
+    ///
+    /// Applies the same CPU instruction limit, memory limit, and timeout as the
+    /// production transformer. Each event is transformed independently; an error
+    /// on one event does not abort the rest.
+    ///
+    /// Returns one [`LuaPreviewItem`] per input event containing the original
+    /// event data, the transformed result (or `None` when the script returns
+    /// `nil`), and any per-event error message.
+    pub async fn preview_events(
+        script: String,
+        events: Vec<SorobanEvent>,
+        timeout_ms: u64,
+    ) -> Vec<LuaPreviewItem> {
+        let timeout = Duration::from_millis(timeout_ms);
+        let mut results = Vec::with_capacity(events.len());
+
+        for event in events {
+            let event_id = uuid::Uuid::new_v4(); // placeholder; caller should supply real IDs
+            let original = serde_json::to_value(&event).unwrap_or(serde_json::Value::Null);
+            let script_clone = script.clone();
+
+            let outcome = tokio::time::timeout(
+                timeout,
+                tokio::task::spawn_blocking(move || {
+                    Self::preview_event_sync(&script_clone, event)
+                }),
+            )
+            .await;
+
+            let item = match outcome {
+                Ok(Ok(Ok(Some(transformed)))) => LuaPreviewItem {
+                    event_id,
+                    original,
+                    transformed: serde_json::to_value(&transformed).ok(),
+                    error: None,
+                },
+                Ok(Ok(Ok(None))) => LuaPreviewItem {
+                    event_id,
+                    original,
+                    transformed: None,
+                    error: None,
+                },
+                Ok(Ok(Err(e))) => LuaPreviewItem {
+                    event_id,
+                    original,
+                    transformed: None,
+                    error: Some(e.to_string()),
+                },
+                Ok(Err(e)) => LuaPreviewItem {
+                    event_id,
+                    original,
+                    transformed: None,
+                    error: Some(format!("internal error: {e}")),
+                },
+                Err(_) => LuaPreviewItem {
+                    event_id,
+                    original,
+                    transformed: None,
+                    error: Some(format!(
+                        "script timeout after {}ms",
+                        timeout_ms
+                    )),
+                },
+            };
+            results.push(item);
+        }
+
+        results
+    }
+
+    /// Synchronous single-event preview used inside `spawn_blocking`.
+    /// Compiles the script from a string (not a file) and applies the same limits.
+    fn preview_event_sync(script: &str, event: SorobanEvent) -> Result<Option<SorobanEvent>> {
+        let lua = Lua::new();
+        lua.set_memory_limit(LUA_MEMORY_LIMIT_MB * 1024 * 1024)?;
+        lua.load(script)
+            .exec()
+            .context("failed to compile preview script")?;
+        Self::transform_sync(&lua, event)
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -89,6 +89,14 @@ pub struct PaginationParams {
     pub topic_sym: Option<String>,
     /// Filter by topic array using JSONB containment (e.g., ?topic=["transfer"]).
     pub topic: Option<String>,
+    /// Filter by exact value of topic[0] (e.g. "transfer"). Uses topic_0_sym index.
+    pub topic_0: Option<String>,
+    /// Filter by exact value of topic[1]. Uses GIN index on event_data->'topic'.
+    pub topic_1: Option<String>,
+    /// Filter by exact value of topic[2]. Uses GIN index on event_data->'topic'.
+    pub topic_2: Option<String>,
+    /// Filter by exact value of topic[3]. Uses GIN index on event_data->'topic'.
+    pub topic_3: Option<String>,
     /// Full-text search query for event_data (uses event_data_tsv tsvector index).
     pub search: Option<String>,
     /// Filter events at or after this timestamp (ISO 8601 format).
@@ -443,6 +451,32 @@ pub struct RpcError {
     #[allow(dead_code)]
     pub code: i64,
     pub message: String,
+}
+
+/// Request body for POST /v1/admin/lua/preview
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct LuaPreviewRequest {
+    /// The Lua script to preview. Must define a `transform_event(event)` function.
+    pub script: String,
+    /// IDs of events to apply the script to (max 20).
+    pub event_ids: Vec<uuid::Uuid>,
+}
+
+/// One entry in the preview response — original event alongside the transformed result.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct LuaPreviewItem {
+    pub event_id: uuid::Uuid,
+    pub original: serde_json::Value,
+    /// `null` when the script returned `nil` (event would be skipped).
+    pub transformed: Option<serde_json::Value>,
+    /// Non-null when the script raised an error for this event.
+    pub error: Option<String>,
+}
+
+/// Response body for POST /v1/admin/lua/preview
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct LuaPreviewResponse {
+    pub results: Vec<LuaPreviewItem>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -323,6 +323,7 @@ pub fn create_router_with_tx_and_tenant_map(
     // addition to the global auth layer. The admin layer requires an
     // ADMIN_API_KEY even when no regular API_KEY is configured.
     let admin_routes = Router::new()
+        .route("/admin/lua/preview", axum::routing::post(handlers::lua_preview))
         .route("/admin/replay", axum::routing::post(handlers::replay_events))
         .route("/admin/reencrypt", axum::routing::post(handlers::start_reencrypt))
         .route("/admin/contracts/{contract_id}/abi", axum::routing::post(handlers::register_contract_abi))


### PR DESCRIPTION
Closes #444, closes #446 
Closes #443 

## Summary

### #444 — Server-side event search by topic value
- Add `topic_0`, `topic_1`, `topic_2`, `topic_3` query parameters to `PaginationParams` in `src/models.rs`
- `topic_0` uses the existing `topic_0_sym` generated-column index for O(log n) lookups — no additional index needed
- `topic_1` / `topic_2` / `topic_3` use JSONB `@>` containment against `event_data->'topic'->N`
- New migration `20260530000000_topic_1_2_3_gin.sql` adds GIN indexes on `event_data->'topic'->1/2/3` using `jsonb_path_ops`
- OpenAPI `utoipa` param annotations added to `get_events` documenting each filter and its backing index
- Unit tests: `topic_0` returns matching events; returns empty when no match

### #446 — Lua script preview endpoint
- New `POST /v1/admin/lua/preview` endpoint: accepts a Lua script + up to 20 event IDs, transforms events **in memory only** (no DB writes), returns original and transformed event data side-by-side
- Applies the same CPU instruction limit (1 M), memory limit (64 MB), and `EVENT_TRANSFORM_TIMEOUT_MS` timeout as the production transformer — operators see exactly what production would do
- `LuaTransformer::preview_events`: compiles the script from the request body (not a file path), processes each event independently in `spawn_blocking`, captures per-event errors without aborting the batch
- New `LuaPreviewRequest` / `LuaPreviewItem` / `LuaPreviewResponse` types in `src/models.rs`
- `Config` gains `event_transform_script` and `event_transform_timeout_ms` fields (read from `EVENT_TRANSFORM_SCRIPT` / `EVENT_TRANSFORM_TIMEOUT_MS` env vars) — fixes a pre-existing compilation issue in `main.rs`
- Route registered in `admin_routes` and protected by the `ADMIN_API_KEY` auth middleware
- Unit tests: rejects empty script (400), rejects >20 event IDs (400), returns 404 when events not found, proves no DB modification, enforces admin-only auth (401/403)
- `docs/lua-transformation.md`: new **Preview Endpoint** section with request/response schema, per-field descriptions, resource limits table, and cURL example

## Test plan
- [ ] `GET /v1/events?topic_0=transfer` returns only events where `topic[0].sym == "transfer"`
- [ ] `GET /v1/events?topic_1=CABC...` filters by topic[1] value via GIN index
- [ ] `EXPLAIN ANALYZE` on `topic_0` query shows `Index Scan using idx_events_topic_0_sym`
- [ ] `POST /v1/admin/lua/preview` with a passthrough script returns identical original and transformed data
- [ ] Preview with a nil-returning script returns `transformed: null`
- [ ] Preview with an infinite-loop script returns a timeout error per event
- [ ] DB remains unchanged after a preview call that modifies event fields
- [ ] Unit tests pass in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)