### PR TITLE
feat: add subscription scaffolding code generator

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -123,6 +123,10 @@ version = "53"
 version = "0.19"
 optional = true
 
+[[bin]]
+name = "gen_subscription_scaffold"
+path = "src/bin/gen_subscription_scaffold.rs"
+
 [[bench]]
 name = "pagination"
 harness = false

--- a/docs/codegen.md
+++ b/docs/codegen.md
@@ -1,0 +1,123 @@
+# Subscription Code Generator
+
+`gen_subscription_scaffold` generates a complete set of Rust source files, a SQL migration, and optionally content filter and test scaffolding for a new subscription type.
+
+## Usage
+
+```bash
+cargo run --bin gen_subscription_scaffold -- <NAME> [OPTIONS]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--output-dir <path>` | `.` (current dir) | Where to write generated files |
+| `--channel-type <type>` | `webhook` | `webhook`, `email`, or `sms` |
+| `--with-filter` | off | Generate a content filter config module |
+| `--with-tests` | off | Generate a test scaffold module |
+| `--dry-run` | off | Print files to stdout instead of writing |
+
+## Examples
+
+```bash
+# Minimal: webhook subscription named "token-transfer"
+cargo run --bin gen_subscription_scaffold -- token-transfer
+
+# Email subscription with tests
+cargo run --bin gen_subscription_scaffold -- payment \
+  --channel-type email \
+  --with-tests
+
+# Full scaffold with filter and tests, preview to stdout
+cargo run --bin gen_subscription_scaffold -- nft-sale \
+  --with-filter \
+  --with-tests \
+  --dry-run
+
+# Write to a specific directory
+cargo run --bin gen_subscription_scaffold -- dex-swap \
+  --with-filter \
+  --with-tests \
+  --output-dir /tmp/scaffold-preview
+```
+
+## Generated Files
+
+Given `NAME = token-transfer` and `--channel-type webhook`:
+
+| File | Description |
+|------|-------------|
+| `src/token_transfer_subscriptions.rs` | Axum handlers: create, get, cancel, ack; delivery worker |
+| `migrations/<ts>_add_token_transfer_subscriptions.sql` | Creates `token_transfer_subscriptions` + `token_transfer_delivery_queue` tables |
+| `src/token_transfer_webhook.rs` | Webhook delivery with HMAC signing, retry, failover, DLQ |
+| `src/token_transfer_filter_config.rs` | *(with `--with-filter`)* Filter config struct and preset bundles |
+| `tests/token_transfer_subscription_tests.rs` | *(with `--with-tests`)* Unit + integration test stubs |
+
+## Integration Steps
+
+After generation:
+
+1. **Register the module** in `src/lib.rs`:
+   ```rust
+   pub mod token_transfer_subscriptions;
+   pub mod token_transfer_webhook;          // for webhook channel
+   pub mod token_transfer_filter_config;   // if --with-filter was used
+   ```
+
+2. **Register routes** in `src/routes.rs`:
+   ```rust
+   use crate::token_transfer_subscriptions::*;
+
+   // Inside your router builder:
+   .route("/subscriptions/token-transfer",      post(create_token_transfer_subscription))
+   .route("/subscriptions/token-transfer/:id",  get(get_token_transfer_subscription))
+   .route("/subscriptions/token-transfer/:id",  delete(cancel_token_transfer_subscription))
+   .route("/subscriptions/token-transfer/:id/ack", post(ack_token_transfer_subscription))
+   ```
+
+3. **Apply the migration**:
+   ```bash
+   sqlx migrate run
+   ```
+
+4. **Start the delivery worker** alongside your main server:
+   ```rust
+   tokio::spawn(run_token_transfer_delivery_worker(pool.clone(), http_client.clone()));
+   ```
+
+5. **Wire content filters** (if generated):
+   ```rust
+   use crate::token_transfer_filter_config::{TokenTransferFilterConfig, evaluate_all};
+
+   // In your delivery worker, before posting to callback_url:
+   if !evaluate_all(&active_filters, &event_data) {
+       continue; // skip this event
+   }
+   ```
+
+6. **Run tests**:
+   ```bash
+   cargo test token_transfer            # unit tests
+   make test-db                         # integration tests (requires PostgreSQL)
+   ```
+
+## How It Works
+
+The generator lives in `src/codegen/`:
+
+| Module | Purpose |
+|--------|---------|
+| `mod.rs` | `ScaffoldConfig`, `ChannelType`, `generate_all()`, `write_files()` |
+| `subscription.rs` | Handler + migration templates |
+| `filter.rs` | Content filter config template |
+| `webhook.rs` | Webhook, email, or SMS delivery template (selected by `--channel-type`) |
+| `tests.rs` | Test scaffold template |
+
+Templates use `{{PASCAL}}` / `{{SNAKE}}` / `{{CHANNEL}}` placeholder substitution via simple `str::replace`, avoiding any external template engine dependency.
+
+## Design Decisions
+
+- **No new dependencies**: uses `str::replace` for templating instead of Handlebars or Tera.
+- **Templates match existing conventions**: generated code follows the same patterns as `subscriptions.rs` and `webhook.rs`.
+- **SQL mirrors the base schema**: generated tables parallel `subscriptions` and `delivery_queue` with the same columns and index strategy.
+- **Exponential backoff is preserved**: generated retry SQL uses `LEAST(POWER(2, attempts + 1), 3600)` — identical to the base worker.
+- **SSRF protection reused**: generated handlers call `validate_callback_url()` from `crate::subscriptions` rather than duplicating the logic.

--- a/src/bin/gen_subscription_scaffold.rs
+++ b/src/bin/gen_subscription_scaffold.rs
@@ -1,0 +1,244 @@
+//! Subscription scaffolding generator CLI.
+//!
+//! Generates a complete set of Rust source files, SQL migration, and tests
+//! for a new named subscription + delivery channel.
+//!
+//! Usage:
+//!   gen_subscription_scaffold <NAME> [OPTIONS]
+//!
+//! Options:
+//!   --output-dir <path>      Destination directory (default: current directory)
+//!   --channel-type <type>    webhook | email | sms  (default: webhook)
+//!   --with-filter            Also generate content filter configuration module
+//!   --with-tests             Also generate a test scaffold module
+//!   --dry-run                Print file contents to stdout; do not write files
+//!
+//! Examples:
+//!   cargo run --bin gen_subscription_scaffold -- token-transfer
+//!   cargo run --bin gen_subscription_scaffold -- payment --channel-type email --with-tests
+//!   cargo run --bin gen_subscription_scaffold -- nft-sale --with-filter --with-tests --dry-run
+
+use soroban_pulse::codegen::{self, ChannelType, GeneratedFile, ScaffoldConfig};
+use std::{path::PathBuf, process};
+
+fn main() {
+    let args: Vec<String> = std::env::args().skip(1).collect();
+
+    if args.is_empty() || args.iter().any(|a| a == "--help" || a == "-h") {
+        print_usage();
+        process::exit(0);
+    }
+
+    match run(&args) {
+        Ok(()) => {}
+        Err(e) => {
+            eprintln!("error: {e}");
+            process::exit(1);
+        }
+    }
+}
+
+fn run(args: &[String]) -> Result<(), String> {
+    let config = parse_args(args)?;
+    let output_dir = parse_output_dir(args).unwrap_or_else(|| PathBuf::from("."));
+    let dry_run = args.iter().any(|a| a == "--dry-run");
+
+    let files = codegen::generate_all(&config);
+
+    if dry_run {
+        print_dry_run(&files);
+    } else {
+        codegen::write_files(&files, &output_dir)
+            .map_err(|e| format!("failed to write files: {e}"))?;
+        print_summary(&config, &files, &output_dir);
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+fn parse_args(args: &[String]) -> Result<ScaffoldConfig, String> {
+    let name = args
+        .first()
+        .filter(|a| !a.starts_with('-'))
+        .ok_or("NAME is required as the first argument")?
+        .clone();
+
+    if name.is_empty() || name == "--help" {
+        return Err("NAME must be a non-empty string".into());
+    }
+
+    let channel_type = flag_value(args, "--channel-type")
+        .map(|s| ChannelType::parse(&s))
+        .transpose()?
+        .unwrap_or(ChannelType::Webhook);
+
+    let with_filter = args.iter().any(|a| a == "--with-filter");
+    let with_tests = args.iter().any(|a| a == "--with-tests");
+
+    Ok(ScaffoldConfig::new(&name, channel_type, with_filter, with_tests))
+}
+
+fn parse_output_dir(args: &[String]) -> Option<PathBuf> {
+    flag_value(args, "--output-dir").map(PathBuf::from)
+}
+
+/// Return the value that follows `flag` in `args`, if present.
+fn flag_value(args: &[String], flag: &str) -> Option<String> {
+    args.windows(2)
+        .find(|w| w[0] == flag)
+        .map(|w| w[1].clone())
+}
+
+// ---------------------------------------------------------------------------
+// Output helpers
+// ---------------------------------------------------------------------------
+
+fn print_dry_run(files: &[GeneratedFile]) {
+    for file in files {
+        println!("=== {} ===", file.relative_path);
+        println!("{}", file.content);
+        println!();
+    }
+}
+
+fn print_summary(config: &ScaffoldConfig, files: &[GeneratedFile], output_dir: &PathBuf) {
+    println!(
+        "Generated {} file(s) for '{}' ({}) in '{}':",
+        files.len(),
+        config.name,
+        config.channel_type.as_str(),
+        output_dir.display()
+    );
+    for file in files {
+        println!("  {}", file.relative_path);
+    }
+    println!();
+    println!("Next steps:");
+    println!(
+        "  1. Add `pub mod {snake};` to src/lib.rs",
+        snake = config.snake_name
+    );
+
+    let handler_file = format!("src/{}_subscriptions.rs", config.snake_name);
+    println!("  2. Register routes from {handler_file} in src/routes.rs");
+
+    // Migration hint
+    let migration_file = files
+        .iter()
+        .find(|f| f.relative_path.ends_with(".sql"))
+        .map(|f| f.relative_path.as_str())
+        .unwrap_or("migrations/<timestamp>_add_*.sql");
+    println!("  3. Run: sqlx migrate run   # applies {migration_file}");
+
+    if config.with_filter {
+        println!(
+            "  4. Wire {snake}_filter_config::evaluate_all() into the delivery worker",
+            snake = config.snake_name
+        );
+    }
+    if config.with_tests {
+        println!(
+            "  {}. Run: cargo test {snake}",
+            if config.with_filter { "5" } else { "4" },
+            snake = config.snake_name
+        );
+    }
+}
+
+fn print_usage() {
+    eprintln!(
+        "Usage: gen_subscription_scaffold <NAME> [OPTIONS]
+
+Arguments:
+  NAME                     Subscription name, e.g. token-transfer or payment
+
+Options:
+  --output-dir <path>      Write files here (default: current directory)
+  --channel-type <type>    webhook | email | sms  (default: webhook)
+  --with-filter            Generate content filter configuration module
+  --with-tests             Generate test scaffold module
+  --dry-run                Print generated files to stdout without writing
+  -h, --help               Show this message
+
+Examples:
+  cargo run --bin gen_subscription_scaffold -- token-transfer
+  cargo run --bin gen_subscription_scaffold -- payment --channel-type email --with-tests
+  cargo run --bin gen_subscription_scaffold -- nft-sale --with-filter --with-tests --dry-run
+"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn args(v: &[&str]) -> Vec<String> {
+        v.iter().map(|s| s.to_string()).collect()
+    }
+
+    #[test]
+    fn parses_name_only() {
+        let cfg = parse_args(&args(&["transfer"])).unwrap();
+        assert_eq!(cfg.name, "transfer");
+        assert_eq!(cfg.channel_type, ChannelType::Webhook);
+        assert!(!cfg.with_filter);
+        assert!(!cfg.with_tests);
+    }
+
+    #[test]
+    fn parses_channel_type_email() {
+        let cfg = parse_args(&args(&["payment", "--channel-type", "email"])).unwrap();
+        assert_eq!(cfg.channel_type, ChannelType::Email);
+    }
+
+    #[test]
+    fn parses_flags() {
+        let cfg =
+            parse_args(&args(&["nft", "--with-filter", "--with-tests"])).unwrap();
+        assert!(cfg.with_filter);
+        assert!(cfg.with_tests);
+    }
+
+    #[test]
+    fn errors_without_name() {
+        assert!(parse_args(&args(&[])).is_err());
+    }
+
+    #[test]
+    fn errors_on_unknown_channel_type() {
+        let result = parse_args(&args(&["transfer", "--channel-type", "fax"]));
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("fax"));
+    }
+
+    #[test]
+    fn flag_value_finds_next_arg() {
+        let a = args(&["name", "--output-dir", "/tmp/out", "--channel-type", "sms"]);
+        assert_eq!(flag_value(&a, "--output-dir"), Some("/tmp/out".into()));
+        assert_eq!(flag_value(&a, "--channel-type"), Some("sms".into()));
+        assert_eq!(flag_value(&a, "--missing"), None);
+    }
+
+    #[test]
+    fn parse_output_dir_returns_none_when_absent() {
+        let a = args(&["name"]);
+        assert!(parse_output_dir(&a).is_none());
+    }
+
+    #[test]
+    fn parse_output_dir_returns_path() {
+        let a = args(&["name", "--output-dir", "/some/path"]);
+        assert_eq!(
+            parse_output_dir(&a),
+            Some(PathBuf::from("/some/path"))
+        );
+    }
+}

--- a/src/codegen/filter.rs
+++ b/src/codegen/filter.rs
@@ -1,0 +1,219 @@
+//! Generates content filter configuration scaffolding.
+//!
+//! The output module shows how to wire the existing `ContentFilter` type
+//! into a named subscription, with ready-made predicate examples.
+
+use super::{apply, GeneratedFile, ScaffoldConfig};
+
+const FILTER_TEMPLATE: &str = r#"//! Content filter configuration for {{PASCAL}} subscriptions.
+//!
+//! Filters are evaluated before each notification is delivered. Only events
+//! whose data satisfies every predicate in the active filter set are sent to
+//! the callback URL, reducing noise for high-volume contracts.
+//!
+//! Add this module to your subscription route and pass a `Vec<ContentFilter>`
+//! when creating or updating a subscription.
+
+use crate::content_filter::{ContentFilter, FilterOp};
+
+// ---------------------------------------------------------------------------
+// Preset filter bundles
+// ---------------------------------------------------------------------------
+
+/// Returns filters that pass only high-value transfer events (amount > 1_000_000).
+pub fn high_value_only() -> Vec<ContentFilter> {
+    vec![ContentFilter {
+        path: "$.amount".into(),
+        op: FilterOp::Gt,
+        value: "1000000".into(),
+    }]
+}
+
+/// Returns filters that limit events to a specific Stellar account address.
+pub fn for_account(account: impl Into<String>) -> Vec<ContentFilter> {
+    vec![ContentFilter {
+        path: "$.transfer.to".into(),
+        op: FilterOp::Eq,
+        value: account.into(),
+    }]
+}
+
+/// Returns filters that match a specific event action (e.g. "transfer", "mint").
+pub fn for_action(action: impl Into<String>) -> Vec<ContentFilter> {
+    vec![ContentFilter {
+        path: "$.action".into(),
+        op: FilterOp::Eq,
+        value: action.into(),
+    }]
+}
+
+/// Returns filters scoped to accounts matching a Stellar address regex pattern.
+pub fn for_account_pattern(pattern: impl Into<String>) -> Vec<ContentFilter> {
+    vec![ContentFilter {
+        path: "$.account".into(),
+        op: FilterOp::Matches,
+        value: pattern.into(),
+    }]
+}
+
+// ---------------------------------------------------------------------------
+// Config struct
+// ---------------------------------------------------------------------------
+
+/// Declarative filter configuration for {{PASCAL}} subscriptions.
+///
+/// Deserializable from JSON so subscribers can supply filters at creation time
+/// alongside `callback_url` and `from_ledger`.
+#[derive(Debug, serde::Deserialize, serde::Serialize)]
+pub struct {{PASCAL}}FilterConfig {
+    /// Minimum amount threshold. Events with `$.amount <= min_amount` are dropped.
+    pub min_amount: Option<String>,
+    /// Restrict to a specific recipient account.
+    pub to_account: Option<String>,
+    /// Restrict to a specific event action type.
+    pub action: Option<String>,
+    /// Additional freeform predicates (JSONPath path/op/value triples).
+    #[serde(default)]
+    pub predicates: Vec<ContentFilter>,
+}
+
+impl {{PASCAL}}FilterConfig {
+    /// Build a validated `Vec<ContentFilter>` from this config.
+    pub fn build(&self) -> Result<Vec<ContentFilter>, String> {
+        let mut filters: Vec<ContentFilter> = Vec::new();
+
+        if let Some(ref min) = self.min_amount {
+            filters.push(ContentFilter {
+                path: "$.amount".into(),
+                op: FilterOp::Gt,
+                value: min.clone(),
+            });
+        }
+        if let Some(ref account) = self.to_account {
+            filters.push(ContentFilter {
+                path: "$.transfer.to".into(),
+                op: FilterOp::Eq,
+                value: account.clone(),
+            });
+        }
+        if let Some(ref action) = self.action {
+            filters.push(ContentFilter {
+                path: "$.action".into(),
+                op: FilterOp::Eq,
+                value: action.clone(),
+            });
+        }
+
+        for predicate in &self.predicates {
+            predicate.validate().map_err(|e| e.to_string())?;
+            filters.push(predicate.clone());
+        }
+
+        Ok(filters)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Evaluation helper
+// ---------------------------------------------------------------------------
+
+/// Returns `true` if `data` passes all filters in `filters`.
+/// An empty filter list passes every event (no filtering).
+pub fn evaluate_all(filters: &[ContentFilter], data: &serde_json::Value) -> bool {
+    filters.iter().all(|f| f.evaluate(data))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn high_value_only_passes_large_amounts() {
+        let filters = high_value_only();
+        assert!(evaluate_all(&filters, &json!({ "amount": "5000000" })));
+        assert!(!evaluate_all(&filters, &json!({ "amount": "100" })));
+    }
+
+    #[test]
+    fn for_account_matches_exact_address() {
+        let account = "GABC1234567890";
+        let filters = for_account(account);
+        assert!(evaluate_all(
+            &filters,
+            &json!({ "transfer": { "to": account } })
+        ));
+        assert!(!evaluate_all(
+            &filters,
+            &json!({ "transfer": { "to": "GOTHER" } })
+        ));
+    }
+
+    #[test]
+    fn for_action_filters_by_event_type() {
+        let filters = for_action("transfer");
+        assert!(evaluate_all(&filters, &json!({ "action": "transfer" })));
+        assert!(!evaluate_all(&filters, &json!({ "action": "mint" })));
+    }
+
+    #[test]
+    fn empty_filters_pass_everything() {
+        let filters: Vec<ContentFilter> = vec![];
+        assert!(evaluate_all(&filters, &json!({ "any": "value" })));
+    }
+
+    #[test]
+    fn config_build_validates_predicates() {
+        let cfg = {{PASCAL}}FilterConfig {
+            min_amount: Some("500000".into()),
+            to_account: None,
+            action: Some("transfer".into()),
+            predicates: vec![],
+        };
+        let filters = cfg.build().expect("valid config");
+        assert_eq!(filters.len(), 2);
+    }
+
+    #[test]
+    fn config_build_rejects_bad_predicate_path() {
+        let cfg = {{PASCAL}}FilterConfig {
+            min_amount: None,
+            to_account: None,
+            action: None,
+            predicates: vec![ContentFilter {
+                path: "bad_path".into(), // must start with $
+                op: FilterOp::Eq,
+                value: "x".into(),
+            }],
+        };
+        assert!(cfg.build().is_err());
+    }
+}
+"#;
+
+pub fn generate(config: &ScaffoldConfig) -> GeneratedFile {
+    GeneratedFile {
+        relative_path: format!("src/{}_filter_config.rs", config.snake_name),
+        content: apply(FILTER_TEMPLATE, config),
+    }
+}
+
+#[cfg(test)]
+mod meta_tests {
+    use super::*;
+    use crate::codegen::{ChannelType, ScaffoldConfig};
+
+    #[test]
+    fn generated_file_contains_struct_name() {
+        let cfg = ScaffoldConfig::new("payment", ChannelType::Webhook, false, false);
+        let f = generate(&cfg);
+        assert!(f.content.contains("PaymentFilterConfig"));
+    }
+
+    #[test]
+    fn generated_file_path_uses_snake_name() {
+        let cfg = ScaffoldConfig::new("nft-sale", ChannelType::Webhook, false, false);
+        let f = generate(&cfg);
+        assert_eq!(f.relative_path, "src/nft_sale_filter_config.rs");
+    }
+}

--- a/src/codegen/mod.rs
+++ b/src/codegen/mod.rs
@@ -1,0 +1,184 @@
+//! Subscription scaffolding code generator.
+//!
+//! Generates Rust handler modules, SQL migrations, webhook delivery code,
+//! content filter configs, and test suites from name and channel-type inputs.
+
+pub mod filter;
+pub mod subscription;
+pub mod tests;
+pub mod webhook;
+
+use std::{fs, path::Path};
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ChannelType {
+    Webhook,
+    Email,
+    Sms,
+}
+
+impl ChannelType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ChannelType::Webhook => "webhook",
+            ChannelType::Email => "email",
+            ChannelType::Sms => "sms",
+        }
+    }
+
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.to_lowercase().as_str() {
+            "webhook" => Ok(ChannelType::Webhook),
+            "email" => Ok(ChannelType::Email),
+            "sms" => Ok(ChannelType::Sms),
+            other => Err(format!(
+                "unknown channel type '{}'; expected webhook, email, or sms",
+                other
+            )),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ScaffoldConfig {
+    pub name: String,
+    pub snake_name: String,
+    pub pascal_name: String,
+    pub channel_type: ChannelType,
+    pub with_filter: bool,
+    pub with_tests: bool,
+}
+
+impl ScaffoldConfig {
+    pub fn new(
+        name: &str,
+        channel_type: ChannelType,
+        with_filter: bool,
+        with_tests: bool,
+    ) -> Self {
+        ScaffoldConfig {
+            name: name.to_string(),
+            snake_name: to_snake_case(name),
+            pascal_name: to_pascal_case(name),
+            channel_type,
+            with_filter,
+            with_tests,
+        }
+    }
+}
+
+fn to_snake_case(s: &str) -> String {
+    s.chars()
+        .map(|c| match c {
+            ' ' | '-' => '_',
+            c => c.to_ascii_lowercase(),
+        })
+        .collect()
+}
+
+fn to_pascal_case(s: &str) -> String {
+    s.split(|c: char| c == '_' || c == '-' || c == ' ')
+        .filter(|p| !p.is_empty())
+        .map(|p| {
+            let mut chars = p.chars();
+            match chars.next() {
+                None => String::new(),
+                Some(f) => f.to_uppercase().to_string() + &chars.as_str().to_lowercase(),
+            }
+        })
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+pub struct GeneratedFile {
+    pub relative_path: String,
+    pub content: String,
+}
+
+// ---------------------------------------------------------------------------
+// Orchestration
+// ---------------------------------------------------------------------------
+
+pub fn generate_all(config: &ScaffoldConfig) -> Vec<GeneratedFile> {
+    let mut files = vec![
+        subscription::generate_handler(config),
+        subscription::generate_migration(config),
+        webhook::generate(config),
+    ];
+    if config.with_filter {
+        files.push(filter::generate(config));
+    }
+    if config.with_tests {
+        files.push(tests::generate(config));
+    }
+    files
+}
+
+pub fn write_files(files: &[GeneratedFile], output_dir: &Path) -> anyhow::Result<()> {
+    for file in files {
+        let dest = output_dir.join(&file.relative_path);
+        if let Some(parent) = dest.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        fs::write(&dest, &file.content)?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Template helper
+// ---------------------------------------------------------------------------
+
+pub(crate) fn apply(template: &str, config: &ScaffoldConfig) -> String {
+    template
+        .replace("{{PASCAL}}", &config.pascal_name)
+        .replace("{{SNAKE}}", &config.snake_name)
+        .replace("{{CHANNEL}}", config.channel_type.as_str())
+}
+
+#[cfg(test)]
+mod tests_mod {
+    use super::*;
+
+    #[test]
+    fn snake_case_conversion() {
+        assert_eq!(to_snake_case("MySubscription"), "mysubscription");
+        assert_eq!(to_snake_case("my-subscription"), "my_subscription");
+        assert_eq!(to_snake_case("token transfer"), "token_transfer");
+    }
+
+    #[test]
+    fn pascal_case_conversion() {
+        assert_eq!(to_pascal_case("token_transfer"), "TokenTransfer");
+        assert_eq!(to_pascal_case("my-subscription"), "MySubscription");
+        assert_eq!(to_pascal_case("nft sale"), "NftSale");
+    }
+
+    #[test]
+    fn scaffold_config_derives_names() {
+        let cfg = ScaffoldConfig::new("token-transfer", ChannelType::Webhook, false, false);
+        assert_eq!(cfg.snake_name, "token_transfer");
+        assert_eq!(cfg.pascal_name, "TokenTransfer");
+    }
+
+    #[test]
+    fn channel_type_round_trips() {
+        assert_eq!(ChannelType::parse("webhook").unwrap(), ChannelType::Webhook);
+        assert_eq!(ChannelType::parse("EMAIL").unwrap(), ChannelType::Email);
+        assert!(ChannelType::parse("fax").is_err());
+    }
+
+    #[test]
+    fn generate_all_produces_expected_file_count() {
+        let cfg = ScaffoldConfig::new("payment", ChannelType::Webhook, true, true);
+        let files = generate_all(&cfg);
+        assert_eq!(files.len(), 5); // handler, migration, webhook, filter, tests
+    }
+}

--- a/src/codegen/subscription.rs
+++ b/src/codegen/subscription.rs
@@ -1,0 +1,377 @@
+//! Generates subscription handler module and SQL migration.
+
+use super::{apply, GeneratedFile, ScaffoldConfig};
+
+const HANDLER_TEMPLATE: &str = r#"use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    Json,
+};
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use sqlx::PgPool;
+use std::time::Duration;
+use tokio::time::sleep;
+use uuid::Uuid;
+
+use crate::{error::AppError, routes::AppState};
+use crate::subscriptions::validate_callback_url;
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Serialize, sqlx::FromRow)]
+pub struct {{PASCAL}}Subscription {
+    pub id: Uuid,
+    pub callback_url: String,
+    pub from_ledger: i64,
+    pub acked_ledger: i64,
+    pub status: String,
+    pub created_at: DateTime<Utc>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct Create{{PASCAL}}SubscriptionRequest {
+    pub callback_url: String,
+    pub from_ledger: i64,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct {{PASCAL}}AckRequest {
+    pub ledger: i64,
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+pub async fn create_{{SNAKE}}_subscription(
+    State(state): State<AppState>,
+    Json(body): Json<Create{{PASCAL}}SubscriptionRequest>,
+) -> Result<(StatusCode, Json<Value>), AppError> {
+    if body.callback_url.is_empty() {
+        return Err(AppError::Validation("callback_url is required".into()));
+    }
+    validate_callback_url(&body.callback_url, &state.config.environment)?;
+    if body.from_ledger < 0 {
+        return Err(AppError::Validation(
+            "from_ledger must be non-negative".into(),
+        ));
+    }
+
+    let sub: {{PASCAL}}Subscription = sqlx::query_as(
+        "INSERT INTO {{SNAKE}}_subscriptions (callback_url, from_ledger)
+         VALUES ($1, $2)
+         RETURNING id, callback_url, from_ledger, acked_ledger, status, created_at",
+    )
+    .bind(&body.callback_url)
+    .bind(body.from_ledger)
+    .fetch_one(&state.pool)
+    .await?;
+
+    sqlx::query(
+        "INSERT INTO {{SNAKE}}_delivery_queue (subscription_id, event_id, ledger)
+         SELECT $1, id, ledger FROM events WHERE ledger >= $2
+         ORDER BY ledger ASC",
+    )
+    .bind(sub.id)
+    .bind(body.from_ledger)
+    .execute(&state.pool)
+    .await?;
+
+    Ok((StatusCode::CREATED, Json(json!(sub))))
+}
+
+pub async fn get_{{SNAKE}}_subscription(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<Value>, AppError> {
+    let sub: {{PASCAL}}Subscription = sqlx::query_as(
+        "SELECT id, callback_url, from_ledger, acked_ledger, status, created_at
+         FROM {{SNAKE}}_subscriptions WHERE id = $1",
+    )
+    .bind(id)
+    .fetch_optional(&state.pool)
+    .await?
+    .ok_or(AppError::NotFound)?;
+
+    let pending: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM {{SNAKE}}_delivery_queue
+         WHERE subscription_id = $1 AND status = 'pending'",
+    )
+    .bind(id)
+    .fetch_one(&state.pool)
+    .await?;
+
+    Ok(Json(json!({
+        "subscription": sub,
+        "pending_deliveries": pending
+    })))
+}
+
+pub async fn cancel_{{SNAKE}}_subscription(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, AppError> {
+    let rows = sqlx::query(
+        "UPDATE {{SNAKE}}_subscriptions SET status = 'cancelled'
+         WHERE id = $1 AND status = 'active'",
+    )
+    .bind(id)
+    .execute(&state.pool)
+    .await?
+    .rows_affected();
+
+    if rows == 0 {
+        return Err(AppError::NotFound);
+    }
+    Ok(StatusCode::NO_CONTENT)
+}
+
+pub async fn ack_{{SNAKE}}_subscription(
+    State(state): State<AppState>,
+    Path(id): Path<Uuid>,
+    Json(body): Json<{{PASCAL}}AckRequest>,
+) -> Result<Json<Value>, AppError> {
+    // Advance acked_ledger only forward; ignore if already at or past this ledger.
+    let rows = sqlx::query(
+        "UPDATE {{SNAKE}}_subscriptions SET acked_ledger = $1
+         WHERE id = $2 AND status = 'active' AND acked_ledger < $1",
+    )
+    .bind(body.ledger)
+    .bind(id)
+    .execute(&state.pool)
+    .await?
+    .rows_affected();
+
+    if rows == 0 {
+        let exists: bool = sqlx::query_scalar(
+            "SELECT EXISTS(SELECT 1 FROM {{SNAKE}}_subscriptions WHERE id = $1)",
+        )
+        .bind(id)
+        .fetch_one(&state.pool)
+        .await?;
+        if !exists {
+            return Err(AppError::NotFound);
+        }
+    }
+
+    sqlx::query(
+        "UPDATE {{SNAKE}}_delivery_queue SET status = 'delivered'
+         WHERE subscription_id = $1 AND ledger <= $2 AND status = 'pending'",
+    )
+    .bind(id)
+    .bind(body.ledger)
+    .execute(&state.pool)
+    .await?;
+
+    Ok(Json(json!({ "acked_ledger": body.ledger })))
+}
+
+// ---------------------------------------------------------------------------
+// Delivery worker
+// ---------------------------------------------------------------------------
+
+pub async fn enqueue_{{SNAKE}}_event(pool: &PgPool, event_id: Uuid, ledger: i64) {
+    let result = sqlx::query(
+        "INSERT INTO {{SNAKE}}_delivery_queue (subscription_id, event_id, ledger)
+         SELECT id, $1, $2 FROM {{SNAKE}}_subscriptions
+         WHERE status = 'active' AND from_ledger <= $2
+         ON CONFLICT DO NOTHING",
+    )
+    .bind(event_id)
+    .bind(ledger)
+    .execute(pool)
+    .await;
+
+    if let Err(e) = result {
+        tracing::warn!(error = %e, "Failed to enqueue event for {{PASCAL}} subscriptions");
+    }
+}
+
+pub async fn run_{{SNAKE}}_delivery_worker(pool: PgPool, http: reqwest::Client) {
+    loop {
+        match deliver_{{SNAKE}}_pending(&pool, &http).await {
+            Ok(n) if n > 0 => tracing::debug!(delivered = n, "{{PASCAL}} delivery worker cycle"),
+            Ok(_) => {}
+            Err(e) => tracing::warn!(error = %e, "{{PASCAL}} delivery worker error"),
+        }
+        sleep(Duration::from_secs(5)).await;
+    }
+}
+
+async fn deliver_{{SNAKE}}_pending(
+    pool: &PgPool,
+    http: &reqwest::Client,
+) -> Result<usize, sqlx::Error> {
+    let rows: Vec<(Uuid, Uuid, String, Value, i64)> = sqlx::query_as(
+        "SELECT dq.id, dq.event_id, s.callback_url, e.event_data, dq.ledger
+         FROM {{SNAKE}}_delivery_queue dq
+         JOIN {{SNAKE}}_subscriptions s ON s.id = dq.subscription_id
+         JOIN events e ON e.id = dq.event_id
+         WHERE dq.status = 'pending'
+           AND dq.next_attempt_at <= NOW()
+           AND s.status = 'active'
+         ORDER BY dq.ledger ASC
+         LIMIT 50",
+    )
+    .fetch_all(pool)
+    .await?;
+
+    let count = rows.len();
+    for (queue_id, event_id, callback_url, event_data, ledger) in rows {
+        let payload = json!({
+            "event_id": event_id,
+            "ledger": ledger,
+            "event_data": event_data,
+        });
+        match http
+            .post(&callback_url)
+            .json(&payload)
+            .timeout(Duration::from_secs(10))
+            .send()
+            .await
+        {
+            Ok(resp) if resp.status().is_success() => {
+                sqlx::query(
+                    "UPDATE {{SNAKE}}_delivery_queue SET status = 'delivered' WHERE id = $1",
+                )
+                .bind(queue_id)
+                .execute(pool)
+                .await?;
+            }
+            Ok(resp) => {
+                schedule_{{SNAKE}}_retry(pool, queue_id, &format!("HTTP {}", resp.status())).await?;
+            }
+            Err(e) => {
+                schedule_{{SNAKE}}_retry(pool, queue_id, &e.to_string()).await?;
+            }
+        }
+    }
+    Ok(count)
+}
+
+// Exponential backoff: 2^attempts seconds, capped at 1 hour.
+async fn schedule_{{SNAKE}}_retry(
+    pool: &PgPool,
+    queue_id: Uuid,
+    error: &str,
+) -> Result<(), sqlx::Error> {
+    sqlx::query(
+        "UPDATE {{SNAKE}}_delivery_queue
+         SET attempts = attempts + 1,
+             last_error = $2,
+             next_attempt_at = NOW() + (LEAST(POWER(2, attempts + 1), 3600) || ' seconds')::interval
+         WHERE id = $1",
+    )
+    .bind(queue_id)
+    .bind(error)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+"#;
+
+const MIGRATION_TEMPLATE: &str = r#"-- Migration: {{SNAKE}} subscriptions + delivery queue
+-- Generated by gen_subscription_scaffold
+-- Run: sqlx migrate run
+
+CREATE TABLE IF NOT EXISTS {{SNAKE}}_subscriptions (
+    id            UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    callback_url  TEXT        NOT NULL,
+    from_ledger   BIGINT      NOT NULL,
+    acked_ledger  BIGINT      NOT NULL DEFAULT 0,
+    status        TEXT        NOT NULL DEFAULT 'active'
+                              CHECK (status IN ('active', 'cancelled')),
+    channel_type  TEXT        NOT NULL DEFAULT '{{CHANNEL}}',
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS {{SNAKE}}_delivery_queue (
+    id               UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    subscription_id  UUID        NOT NULL
+                                 REFERENCES {{SNAKE}}_subscriptions(id) ON DELETE CASCADE,
+    event_id         UUID        NOT NULL
+                                 REFERENCES events(id) ON DELETE CASCADE,
+    ledger           BIGINT      NOT NULL,
+    status           TEXT        NOT NULL DEFAULT 'pending'
+                                 CHECK (status IN ('pending', 'delivered', 'failed')),
+    attempts         INT         NOT NULL DEFAULT 0,
+    next_attempt_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_error       TEXT,
+    UNIQUE (subscription_id, event_id)
+);
+
+CREATE INDEX idx_{{SNAKE}}_delivery_queue_pending
+    ON {{SNAKE}}_delivery_queue (next_attempt_at)
+    WHERE status = 'pending';
+"#;
+
+pub fn generate_handler(config: &ScaffoldConfig) -> GeneratedFile {
+    GeneratedFile {
+        relative_path: format!("src/{}_subscriptions.rs", config.snake_name),
+        content: apply(HANDLER_TEMPLATE, config),
+    }
+}
+
+pub fn generate_migration(config: &ScaffoldConfig) -> GeneratedFile {
+    let timestamp = chrono::Utc::now().format("%Y%m%d%H%M%S");
+    GeneratedFile {
+        relative_path: format!(
+            "migrations/{}_add_{}_subscriptions.sql",
+            timestamp, config.snake_name
+        ),
+        content: apply(MIGRATION_TEMPLATE, config),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codegen::{ChannelType, ScaffoldConfig};
+
+    fn cfg() -> ScaffoldConfig {
+        ScaffoldConfig::new("token-transfer", ChannelType::Webhook, false, false)
+    }
+
+    #[test]
+    fn handler_contains_pascal_name() {
+        let f = generate_handler(&cfg());
+        assert!(f.content.contains("TokenTransferSubscription"));
+        assert!(f.content.contains("CreateTokenTransferSubscriptionRequest"));
+    }
+
+    #[test]
+    fn handler_contains_snake_name() {
+        let f = generate_handler(&cfg());
+        assert!(f.content.contains("create_token_transfer_subscription"));
+        assert!(f.content.contains("token_transfer_subscriptions"));
+    }
+
+    #[test]
+    fn migration_contains_table_names() {
+        let f = generate_migration(&cfg());
+        assert!(f.content.contains("token_transfer_subscriptions"));
+        assert!(f.content.contains("token_transfer_delivery_queue"));
+    }
+
+    #[test]
+    fn migration_contains_channel_type() {
+        let f = generate_migration(&cfg());
+        assert!(f.content.contains("'webhook'"));
+    }
+
+    #[test]
+    fn handler_path_uses_snake_name() {
+        let f = generate_handler(&cfg());
+        assert_eq!(f.relative_path, "src/token_transfer_subscriptions.rs");
+    }
+
+    #[test]
+    fn migration_path_ends_with_sql() {
+        let f = generate_migration(&cfg());
+        assert!(f.relative_path.ends_with("_add_token_transfer_subscriptions.sql"));
+    }
+}

--- a/src/codegen/tests.rs
+++ b/src/codegen/tests.rs
@@ -1,0 +1,290 @@
+//! Generates test scaffolding for a named subscription type.
+//!
+//! Produces a standalone test file covering:
+//! - SSRF URL validation
+//! - Exponential backoff formula
+//! - Mock delivery success and retry paths
+//! - Ack cursor monotonicity
+//! - Content filter evaluation (if applicable)
+//! - Integration test stubs (require `sqlx::test`)
+
+use super::{apply, GeneratedFile, ScaffoldConfig};
+
+const TEST_TEMPLATE: &str = r#"//! Tests for {{PASCAL}} subscription scaffolding.
+//!
+//! Run unit tests:   cargo test {{SNAKE}}
+//! Run DB tests:     make test-db  (requires PostgreSQL via docker-compose.test.yml)
+
+#[cfg(test)]
+mod {{SNAKE}}_subscription_tests {
+    use serde_json::json;
+    use std::sync::{Arc, Mutex};
+    use uuid::Uuid;
+
+    use soroban_pulse::content_filter::{ContentFilter, FilterOp};
+    use soroban_pulse::subscriptions::validate_callback_url;
+    use soroban_pulse::config::Environment;
+
+    // -----------------------------------------------------------------------
+    // SSRF validation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn rejects_localhost_callback() {
+        assert!(
+            validate_callback_url("http://localhost/{{SNAKE}}", &Environment::Development).is_err(),
+            "localhost must be rejected"
+        );
+    }
+
+    #[test]
+    fn rejects_rfc1918_address() {
+        assert!(
+            validate_callback_url("http://192.168.1.1/hook", &Environment::Development).is_err(),
+            "RFC 1918 address must be rejected"
+        );
+    }
+
+    #[test]
+    fn rejects_http_in_production() {
+        assert!(
+            validate_callback_url("http://example.com/hook", &Environment::Production).is_err(),
+            "HTTP callback must be rejected in production"
+        );
+    }
+
+    #[test]
+    fn accepts_https_in_production() {
+        assert!(
+            validate_callback_url("https://example.com/{{SNAKE}}", &Environment::Production).is_ok(),
+            "HTTPS public URL must be accepted in production"
+        );
+    }
+
+    #[test]
+    fn allowlist_permits_internal_url() {
+        std::env::set_var(
+            "SUBSCRIPTION_ALLOWED_URL_PREFIXES",
+            "http://internal.corp/,https://trusted.corp/",
+        );
+        let result =
+            validate_callback_url("http://internal.corp/{{SNAKE}}", &Environment::Production);
+        std::env::remove_var("SUBSCRIPTION_ALLOWED_URL_PREFIXES");
+        assert!(result.is_ok(), "allowlisted prefix must be permitted");
+    }
+
+    // -----------------------------------------------------------------------
+    // Exponential backoff formula
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn backoff_is_capped_at_3600_seconds() {
+        let backoff = |attempts: u32| -> u64 { 2u64.pow(attempts + 1).min(3600) };
+        assert_eq!(backoff(0), 2);
+        assert_eq!(backoff(1), 4);
+        assert_eq!(backoff(10), 2048);
+        assert_eq!(backoff(11), 3600, "2^12=4096 should be capped at 3600");
+        assert_eq!(backoff(20), 3600, "large attempt count stays capped");
+    }
+
+    // -----------------------------------------------------------------------
+    // Mock HTTP delivery
+    // -----------------------------------------------------------------------
+
+    struct MockDelivery {
+        received: Arc<Mutex<Vec<serde_json::Value>>>,
+        remaining_failures: Arc<Mutex<u32>>,
+    }
+
+    impl MockDelivery {
+        fn new() -> Self {
+            Self {
+                received: Arc::new(Mutex::new(Vec::new())),
+                remaining_failures: Arc::new(Mutex::new(0)),
+            }
+        }
+
+        fn with_failures(n: u32) -> Self {
+            Self {
+                received: Arc::new(Mutex::new(Vec::new())),
+                remaining_failures: Arc::new(Mutex::new(n)),
+            }
+        }
+
+        async fn send(&self, payload: serde_json::Value) -> Result<(), String> {
+            let mut fails = self.remaining_failures.lock().unwrap();
+            if *fails > 0 {
+                *fails -= 1;
+                return Err("connection refused".into());
+            }
+            self.received.lock().unwrap().push(payload);
+            Ok(())
+        }
+    }
+
+    #[tokio::test]
+    async fn delivery_succeeds_on_first_attempt() {
+        let mock = MockDelivery::new();
+        let payload = json!({
+            "event_id": Uuid::new_v4(),
+            "ledger": 100,
+            "event_data": {}
+        });
+        mock.send(payload.clone()).await.expect("should succeed");
+        assert_eq!(mock.received.lock().unwrap().len(), 1);
+        assert_eq!(mock.received.lock().unwrap()[0]["ledger"], 100);
+    }
+
+    #[tokio::test]
+    async fn delivery_succeeds_after_transient_failures() {
+        let mock = MockDelivery::with_failures(2);
+        let payload = json!({ "event_id": Uuid::new_v4(), "ledger": 200, "event_data": {} });
+
+        // Two failures
+        assert!(mock.send(payload.clone()).await.is_err());
+        assert!(mock.send(payload.clone()).await.is_err());
+        // Third attempt succeeds
+        mock.send(payload.clone()).await.expect("should succeed on third attempt");
+
+        assert_eq!(mock.received.lock().unwrap().len(), 1);
+        assert_eq!(mock.received.lock().unwrap()[0]["ledger"], 200);
+    }
+
+    // -----------------------------------------------------------------------
+    // Ack cursor monotonicity
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn ack_cursor_only_advances_forward() {
+        let advance = |current: i64, proposed: i64| -> i64 {
+            if proposed > current { proposed } else { current }
+        };
+
+        let mut cursor: i64 = 50;
+        cursor = advance(cursor, 100);
+        assert_eq!(cursor, 100);
+
+        cursor = advance(cursor, 80); // regression attempt
+        assert_eq!(cursor, 100, "cursor must not regress");
+
+        cursor = advance(cursor, 150);
+        assert_eq!(cursor, 150);
+    }
+
+    // -----------------------------------------------------------------------
+    // Payload structure
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn delivery_payload_has_required_fields() {
+        let event_id = Uuid::new_v4();
+        let payload = json!({
+            "event_id": event_id,
+            "ledger": 42_i64,
+            "event_data": { "amount": "100" },
+        });
+        assert!(payload.get("event_id").is_some());
+        assert!(payload.get("ledger").is_some());
+        assert!(payload.get("event_data").is_some());
+    }
+
+    // -----------------------------------------------------------------------
+    // Content filter evaluation
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn filter_passes_matching_event() {
+        let filter = ContentFilter {
+            path: "$.amount".into(),
+            op: FilterOp::Gt,
+            value: "1000000".into(),
+        };
+        assert!(filter.evaluate(&json!({ "amount": "5000000" })));
+        assert!(!filter.evaluate(&json!({ "amount": "100" })));
+    }
+
+    #[test]
+    fn filter_absent_field_fails_except_ne() {
+        let ne = ContentFilter { path: "$.x".into(), op: FilterOp::Ne, value: "y".into() };
+        let eq = ContentFilter { path: "$.x".into(), op: FilterOp::Eq, value: "y".into() };
+        assert!(ne.evaluate(&json!({})), "ne on absent field is vacuously true");
+        assert!(!eq.evaluate(&json!({})), "eq on absent field is false");
+    }
+
+    // -----------------------------------------------------------------------
+    // Integration test stubs (require PostgreSQL)
+    // -----------------------------------------------------------------------
+    //
+    // Uncomment and run with: make test-db
+    //
+    // #[sqlx::test(migrations = "./migrations")]
+    // async fn creates_{{SNAKE}}_subscription(pool: sqlx::PgPool) {
+    //     let row: (uuid::Uuid,) = sqlx::query_as(
+    //         "INSERT INTO {{SNAKE}}_subscriptions (callback_url, from_ledger)
+    //          VALUES ($1, $2) RETURNING id",
+    //     )
+    //     .bind("https://example.com/hook")
+    //     .bind(1_i64)
+    //     .fetch_one(&pool)
+    //     .await
+    //     .expect("insert should succeed");
+    //     assert!(!row.0.is_nil());
+    // }
+    //
+    // #[sqlx::test(migrations = "./migrations")]
+    // async fn enqueue_populates_delivery_queue(pool: sqlx::PgPool) {
+    //     // Insert a subscription then call enqueue_{{SNAKE}}_event and verify
+    //     // the delivery_queue receives a row.
+    //     todo!("implement this test");
+    // }
+}
+"#;
+
+pub fn generate(config: &ScaffoldConfig) -> GeneratedFile {
+    GeneratedFile {
+        relative_path: format!("tests/{}_subscription_tests.rs", config.snake_name),
+        content: apply(TEST_TEMPLATE, config),
+    }
+}
+
+#[cfg(test)]
+mod meta_tests {
+    use super::*;
+    use crate::codegen::{ChannelType, ScaffoldConfig};
+
+    #[test]
+    fn test_file_path_uses_snake_name() {
+        let cfg = ScaffoldConfig::new("token-swap", ChannelType::Webhook, false, true);
+        let f = generate(&cfg);
+        assert_eq!(f.relative_path, "tests/token_swap_subscription_tests.rs");
+    }
+
+    #[test]
+    fn test_file_contains_pascal_name() {
+        let cfg = ScaffoldConfig::new("nft-sale", ChannelType::Webhook, false, true);
+        let f = generate(&cfg);
+        assert!(f.content.contains("NftSale"));
+    }
+
+    #[test]
+    fn test_file_contains_snake_name_in_module() {
+        let cfg = ScaffoldConfig::new("nft-sale", ChannelType::Webhook, false, true);
+        let f = generate(&cfg);
+        assert!(f.content.contains("nft_sale_subscription_tests"));
+    }
+
+    #[test]
+    fn test_file_has_ssrf_tests() {
+        let cfg = ScaffoldConfig::new("payment", ChannelType::Webhook, false, true);
+        let f = generate(&cfg);
+        assert!(f.content.contains("rejects_localhost_callback"));
+        assert!(f.content.contains("rejects_rfc1918_address"));
+    }
+
+    #[test]
+    fn test_file_has_backoff_test() {
+        let cfg = ScaffoldConfig::new("payment", ChannelType::Webhook, false, true);
+        let f = generate(&cfg);
+        assert!(f.content.contains("backoff_is_capped_at_3600_seconds"));
+    }
+}

--- a/src/codegen/webhook.rs
+++ b/src/codegen/webhook.rs
@@ -1,0 +1,410 @@
+//! Generates webhook handler scaffolding with HMAC signing, retry policy,
+//! priority evaluation, failover, and DLQ integration.
+
+use super::{apply, ChannelType, GeneratedFile, ScaffoldConfig};
+
+const WEBHOOK_TEMPLATE: &str = r#"//! Webhook delivery for {{PASCAL}} subscriptions.
+//!
+//! Integrates HMAC-SHA256 payload signing, configurable retry policy,
+//! JSONPath-based priority evaluation, optional failover URL, and DLQ
+//! insertion on final failure. Wire `deliver_{{SNAKE}}_webhook` into the
+//! delivery worker once the event passes content filters.
+
+use crate::{
+    metrics,
+    models::SorobanEvent,
+    retry_policy::RetryPolicy,
+    webhook::{evaluate_priority, sign_payload},
+};
+use reqwest::Client;
+use serde_json::json;
+use tracing::{error, info, warn};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Delivery
+// ---------------------------------------------------------------------------
+
+/// Deliver `event` to `url` for a {{PASCAL}} subscription.
+///
+/// Signs the payload with `secret` when provided and attaches the signature
+/// as `X-Signature-256`. On final failure the event is inserted into the
+/// webhook DLQ for manual inspection or reprocessing.
+pub async fn deliver_{{SNAKE}}_webhook(
+    client: Client,
+    url: String,
+    secret: Option<String>,
+    event: SorobanEvent,
+    pool: Option<&sqlx::PgPool>,
+) {
+    let policy = RetryPolicy::webhook_default();
+    deliver_{{SNAKE}}_with_policy(client, url, secret, event, pool, &policy, "medium".into()).await;
+}
+
+/// Deliver with an explicit retry policy and priority label.
+pub async fn deliver_{{SNAKE}}_with_policy(
+    client: Client,
+    url: String,
+    secret: Option<String>,
+    event: SorobanEvent,
+    pool: Option<&sqlx::PgPool>,
+    policy: &RetryPolicy,
+    priority: String,
+) {
+    // Suppress delivery to blocked URLs.
+    if let Some(pool) = pool {
+        match sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM suppression_lists \
+             WHERE target = $1 AND target_type = 'webhook' \
+             AND (expires_at IS NULL OR expires_at > NOW())",
+        )
+        .bind(&url)
+        .fetch_one(pool)
+        .await
+        {
+            Ok(count) if count > 0 => {
+                info!(url = %url, "{{PASCAL}} webhook suppressed, skipping delivery");
+                metrics::record_notification_suppressed();
+                return;
+            }
+            _ => {}
+        }
+    }
+
+    let body = match serde_json::to_vec(&event) {
+        Ok(b) => b,
+        Err(e) => {
+            error!(error = %e, "Failed to serialize event for {{PASCAL}} webhook");
+            return;
+        }
+    };
+
+    let signature = secret.as_deref().map(|s| sign_payload(s, &body));
+    let priority_owned = priority.clone();
+
+    let result = policy
+        .execute_with_retry(|attempt| {
+            let client = client.clone();
+            let url = url.clone();
+            let body = body.clone();
+            let sig = signature.clone();
+            let pri = priority_owned.clone();
+            async move {
+                let mut req = client
+                    .post(&url)
+                    .header("Content-Type", "application/json")
+                    .header("X-Notification-Priority", pri)
+                    .body(body);
+                if let Some(ref s) = sig {
+                    req = req.header("X-Signature-256", format!("sha256={s}"));
+                }
+                match req.send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        info!(url = %url, attempt = attempt, "{{PASCAL}} webhook delivered");
+                        Ok(())
+                    }
+                    Ok(resp) => Err(format!("HTTP {}", resp.status())),
+                    Err(e) => Err(format!("Request error: {e}")),
+                }
+            }
+        })
+        .await;
+
+    if let Err(error_msg) = result {
+        error!(
+            url = %url,
+            contract = %event.contract_id,
+            error = %error_msg,
+            "{{PASCAL}} webhook failed after all retries"
+        );
+        insert_{{SNAKE}}_dlq(&url, &event, policy.max_attempts, &error_msg, pool).await;
+        metrics::record_webhook_failure();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Failover delivery
+// ---------------------------------------------------------------------------
+
+/// Attempt delivery to `primary_url`; fall back to `failover_url` on failure.
+/// Returns `true` if at least one URL succeeded.
+pub async fn deliver_{{SNAKE}}_with_failover(
+    client: Client,
+    primary_url: String,
+    primary_secret: Option<String>,
+    failover_url: Option<String>,
+    failover_secret: Option<String>,
+    event: SorobanEvent,
+    pool: Option<&sqlx::PgPool>,
+    policy: &RetryPolicy,
+) -> bool {
+    let body = match serde_json::to_vec(&event) {
+        Ok(b) => b,
+        Err(e) => {
+            error!(error = %e, "Failed to serialize {{PASCAL}} event");
+            return false;
+        }
+    };
+
+    let primary_sig = primary_secret.as_deref().map(|s| sign_payload(s, &body));
+
+    let primary_ok = policy
+        .execute_with_retry(|attempt| {
+            let client = client.clone();
+            let url = primary_url.clone();
+            let body = body.clone();
+            let sig = primary_sig.clone();
+            async move {
+                let mut req = client
+                    .post(&url)
+                    .header("Content-Type", "application/json")
+                    .body(body);
+                if let Some(ref s) = sig {
+                    req = req.header("X-Signature-256", format!("sha256={s}"));
+                }
+                match req.send().await {
+                    Ok(r) if r.status().is_success() => {
+                        info!(url = %url, attempt = attempt, "{{PASCAL}} delivered (primary)");
+                        Ok(())
+                    }
+                    Ok(r) => Err(format!("HTTP {}", r.status())),
+                    Err(e) => Err(e.to_string()),
+                }
+            }
+        })
+        .await
+        .is_ok();
+
+    if primary_ok {
+        return true;
+    }
+
+    warn!(primary = %primary_url, "{{PASCAL}} primary delivery failed, trying failover");
+
+    if let Some(f_url) = failover_url {
+        metrics::record_notification_failover("webhook");
+        let f_sig = failover_secret.as_deref().map(|s| sign_payload(s, &body));
+
+        let failover_ok = policy
+            .execute_with_retry(|attempt| {
+                let client = client.clone();
+                let url = f_url.clone();
+                let body = body.clone();
+                let sig = f_sig.clone();
+                async move {
+                    let mut req = client
+                        .post(&url)
+                        .header("Content-Type", "application/json")
+                        .body(body);
+                    if let Some(ref s) = sig {
+                        req = req.header("X-Signature-256", format!("sha256={s}"));
+                    }
+                    match req.send().await {
+                        Ok(r) if r.status().is_success() => {
+                            info!(url = %url, attempt = attempt, "{{PASCAL}} delivered (failover)");
+                            Ok(())
+                        }
+                        Ok(r) => Err(format!("HTTP {}", r.status())),
+                        Err(e) => Err(e.to_string()),
+                    }
+                }
+            })
+            .await
+            .is_ok();
+
+        if failover_ok {
+            return true;
+        }
+
+        error!(failover = %f_url, "{{PASCAL}} failover delivery also failed");
+    }
+
+    insert_{{SNAKE}}_dlq(
+        &primary_url,
+        &event,
+        policy.max_attempts,
+        "Primary and failover both failed",
+        pool,
+    )
+    .await;
+    metrics::record_webhook_failure();
+    false
+}
+
+// ---------------------------------------------------------------------------
+// Priority evaluation
+// ---------------------------------------------------------------------------
+
+/// Determine the delivery priority for a {{PASCAL}} event.
+///
+/// Override the default `"medium"` priority by supplying a JSONPath rule.
+/// Example: `rule_path = Some("$.amount")`, `rule_value = Some("5000000")`,
+/// `rule_priority = Some("critical")`.
+pub fn evaluate_{{SNAKE}}_priority<'a>(
+    event: &crate::models::SorobanEvent,
+    rule_path: Option<&str>,
+    rule_value: Option<&str>,
+    rule_priority: Option<&'a str>,
+) -> &'a str {
+    evaluate_priority(event, rule_path, rule_value, rule_priority, "medium")
+}
+
+// ---------------------------------------------------------------------------
+// DLQ insertion
+// ---------------------------------------------------------------------------
+
+async fn insert_{{SNAKE}}_dlq(
+    url: &str,
+    event: &SorobanEvent,
+    attempts: usize,
+    error: &str,
+    pool: Option<&sqlx::PgPool>,
+) {
+    let Some(pool) = pool else { return };
+    let payload = serde_json::to_value(event).unwrap_or(json!({}));
+    let next_retry = chrono::Utc::now() + chrono::Duration::seconds(60);
+    if let Err(e) = sqlx::query(
+        "INSERT INTO webhook_failures (url, payload, attempts, last_error, next_retry_at)
+         VALUES ($1, $2, $3, $4, $5)",
+    )
+    .bind(url)
+    .bind(payload)
+    .bind(attempts as i32)
+    .bind(error)
+    .bind(next_retry)
+    .execute(pool)
+    .await
+    {
+        error!(error = %e, "Failed to insert {{PASCAL}} webhook failure into DLQ");
+    }
+}
+"#;
+
+const EMAIL_TEMPLATE: &str = r#"//! Email notification handler for {{PASCAL}} subscriptions.
+//!
+//! Renders a Handlebars template and sends via SMTP. Wire `send_{{SNAKE}}_email`
+//! into the delivery worker once the event passes content filters.
+
+use crate::{
+    email::{render_template, send_email},
+    error::AppError,
+    models::SorobanEvent,
+};
+use serde_json::json;
+
+/// Send an email notification for a {{PASCAL}} event to `recipient`.
+pub async fn send_{{SNAKE}}_email(
+    event: &SorobanEvent,
+    recipient: &str,
+    smtp_host: &str,
+    smtp_user: &str,
+    smtp_pass: &str,
+) -> Result<(), AppError> {
+    let context = json!({
+        "contract_id": event.contract_id,
+        "ledger": event.ledger,
+        "event_type": event.event_type,
+        "value": event.value,
+        "ledger_closed_at": event.ledger_closed_at,
+    });
+
+    let subject = format!("{{PASCAL}} Event — {}", event.event_type);
+    let html = render_template("{{SNAKE}}_notification", &context)?;
+
+    send_email(smtp_host, smtp_user, smtp_pass, recipient, &subject, &html).await
+}
+"#;
+
+const SMS_TEMPLATE: &str = r#"//! SMS notification handler for {{PASCAL}} subscriptions.
+//!
+//! Formats a short message and dispatches via the configured SMS provider.
+//! Wire `send_{{SNAKE}}_sms` into the delivery worker once the event passes
+//! content filters.
+
+use crate::{error::AppError, models::SorobanEvent, sms::send_sms};
+
+/// Send an SMS notification for a {{PASCAL}} event to `phone_number`.
+pub async fn send_{{SNAKE}}_sms(
+    event: &SorobanEvent,
+    phone_number: &str,
+    provider_api_key: &str,
+) -> Result<(), AppError> {
+    let message = format!(
+        "SorobanPulse: {{PASCAL}} event on contract {} at ledger {}. Type: {}.",
+        event.contract_id, event.ledger, event.event_type,
+    );
+    send_sms(phone_number, &message, provider_api_key).await
+}
+"#;
+
+pub fn generate(config: &ScaffoldConfig) -> GeneratedFile {
+    let (filename, template) = match config.channel_type {
+        ChannelType::Webhook => (
+            format!("src/{}_webhook.rs", config.snake_name),
+            WEBHOOK_TEMPLATE,
+        ),
+        ChannelType::Email => (
+            format!("src/{}_email.rs", config.snake_name),
+            EMAIL_TEMPLATE,
+        ),
+        ChannelType::Sms => (
+            format!("src/{}_sms.rs", config.snake_name),
+            SMS_TEMPLATE,
+        ),
+    };
+    GeneratedFile {
+        relative_path: filename,
+        content: apply(template, config),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::codegen::{ChannelType, ScaffoldConfig};
+
+    #[test]
+    fn webhook_file_contains_signing_call() {
+        let cfg = ScaffoldConfig::new("transfer", ChannelType::Webhook, false, false);
+        let f = generate(&cfg);
+        assert!(f.content.contains("sign_payload"));
+        assert!(f.content.contains("X-Signature-256"));
+    }
+
+    #[test]
+    fn webhook_file_contains_dlq_insert() {
+        let cfg = ScaffoldConfig::new("transfer", ChannelType::Webhook, false, false);
+        let f = generate(&cfg);
+        assert!(f.content.contains("webhook_failures"));
+    }
+
+    #[test]
+    fn webhook_file_contains_failover() {
+        let cfg = ScaffoldConfig::new("transfer", ChannelType::Webhook, false, false);
+        let f = generate(&cfg);
+        assert!(f.content.contains("deliver_transfer_with_failover"));
+    }
+
+    #[test]
+    fn email_file_has_correct_path() {
+        let cfg = ScaffoldConfig::new("payment", ChannelType::Email, false, false);
+        let f = generate(&cfg);
+        assert_eq!(f.relative_path, "src/payment_email.rs");
+        assert!(f.content.contains("send_payment_email"));
+    }
+
+    #[test]
+    fn sms_file_has_correct_path() {
+        let cfg = ScaffoldConfig::new("alert", ChannelType::Sms, false, false);
+        let f = generate(&cfg);
+        assert_eq!(f.relative_path, "src/alert_sms.rs");
+        assert!(f.content.contains("send_alert_sms"));
+    }
+
+    #[test]
+    fn priority_function_name_uses_snake() {
+        let cfg = ScaffoldConfig::new("token-swap", ChannelType::Webhook, false, false);
+        let f = generate(&cfg);
+        assert!(f.content.contains("evaluate_token_swap_priority"));
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod abi;
+pub mod codegen;
 pub mod audit_logging;
 pub mod bloom_filter;
 pub mod config;


### PR DESCRIPTION
## Summary

Adds a CLI code generator that scaffolds all boilerplate for new subscription types — handlers, migrations, delivery code, filters, and tests — from a single command.

## Related Issue

Closes #595

## Changes

- Added `src/codegen/` module with template generators for subscriptions, webhooks, filters, and tests
- Added `src/bin/gen_subscription_scaffold.rs` CLI binary with `--channel-type`, `--with-filter`, `--with-tests`, and `--dry-run` flags
- Added `docs/codegen.md` with usage guide and integration steps

## Testing

- [ ] `cargo test` passes
- [ ] `cargo clippy` reports no warnings
- [ ] Manually tested locally

## Notes

Generated code follows existing conventions from `subscriptions.rs` and `webhook.rs` — same exponential backoff formula, same SSRF validation, same HMAC signing pattern.
