### PR TITLE
feat(email): add unsubscribe links to notification emails (#483)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -238,6 +238,11 @@ MAX_EVENT_DATA_BYTES=65536
 # When unset, all events trigger notifications.
 # EMAIL_CONTRACT_FILTER=CABC...,CDEF...
 
+# Public base URL used to build the unsubscribe link embedded in each email
+# (Issue #483, CAN-SPAM/GDPR). Must be reachable by recipients. When unset,
+# defaults to http://localhost:<PORT>.
+# EMAIL_PUBLIC_BASE_URL=https://pulse.example.com
+
 # ── Redis queue publisher (requires redis-queue feature flag) ──────────────────
 # Publish each indexed event to a Redis Stream.
 # REDIS_URL=redis://localhost:6379

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Email unsubscribe links (CAN-SPAM / GDPR): every notification email now includes a per-recipient unsubscribe link and `List-Unsubscribe` header, a public `/unsubscribe` endpoint to opt out, and `EMAIL_PUBLIC_BASE_URL` to configure the link's base URL. Opted-out recipients are skipped on subsequent sends.
 - Email notification feature for event alerts with batching (one email per minute maximum)
 - Email configuration via `EMAIL_SMTP_HOST`, `EMAIL_SMTP_PORT`, `EMAIL_SMTP_USER`, `EMAIL_SMTP_PASSWORD`, `EMAIL_FROM`, `EMAIL_TO`, and `EMAIL_CONTRACT_FILTER` environment variables
 - Email notifications can be filtered by contract ID using `EMAIL_CONTRACT_FILTER`

--- a/docs/email-notifications.md
+++ b/docs/email-notifications.md
@@ -8,6 +8,7 @@ The email notification feature allows operators to receive email alerts when spe
 - **Contract Filtering**: Optional filtering to only receive notifications for specific contracts
 - **SMTP Support**: Works with any SMTP server (Gmail, SendGrid, AWS SES, etc.)
 - **Multiple Recipients**: Send notifications to multiple email addresses
+- **Unsubscribe Links**: Every email carries a per-recipient unsubscribe link and a `List-Unsubscribe` header (CAN-SPAM / GDPR). Opted-out recipients are skipped on subsequent sends.
 - **Secure**: SMTP credentials are never logged or exposed in metrics
 
 ## Configuration
@@ -26,6 +27,17 @@ Email notifications are configured via environment variables:
 - `EMAIL_SMTP_USER`: SMTP authentication username (required by most servers)
 - `EMAIL_SMTP_PASSWORD`: SMTP authentication password (required by most servers)
 - `EMAIL_CONTRACT_FILTER`: Comma-separated list of contract IDs to filter notifications
+- `EMAIL_PUBLIC_BASE_URL`: Public base URL used to build unsubscribe links (e.g. `https://pulse.example.com`). Defaults to `http://localhost:<PORT>` when unset.
+
+## Unsubscribing
+
+Each notification email includes an unsubscribe link of the form
+`<EMAIL_PUBLIC_BASE_URL>/unsubscribe?token=<token>` and a matching
+`List-Unsubscribe` header. The `/unsubscribe` endpoint is public (no API key
+required). Visiting it records the recipient's opt-out, and no further emails
+are sent to that address. The action is idempotent — re-visiting the link is
+safe. Set `EMAIL_PUBLIC_BASE_URL` to a publicly reachable URL so recipients can
+actually open the link.
 
 ## Example Configuration
 

--- a/migrations/20260601000000_email_unsubscribes.down.sql
+++ b/migrations/20260601000000_email_unsubscribes.down.sql
@@ -1,0 +1,2 @@
+-- Revert Issue #483: email unsubscribe links
+DROP TABLE IF EXISTS email_unsubscribes;

--- a/migrations/20260601000000_email_unsubscribes.sql
+++ b/migrations/20260601000000_email_unsubscribes.sql
@@ -1,0 +1,13 @@
+-- Migration for Issue #483: email unsubscribe links (CAN-SPAM / GDPR)
+-- Stores a unique, per-recipient unsubscribe token. When unsubscribed_at is
+-- non-NULL the recipient has opted out and no further emails are sent.
+CREATE TABLE IF NOT EXISTS email_unsubscribes (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    email TEXT NOT NULL UNIQUE,
+    token TEXT NOT NULL UNIQUE,
+    unsubscribed_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_email_unsubscribes_token ON email_unsubscribes(token);
+CREATE INDEX IF NOT EXISTS idx_email_unsubscribes_email ON email_unsubscribes(email);

--- a/src/config.rs
+++ b/src/config.rs
@@ -250,6 +250,10 @@ pub struct Config {
     pub email_from: Option<String>,
     pub email_to: Vec<String>,
     pub email_contract_filter: Vec<String>,
+    /// Public base URL used to build unsubscribe links in emails (Issue #483).
+    /// e.g. `https://pulse.example.com`. When unset, defaults to
+    /// `http://localhost:<PORT>`.
+    pub email_public_base_url: Option<String>,
     // SMS notification fields (Issue #473)
     pub twilio_account_sid: Option<String>,
     pub twilio_auth_token: Option<SecretString>,
@@ -385,6 +389,7 @@ impl Default for Config {
             email_from: None,
             email_to: Vec::new(),
             email_contract_filter: Vec::new(),
+            email_public_base_url: None,
             redis_url: None,
             redis_stream_key: None,
             redis_buffer_max_size: 10_000,
@@ -1169,6 +1174,7 @@ impl Config {
                         .collect()
                 })
                 .unwrap_or_default(),
+            email_public_base_url: env_or_file("EMAIL_PUBLIC_BASE_URL", &file),
             redis_url: env_or_file("REDIS_URL", &file),
             redis_stream_key: env_or_file("REDIS_STREAM_KEY", &file),
             redis_buffer_max_size: env_or_file("REDIS_BUFFER_MAX_SIZE", &file)

--- a/src/email.rs
+++ b/src/email.rs
@@ -1,15 +1,131 @@
-use lettre::message::{header, MultiPart, SinglePart};
+use lettre::message::header::{self, Header, HeaderName, HeaderValue};
 use lettre::transport::smtp::authentication::Credentials;
 use lettre::{Message, SmtpTransport, Transport};
 use secrecy::{ExposeSecret, SecretString};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 use std::time::Duration;
-use tokio::sync::mpsc;
-use tokio::time::{interval, sleep};
+use tokio::time::interval;
 use tracing::{error, info, warn};
+use uuid::Uuid;
 
 use crate::{metrics, models::SorobanEvent, retry_policy::RetryPolicy};
+
+/// The `List-Unsubscribe` header (RFC 2369). Lets conforming mail clients
+/// surface a native unsubscribe action pointing at our unsubscribe URL.
+#[derive(Clone)]
+struct ListUnsubscribe(String);
+
+impl Header for ListUnsubscribe {
+    fn name() -> HeaderName {
+        HeaderName::new_from_ascii_str("List-Unsubscribe")
+    }
+
+    fn parse(s: &str) -> Result<Self, Box<dyn std::error::Error + Send + Sync>> {
+        Ok(Self(s.to_string()))
+    }
+
+    fn display(&self) -> HeaderValue {
+        HeaderValue::new(Self::name(), self.0.clone())
+    }
+}
+
+/// Generate an opaque, URL-safe unsubscribe token.
+fn generate_unsubscribe_token() -> String {
+    // Two UUIDs (256 bits of randomness) hashed to a hex string yields a
+    // collision-resistant, opaque token that is safe to embed in a URL.
+    let raw = format!("{}{}", Uuid::new_v4(), Uuid::new_v4());
+    let digest = Sha256::digest(raw.as_bytes());
+    digest.iter().map(|b| format!("{:02x}", b)).collect()
+}
+
+/// Return the existing unsubscribe token for `email`, creating one if absent.
+/// Returns `None` only if the database is unreachable.
+pub async fn get_or_create_unsubscribe_token(
+    pool: &sqlx::PgPool,
+    email: &str,
+) -> Option<String> {
+    // Fast path: token already exists.
+    if let Ok(Some(token)) = sqlx::query_scalar::<_, String>(
+        "SELECT token FROM email_unsubscribes WHERE email = $1",
+    )
+    .bind(email)
+    .fetch_optional(pool)
+    .await
+    {
+        return Some(token);
+    }
+
+    // Insert a new token. ON CONFLICT handles a race where another sender
+    // inserted the same email concurrently — we then read back the winner.
+    let token = generate_unsubscribe_token();
+    let inserted = sqlx::query_scalar::<_, String>(
+        "INSERT INTO email_unsubscribes (email, token) VALUES ($1, $2) \
+         ON CONFLICT (email) DO NOTHING RETURNING token",
+    )
+    .bind(email)
+    .bind(&token)
+    .fetch_optional(pool)
+    .await;
+
+    match inserted {
+        Ok(Some(t)) => Some(t),
+        Ok(None) => sqlx::query_scalar::<_, String>(
+            "SELECT token FROM email_unsubscribes WHERE email = $1",
+        )
+        .bind(email)
+        .fetch_optional(pool)
+        .await
+        .ok()
+        .flatten(),
+        Err(e) => {
+            error!(error = %e, "Failed to create unsubscribe token");
+            None
+        }
+    }
+}
+
+/// True when `email` has opted out of notifications.
+pub async fn is_unsubscribed(pool: &sqlx::PgPool, email: &str) -> bool {
+    sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM email_unsubscribes \
+         WHERE email = $1 AND unsubscribed_at IS NOT NULL",
+    )
+    .bind(email)
+    .fetch_one(pool)
+    .await
+    .map(|c| c > 0)
+    .unwrap_or(false)
+}
+
+/// Mark the recipient identified by `token` as unsubscribed.
+/// Returns `Ok(true)` if a matching, not-yet-unsubscribed recipient was found.
+/// Idempotent: re-using an already-unsubscribed token returns `Ok(true)`.
+pub async fn mark_unsubscribed(pool: &sqlx::PgPool, token: &str) -> Result<bool, sqlx::Error> {
+    // Set unsubscribed_at only if not already set; report whether the token exists.
+    let updated = sqlx::query(
+        "UPDATE email_unsubscribes \
+         SET unsubscribed_at = NOW() \
+         WHERE token = $1 AND unsubscribed_at IS NULL",
+    )
+    .bind(token)
+    .execute(pool)
+    .await?;
+
+    if updated.rows_affected() > 0 {
+        return Ok(true);
+    }
+
+    // No row updated: either the token is unknown or already unsubscribed.
+    let exists = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM email_unsubscribes WHERE token = $1",
+    )
+    .bind(token)
+    .fetch_one(pool)
+    .await?;
+
+    Ok(exists > 0)
+}
 
 /// Batched email notification sender.
 /// Collects events for up to 1 minute, then sends a single summary email.
@@ -23,9 +139,12 @@ pub struct EmailNotifier {
     contract_filter: Vec<String>,
     retry_policy: RetryPolicy,
     pool: sqlx::PgPool,
+    /// Base URL used to build unsubscribe links (Issue #483).
+    base_url: String,
 }
 
 impl EmailNotifier {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         smtp_host: String,
         smtp_port: u16,
@@ -36,6 +155,7 @@ impl EmailNotifier {
         contract_filter: Vec<String>,
         retry_policy: RetryPolicy,
         pool: sqlx::PgPool,
+        base_url: String,
     ) -> Self {
         Self {
             smtp_host,
@@ -47,6 +167,7 @@ impl EmailNotifier {
             contract_filter,
             retry_policy,
             pool,
+            base_url,
         }
     }
 
@@ -179,30 +300,71 @@ impl EmailNotifier {
             body.push('\n');
         }
 
-        // Build and send email
-        if let Err(e) = self.send_email(&subject, &body).await {
-            error!(error = %e, "Failed to send email notification");
-            metrics::record_email_failure();
-        } else {
+        // Send a separate message to each recipient so every email carries its
+        // own unsubscribe link (Issue #483). Recipients who have opted out are
+        // skipped entirely.
+        let mut sent = 0usize;
+        for recipient in &self.to {
+            if is_unsubscribed(&self.pool, recipient).await {
+                info!(recipient = %recipient, "Recipient has unsubscribed, skipping");
+                continue;
+            }
+
+            let unsubscribe_url = get_or_create_unsubscribe_token(&self.pool, recipient)
+                .await
+                .map(|token| {
+                    format!(
+                        "{}/unsubscribe?token={}",
+                        self.base_url.trim_end_matches('/'),
+                        token
+                    )
+                });
+
+            let mut personalized = body.clone();
+            if let Some(ref url) = unsubscribe_url {
+                personalized.push_str(&format!(
+                    "\n--\nYou are receiving this because you subscribed to Soroban Pulse \
+                     notifications.\nTo unsubscribe, visit: {url}\n"
+                ));
+            }
+
+            if let Err(e) = self
+                .send_email(recipient, &subject, &personalized, unsubscribe_url.as_deref())
+                .await
+            {
+                error!(error = %e, recipient = %recipient, "Failed to send email notification");
+                metrics::record_email_failure();
+            } else {
+                sent += 1;
+            }
+        }
+
+        if sent > 0 {
             info!(
-                recipients = self.to.len(),
+                recipients = sent,
                 event_count = events.len(),
                 "Email notification sent successfully"
             );
         }
     }
 
-    /// Send an email using SMTP.
+    /// Send an email to a single recipient using SMTP. When `unsubscribe_url`
+    /// is set, a `List-Unsubscribe` header is added so mail clients can offer a
+    /// one-click unsubscribe (RFC 2369 / CAN-SPAM compliance, Issue #483).
     async fn send_email(
         &self,
+        recipient: &str,
         subject: &str,
         body: &str,
+        unsubscribe_url: Option<&str>,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        // Build message with all recipients
-        let mut message_builder = Message::builder().from(self.from.parse()?).subject(subject);
+        let mut message_builder = Message::builder()
+            .from(self.from.parse()?)
+            .to(recipient.parse()?)
+            .subject(subject);
 
-        for recipient in &self.to {
-            message_builder = message_builder.to(recipient.parse()?);
+        if let Some(url) = unsubscribe_url {
+            message_builder = message_builder.header(ListUnsubscribe(format!("<{url}>")));
         }
 
         let message = message_builder
@@ -252,6 +414,7 @@ mod tests {
 
     #[test]
     fn test_email_notifier_creation() {
+        let pool = sqlx::PgPool::connect_lazy("postgres://localhost/unused").unwrap();
         let notifier = EmailNotifier::new(
             "smtp.example.com".to_string(),
             587,
@@ -260,12 +423,36 @@ mod tests {
             "from@example.com".to_string(),
             vec!["to@example.com".to_string()],
             vec![],
+            RetryPolicy::default(),
+            pool,
+            "https://pulse.example.com".to_string(),
         );
 
         assert_eq!(notifier.smtp_host, "smtp.example.com");
+        assert_eq!(notifier.base_url, "https://pulse.example.com");
         assert_eq!(notifier.smtp_port, 587);
         assert_eq!(notifier.from, "from@example.com");
         assert_eq!(notifier.to.len(), 1);
+    }
+
+    #[test]
+    fn test_unsubscribe_token_is_opaque_and_unique() {
+        let a = generate_unsubscribe_token();
+        let b = generate_unsubscribe_token();
+        assert_ne!(a, b, "tokens must be unique");
+        assert_eq!(a.len(), 64, "sha256 hex digest is 64 chars");
+        assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn test_list_unsubscribe_header_display() {
+        let h = ListUnsubscribe("<https://pulse.example.com/unsubscribe?token=abc>".to_string());
+        assert_eq!(
+            ListUnsubscribe::name(),
+            HeaderName::new_from_ascii_str("List-Unsubscribe")
+        );
+        // display() must not panic and round-trips the raw value.
+        let _ = h.display();
     }
 
     #[test]

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -539,6 +539,65 @@ pub async fn health_ready(State(state): State<AppState>) -> (StatusCode, Json<Va
     (status, Json(body))
 }
 
+/// Query parameters for the email unsubscribe endpoint (Issue #483).
+#[derive(serde::Deserialize)]
+pub struct UnsubscribeQuery {
+    pub token: String,
+}
+
+/// Public, unauthenticated endpoint that recipients reach from the
+/// "unsubscribe" link in notification emails (Issue #483, CAN-SPAM/GDPR).
+/// Marks the token's recipient as opted out and returns a small HTML page.
+#[utoipa::path(
+    get,
+    path = "/unsubscribe",
+    tag = "system",
+    params(("token" = String, Query, description = "Per-recipient unsubscribe token")),
+    responses(
+        (status = 200, description = "Unsubscribed (or already unsubscribed)"),
+        (status = 404, description = "Unknown unsubscribe token"),
+    )
+)]
+pub async fn unsubscribe(
+    State(state): State<AppState>,
+    Query(query): Query<UnsubscribeQuery>,
+) -> Response {
+    fn html_page(status: StatusCode, title: &str, message: &str) -> Response {
+        let body = format!(
+            "<!DOCTYPE html><html><head><meta charset=\"utf-8\">\
+             <title>{title}</title></head><body style=\"font-family:sans-serif;\
+             max-width:32rem;margin:4rem auto;text-align:center;\">\
+             <h1>{title}</h1><p>{message}</p></body></html>"
+        );
+        Response::builder()
+            .status(status)
+            .header(header::CONTENT_TYPE, "text/html; charset=utf-8")
+            .body(Body::from(body))
+            .expect("static html response is always valid")
+    }
+
+    match crate::email::mark_unsubscribed(&state.pool, &query.token).await {
+        Ok(true) => html_page(
+            StatusCode::OK,
+            "Unsubscribed",
+            "You have been unsubscribed from Soroban Pulse notifications.",
+        ),
+        Ok(false) => html_page(
+            StatusCode::NOT_FOUND,
+            "Invalid link",
+            "This unsubscribe link is not valid.",
+        ),
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to process unsubscribe request");
+            html_page(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Something went wrong",
+                "We could not process your request. Please try again later.",
+            )
+        }
+    }
+}
+
 #[utoipa::path(
     get,
     path = "/v1/status",

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,6 +243,12 @@ async fn main() -> anyhow::Result<()> {
         if let Some(ref from) = config.email_from {
             if !config.email_to.is_empty() {
                 let email_rx = event_tx.subscribe();
+                // Base URL for unsubscribe links (Issue #483): honor the
+                // configured public URL, otherwise fall back to localhost:<port>.
+                let base_url = config
+                    .email_public_base_url
+                    .clone()
+                    .unwrap_or_else(|| format!("http://localhost:{}", config.port));
                 let notifier = email::EmailNotifier::new(
                     smtp_host.clone(),
                     config.email_smtp_port,
@@ -253,6 +259,7 @@ async fn main() -> anyhow::Result<()> {
                     config.email_contract_filter.clone(),
                     config.email_retry_policy.clone(),
                     pool.clone(),
+                    base_url,
                 );
 
                 info!(

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -74,8 +74,8 @@ pub async fn auth_middleware(
 ) -> Result<Response, (StatusCode, Json<serde_json::Value>)> {
     let path = req.uri().path();
 
-    // Exclude /health and /healthz/*
-    if path == "/health" || path.starts_with("/healthz/") {
+    // Exclude /health, /healthz/* and the public unsubscribe endpoint (#483).
+    if path == "/health" || path.starts_with("/healthz/") || path == "/unsubscribe" {
         return Ok(next.run(req).await);
     }
 

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -442,10 +442,13 @@ pub fn create_router_with_tx_and_tenant_map(
         ));
 
     // Health endpoints — exempt from rate limiting.
+    // The unsubscribe endpoint is public (reached from email links) and must
+    // bypass both auth and rate limiting (Issue #483).
     let health_routes = Router::new()
         .route("/health", get(handlers::health))
         .route("/healthz/live", get(handlers::health_live))
         .route("/healthz/ready", get(handlers::health_ready))
+        .route("/unsubscribe", get(handlers::unsubscribe))
         .route("/metrics", get(handlers::metrics));
 
     // All other routes — subject to rate limiting.


### PR DESCRIPTION
## Summary

Adds CAN-SPAM / GDPR compliant **unsubscribe links** to email notifications.

- New `email_unsubscribes` table storing a unique per-recipient token and opt-out timestamp (with down migration).
- Token helpers in `src/email.rs`: `get_or_create_unsubscribe_token`, `is_unsubscribed`, `mark_unsubscribed` (idempotent).
- `EmailNotifier` now sends **one message per recipient**, embedding a personalized unsubscribe link and a `List-Unsubscribe` header (RFC 2369). Recipients who have opted out are skipped.
- Public `GET /unsubscribe?token=…` endpoint (no auth, no rate limiting) that records the opt-out and returns an HTML confirmation page.
- New `EMAIL_PUBLIC_BASE_URL` config to build the link URLs (defaults to `http://localhost:<port>`).
- Docs (`docs/email-notifications.md`), `.env.example`, and `CHANGELOG.md` updated.

## Testing

Added unit tests for token generation and the `List-Unsubscribe` header, and fixed the existing `EmailNotifier` construction test.

> Note: the toolchain was unavailable in my environment, so `cargo check` / `cargo test` were not run locally — please rely on CI.

Closes #483
