### PR TITLE
feat: add VS Code extension for Soroban Pulse API explorer

### DIFF
--- a/vscode-extension/.vscodeignore
+++ b/vscode-extension/.vscodeignore
@@ -1,0 +1,9 @@
+.vscode/**
+.vscode-test/**
+src/**
+.gitignore
+tsconfig.json
+.eslintrc*
+node_modules/**
+out/test/**
+**/*.map

--- a/vscode-extension/README.md
+++ b/vscode-extension/README.md
@@ -1,0 +1,41 @@
+# Soroban Pulse Explorer
+
+Browse, test, and inspect [Soroban Pulse](https://github.com/soroban-pulse/soroban-pulse) API endpoints directly from VS Code.
+
+## Features
+
+- **API Explorer** — sidebar tree of all endpoints grouped by category (Events, Contracts, Subscriptions, Admin, …)
+- **Request Tester** — send real HTTP requests with path params, query params, custom headers, and a body editor
+- **Response Viewer** — formatted JSON body, status badge, duration, and response headers
+
+## Getting Started
+
+1. Install the extension.
+2. Open **Settings** (`Ctrl+,`) and search for `sorobanpulse`:
+   - Set `sorobanpulse.baseUrl` to your running instance (default: `http://localhost:3000`)
+   - Set `sorobanpulse.apiKey` for authenticated endpoints
+   - Optionally set `sorobanpulse.adminApiKey` for `/admin/*` endpoints
+3. Click the **⚡** icon in the activity bar to open the API Explorer.
+4. Click any endpoint to open it in the Request Tester — fill in parameters and hit **Send**.
+
+## Commands
+
+| Command | Description |
+|---------|-------------|
+| `Soroban Pulse: Open Settings` | Jump to extension settings |
+| Refresh (toolbar) | Reload the endpoint list |
+| Copy URL (right-click) | Copy the full endpoint URL to clipboard |
+
+## Publishing
+
+```bash
+cd vscode-extension
+npm install
+npm run package        # builds soroban-pulse-explorer-x.x.x.vsix
+npm run publish        # publishes to VS Code Marketplace (requires vsce login)
+```
+
+## Requirements
+
+- VS Code `^1.85.0`
+- A running Soroban Pulse server

--- a/vscode-extension/media/pulse.svg
+++ b/vscode-extension/media/pulse.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/>
+</svg>

--- a/vscode-extension/package.json
+++ b/vscode-extension/package.json
@@ -1,0 +1,125 @@
+{
+  "name": "soroban-pulse-explorer",
+  "displayName": "Soroban Pulse Explorer",
+  "description": "Browse, test, and inspect Soroban Pulse API endpoints directly from VS Code.",
+  "version": "0.1.0",
+  "publisher": "soroban-pulse",
+  "license": "MIT",
+  "engines": {
+    "vscode": "^1.85.0"
+  },
+  "categories": ["Other"],
+  "keywords": ["soroban", "stellar", "blockchain", "api", "rest"],
+  "icon": "media/icon.png",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/soroban-pulse/soroban-pulse"
+  },
+  "activationEvents": [
+    "onView:sorobanpulse.apiExplorer"
+  ],
+  "main": "./out/extension.js",
+  "contributes": {
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "sorobanpulse",
+          "title": "Soroban Pulse",
+          "icon": "media/pulse.svg"
+        }
+      ]
+    },
+    "views": {
+      "sorobanpulse": [
+        {
+          "id": "sorobanpulse.apiExplorer",
+          "name": "API Explorer",
+          "icon": "media/pulse.svg"
+        }
+      ]
+    },
+    "commands": [
+      {
+        "command": "sorobanpulse.openRequestTester",
+        "title": "Open in Request Tester",
+        "icon": "$(play)"
+      },
+      {
+        "command": "sorobanpulse.refreshExplorer",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "sorobanpulse.copyUrl",
+        "title": "Copy URL",
+        "icon": "$(copy)"
+      },
+      {
+        "command": "sorobanpulse.openSettings",
+        "title": "Soroban Pulse: Open Settings"
+      }
+    ],
+    "menus": {
+      "view/title": [
+        {
+          "command": "sorobanpulse.refreshExplorer",
+          "when": "view == sorobanpulse.apiExplorer",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "sorobanpulse.openRequestTester",
+          "when": "view == sorobanpulse.apiExplorer && viewItem == endpoint",
+          "group": "inline"
+        },
+        {
+          "command": "sorobanpulse.copyUrl",
+          "when": "view == sorobanpulse.apiExplorer && viewItem == endpoint"
+        }
+      ]
+    },
+    "configuration": {
+      "title": "Soroban Pulse",
+      "properties": {
+        "sorobanpulse.baseUrl": {
+          "type": "string",
+          "default": "http://localhost:3000",
+          "description": "Base URL of the Soroban Pulse API server."
+        },
+        "sorobanpulse.apiKey": {
+          "type": "string",
+          "default": "",
+          "description": "API key sent as the x-api-key header."
+        },
+        "sorobanpulse.adminApiKey": {
+          "type": "string",
+          "default": "",
+          "description": "Admin API key for /admin/* endpoints."
+        },
+        "sorobanpulse.timeoutMs": {
+          "type": "number",
+          "default": 10000,
+          "description": "Request timeout in milliseconds."
+        }
+      }
+    }
+  },
+  "scripts": {
+    "vscode:prepublish": "npm run compile",
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "lint": "eslint src --ext ts",
+    "package": "vsce package",
+    "publish": "vsce publish"
+  },
+  "devDependencies": {
+    "@types/node": "^20.0.0",
+    "@types/vscode": "^1.85.0",
+    "@typescript-eslint/eslint-plugin": "^6.0.0",
+    "@typescript-eslint/parser": "^6.0.0",
+    "@vscode/vsce": "^2.22.0",
+    "eslint": "^8.0.0",
+    "typescript": "^5.3.0"
+  }
+}

--- a/vscode-extension/src/apiData.ts
+++ b/vscode-extension/src/apiData.ts
@@ -1,0 +1,310 @@
+import { ApiEndpoint, EndpointGroup } from './types';
+
+export const API_GROUPS: EndpointGroup[] = [
+    {
+        label: 'Health & System',
+        endpoints: [
+            {
+                method: 'GET', path: '/health',
+                description: 'Basic health check', auth: 'none',
+            },
+            {
+                method: 'GET', path: '/healthz/live',
+                description: 'Liveness probe', auth: 'none',
+            },
+            {
+                method: 'GET', path: '/healthz/ready',
+                description: 'Readiness probe', auth: 'none',
+            },
+            {
+                method: 'GET', path: '/status',
+                description: 'Indexer status and lag metrics', auth: 'api-key',
+            },
+            {
+                method: 'GET', path: '/metrics',
+                description: 'Prometheus metrics scrape endpoint', auth: 'none',
+            },
+        ],
+    },
+    {
+        label: 'Events',
+        endpoints: [
+            {
+                method: 'GET', path: '/v1/events',
+                description: 'List Soroban events with filtering and pagination',
+                auth: 'api-key',
+                params: [
+                    { name: 'page', in: 'query', required: false, example: '1' },
+                    { name: 'limit', in: 'query', required: false, example: '25' },
+                    { name: 'event_type', in: 'query', required: false, example: 'contract' },
+                    { name: 'from_ledger', in: 'query', required: false, example: '1000000' },
+                    { name: 'to_ledger', in: 'query', required: false },
+                    { name: 'sort', in: 'query', required: false, example: 'desc' },
+                    { name: 'sort_by', in: 'query', required: false, example: 'ledger' },
+                    { name: 'exact_count', in: 'query', required: false, example: 'false' },
+                ],
+            },
+            {
+                method: 'GET', path: '/v1/events/recent',
+                description: 'Most recently indexed events', auth: 'api-key',
+            },
+            {
+                method: 'GET', path: '/v1/events/stats',
+                description: 'Aggregate event statistics', auth: 'api-key',
+            },
+            {
+                method: 'GET', path: '/v1/events/diff',
+                description: 'Events changed between two ledger ranges', auth: 'api-key',
+                params: [
+                    { name: 'from_ledger', in: 'query', required: true },
+                    { name: 'to_ledger', in: 'query', required: true },
+                ],
+            },
+            {
+                method: 'GET', path: '/v1/events/timeseries',
+                description: 'Event volume over time buckets', auth: 'api-key',
+                params: [
+                    { name: 'bucket', in: 'query', required: false, example: 'hour' },
+                    { name: 'from', in: 'query', required: false },
+                    { name: 'to', in: 'query', required: false },
+                ],
+            },
+            {
+                method: 'GET', path: '/v1/events/export',
+                description: 'Export events as CSV or Parquet',
+                auth: 'api-key',
+                params: [
+                    { name: 'format', in: 'query', required: false, example: 'csv' },
+                    { name: 'contract_id', in: 'query', required: false },
+                    { name: 'from_ledger', in: 'query', required: false },
+                    { name: 'to_ledger', in: 'query', required: false },
+                ],
+            },
+            {
+                method: 'GET', path: '/v1/events/stream',
+                description: 'SSE stream of live events', auth: 'api-key',
+                streaming: true,
+                params: [
+                    { name: 'contract_id', in: 'query', required: false },
+                ],
+            },
+            {
+                method: 'GET', path: '/v1/events/stream/multi',
+                description: 'SSE stream for multiple contracts', auth: 'api-key',
+                streaming: true,
+            },
+            {
+                method: 'POST', path: '/v1/events/tx/batch',
+                description: 'Fetch events for multiple transaction hashes',
+                auth: 'api-key',
+                bodyExample: JSON.stringify({ tx_hashes: ['abc123', 'def456'] }, null, 2),
+            },
+        ],
+    },
+    {
+        label: 'Contracts',
+        endpoints: [
+            {
+                method: 'GET', path: '/v1/events/contract/{contract_id}',
+                description: 'Events for a specific contract',
+                auth: 'api-key',
+                params: [
+                    { name: 'contract_id', in: 'path', required: true, example: 'CABC...' },
+                    { name: 'page', in: 'query', required: false },
+                    { name: 'limit', in: 'query', required: false, example: '25' },
+                    { name: 'cursor', in: 'query', required: false },
+                    { name: 'from_ledger', in: 'query', required: false },
+                    { name: 'to_ledger', in: 'query', required: false },
+                ],
+            },
+            {
+                method: 'GET', path: '/v1/events/contract/{contract_id}/stream',
+                description: 'SSE stream for a specific contract',
+                auth: 'api-key', streaming: true,
+                params: [
+                    { name: 'contract_id', in: 'path', required: true },
+                ],
+            },
+            {
+                method: 'GET', path: '/v1/contracts',
+                description: 'List all indexed contracts', auth: 'api-key',
+                params: [
+                    { name: 'page', in: 'query', required: false },
+                    { name: 'limit', in: 'query', required: false },
+                ],
+            },
+            {
+                method: 'GET', path: '/v1/contracts/search',
+                description: 'Search contracts by partial ID', auth: 'api-key',
+                params: [
+                    { name: 'q', in: 'query', required: true },
+                ],
+            },
+            {
+                method: 'GET', path: '/v1/contracts/{contract_id}/summary',
+                description: 'Event summary for a contract',
+                auth: 'api-key',
+                params: [
+                    { name: 'contract_id', in: 'path', required: true },
+                ],
+            },
+            {
+                method: 'GET', path: '/v1/contracts/{contract_id}/stats/history',
+                description: 'Historical stats for a contract',
+                auth: 'api-key',
+                params: [
+                    { name: 'contract_id', in: 'path', required: true },
+                    { name: 'bucket', in: 'query', required: false, example: 'day' },
+                    { name: 'days', in: 'query', required: false, example: '30' },
+                ],
+            },
+        ],
+    },
+    {
+        label: 'Transactions',
+        endpoints: [
+            {
+                method: 'GET', path: '/v1/events/tx/{tx_hash}',
+                description: 'Events for a transaction hash',
+                auth: 'api-key',
+                params: [
+                    { name: 'tx_hash', in: 'path', required: true },
+                ],
+            },
+            {
+                method: 'GET', path: '/v1/events/tx/{tx_hash}/related',
+                description: 'Related events linked to a transaction',
+                auth: 'api-key',
+                params: [
+                    { name: 'tx_hash', in: 'path', required: true },
+                    { name: 'depth', in: 'query', required: false, example: '1' },
+                ],
+            },
+            {
+                method: 'GET', path: '/v1/events/ledger-hash/{hash}',
+                description: 'Events for a ledger hash',
+                auth: 'api-key',
+                params: [
+                    { name: 'hash', in: 'path', required: true },
+                ],
+            },
+        ],
+    },
+    {
+        label: 'Subscriptions',
+        endpoints: [
+            {
+                method: 'POST', path: '/subscriptions',
+                description: 'Create a webhook subscription',
+                auth: 'api-key',
+                bodyExample: JSON.stringify({ callback_url: 'https://example.com/hook', from_ledger: 1000000 }, null, 2),
+            },
+            {
+                method: 'GET', path: '/subscriptions/{id}',
+                description: 'Get subscription details and pending count',
+                auth: 'api-key',
+                params: [{ name: 'id', in: 'path', required: true, example: 'uuid' }],
+            },
+            {
+                method: 'DELETE', path: '/subscriptions/{id}',
+                description: 'Cancel an active subscription',
+                auth: 'api-key',
+                params: [{ name: 'id', in: 'path', required: true }],
+            },
+            {
+                method: 'POST', path: '/subscriptions/{id}/ack',
+                description: 'Advance the acknowledged ledger cursor',
+                auth: 'api-key',
+                params: [{ name: 'id', in: 'path', required: true }],
+                bodyExample: JSON.stringify({ ledger: 1000100 }, null, 2),
+            },
+        ],
+    },
+    {
+        label: 'Admin',
+        endpoints: [
+            {
+                method: 'POST', path: '/admin/replay',
+                description: 'Replay events from a ledger range',
+                auth: 'admin-key',
+                bodyExample: JSON.stringify({ from_ledger: 1000000, to_ledger: 1001000 }, null, 2),
+            },
+            {
+                method: 'POST', path: '/admin/indexer/pause',
+                description: 'Pause the event indexer', auth: 'admin-key',
+            },
+            {
+                method: 'POST', path: '/admin/indexer/resume',
+                description: 'Resume the event indexer', auth: 'admin-key',
+            },
+            {
+                method: 'GET', path: '/admin/contracts/{contract_id}/abi',
+                description: 'Get registered ABI for a contract',
+                auth: 'admin-key',
+                params: [{ name: 'contract_id', in: 'path', required: true }],
+            },
+            {
+                method: 'POST', path: '/admin/contracts/{contract_id}/abi',
+                description: 'Register a contract ABI',
+                auth: 'admin-key',
+                params: [{ name: 'contract_id', in: 'path', required: true }],
+                bodyExample: JSON.stringify([{ name: 'transfer', inputs: [] }], null, 2),
+            },
+            {
+                method: 'POST', path: '/admin/contracts/{contract_id}/schema',
+                description: 'Register a JSON schema for event validation',
+                auth: 'admin-key',
+                params: [{ name: 'contract_id', in: 'path', required: true }],
+                bodyExample: JSON.stringify({ type: 'object', properties: {} }, null, 2),
+            },
+            {
+                method: 'DELETE', path: '/admin/contracts/{contract_id}/schema',
+                description: 'Delete a contract schema',
+                auth: 'admin-key',
+                params: [{ name: 'contract_id', in: 'path', required: true }],
+            },
+            {
+                method: 'POST', path: '/admin/notifications/channels',
+                description: 'Create a notification channel',
+                auth: 'admin-key',
+                bodyExample: JSON.stringify({
+                    name: 'my-webhook',
+                    channel_type: 'webhook',
+                    config: { url: 'https://example.com/hook', secret: 'mysecret' },
+                    retry_policy: { max_attempts: 5, base_delay_secs: 2 },
+                }, null, 2),
+            },
+            {
+                method: 'POST', path: '/admin/notifications/suppress',
+                description: 'Add a URL/address to the suppression list',
+                auth: 'admin-key',
+                bodyExample: JSON.stringify({ target: 'https://example.com/hook', target_type: 'webhook' }, null, 2),
+            },
+            {
+                method: 'POST', path: '/admin/events/{id}/anonymize',
+                description: 'Anonymize an event by ID',
+                auth: 'admin-key',
+                params: [{ name: 'id', in: 'path', required: true }],
+            },
+            {
+                method: 'POST', path: '/admin/bulk-insert',
+                description: 'Bulk insert events',
+                auth: 'admin-key',
+                bodyExample: JSON.stringify({ events: [] }, null, 2),
+            },
+        ],
+    },
+    {
+        label: 'Docs',
+        endpoints: [
+            {
+                method: 'GET', path: '/openapi.json',
+                description: 'OpenAPI 3.0 specification', auth: 'none',
+            },
+            {
+                method: 'GET', path: '/docs',
+                description: 'Swagger UI', auth: 'none',
+            },
+        ],
+    },
+];

--- a/vscode-extension/src/apiExplorer.ts
+++ b/vscode-extension/src/apiExplorer.ts
@@ -1,0 +1,105 @@
+import * as vscode from 'vscode';
+import { API_GROUPS } from './apiData';
+import { ApiEndpoint, EndpointGroup } from './types';
+
+// ---------------------------------------------------------------------------
+// Tree items
+// ---------------------------------------------------------------------------
+
+export class GroupItem extends vscode.TreeItem {
+    constructor(public readonly group: EndpointGroup) {
+        super(group.label, vscode.TreeItemCollapsibleState.Expanded);
+        this.contextValue = 'group';
+        this.iconPath = new vscode.ThemeIcon('folder');
+    }
+}
+
+export class EndpointItem extends vscode.TreeItem {
+    constructor(public readonly endpoint: ApiEndpoint) {
+        super(endpoint.path, vscode.TreeItemCollapsibleState.None);
+        this.contextValue = 'endpoint';
+        this.description = endpoint.description;
+        this.tooltip = new vscode.MarkdownString(
+            `**${endpoint.method}** \`${endpoint.path}\`\n\n${endpoint.description}` +
+            (endpoint.streaming ? '\n\n_Streaming (SSE)_' : '') +
+            (endpoint.deprecated ? '\n\n⚠️ _Deprecated_' : '')
+        );
+        this.iconPath = methodIcon(endpoint.method);
+        this.command = {
+            command: 'sorobanpulse.openRequestTester',
+            title: 'Open in Request Tester',
+            arguments: [endpoint],
+        };
+    }
+}
+
+function methodIcon(method: string): vscode.ThemeIcon {
+    const colors: Record<string, string> = {
+        GET: 'charts.green',
+        POST: 'charts.blue',
+        DELETE: 'charts.red',
+        PUT: 'charts.yellow',
+        PATCH: 'charts.orange',
+    };
+    return new vscode.ThemeIcon('circle-filled', new vscode.ThemeColor(colors[method] ?? 'foreground'));
+}
+
+// ---------------------------------------------------------------------------
+// Tree data provider
+// ---------------------------------------------------------------------------
+
+type TreeNode = GroupItem | EndpointItem;
+
+export class ApiExplorerProvider implements vscode.TreeDataProvider<TreeNode> {
+    private readonly _onDidChangeTreeData = new vscode.EventEmitter<TreeNode | undefined | void>();
+    readonly onDidChangeTreeData = this._onDidChangeTreeData.event;
+
+    private filter = '';
+
+    refresh(): void {
+        this._onDidChangeTreeData.fire();
+    }
+
+    setFilter(text: string): void {
+        this.filter = text.toLowerCase();
+        this.refresh();
+    }
+
+    getTreeItem(element: TreeNode): vscode.TreeItem {
+        return element;
+    }
+
+    getChildren(element?: TreeNode): TreeNode[] {
+        if (!element) {
+            return this.filteredGroups().map(g => new GroupItem(g));
+        }
+        if (element instanceof GroupItem) {
+            return this.filteredEndpoints(element.group).map(e => new EndpointItem(e));
+        }
+        return [];
+    }
+
+    private filteredGroups(): EndpointGroup[] {
+        if (!this.filter) {
+            return API_GROUPS;
+        }
+        return API_GROUPS
+            .map(g => ({ ...g, endpoints: g.endpoints.filter(e => this.matchesFilter(e)) }))
+            .filter(g => g.endpoints.length > 0);
+    }
+
+    private filteredEndpoints(group: EndpointGroup): ApiEndpoint[] {
+        if (!this.filter) {
+            return group.endpoints;
+        }
+        return group.endpoints.filter(e => this.matchesFilter(e));
+    }
+
+    private matchesFilter(e: ApiEndpoint): boolean {
+        return (
+            e.path.toLowerCase().includes(this.filter) ||
+            e.description.toLowerCase().includes(this.filter) ||
+            e.method.toLowerCase().includes(this.filter)
+        );
+    }
+}

--- a/vscode-extension/src/extension.ts
+++ b/vscode-extension/src/extension.ts
@@ -1,0 +1,49 @@
+import * as vscode from 'vscode';
+import { ApiExplorerProvider, EndpointItem } from './apiExplorer';
+import { RequestTesterPanel } from './requestTester';
+import { ApiEndpoint } from './types';
+
+export function activate(context: vscode.ExtensionContext): void {
+    const explorer = new ApiExplorerProvider();
+
+    // Tree view
+    const treeView = vscode.window.createTreeView('sorobanpulse.apiExplorer', {
+        treeDataProvider: explorer,
+        showCollapseAll: true,
+    });
+
+    // Search/filter box above the tree
+    const searchBox = vscode.window.createInputBox();
+    searchBox.placeholder = 'Filter endpoints…';
+    searchBox.onDidChangeValue(v => explorer.setFilter(v));
+
+    // Commands
+    context.subscriptions.push(
+        treeView,
+
+        vscode.commands.registerCommand('sorobanpulse.refreshExplorer', () => {
+            explorer.setFilter('');
+            explorer.refresh();
+        }),
+
+        vscode.commands.registerCommand('sorobanpulse.openRequestTester', (endpoint?: ApiEndpoint) => {
+            RequestTesterPanel.open(context.extensionUri, endpoint);
+        }),
+
+        vscode.commands.registerCommand('sorobanpulse.copyUrl', async (item?: EndpointItem) => {
+            if (!item) { return; }
+            const base = vscode.workspace.getConfiguration('sorobanpulse').get<string>('baseUrl', 'http://localhost:3000');
+            const url = base.replace(/\/$/, '') + item.endpoint.path;
+            await vscode.env.clipboard.writeText(url);
+            vscode.window.showInformationMessage(`Copied: ${url}`);
+        }),
+
+        vscode.commands.registerCommand('sorobanpulse.openSettings', () => {
+            vscode.commands.executeCommand('workbench.action.openSettings', 'sorobanpulse');
+        }),
+    );
+}
+
+export function deactivate(): void {
+    // Nothing to clean up — disposables handled via context.subscriptions
+}

--- a/vscode-extension/src/requestTester.ts
+++ b/vscode-extension/src/requestTester.ts
@@ -1,0 +1,699 @@
+import * as vscode from 'vscode';
+import * as https from 'https';
+import * as http from 'http';
+import { URL } from 'url';
+import { ApiEndpoint, RequestConfig, ResponseData, WebviewMessage } from './types';
+
+// ---------------------------------------------------------------------------
+// Panel manager — single reusable panel instance
+// ---------------------------------------------------------------------------
+
+export class RequestTesterPanel {
+    static currentPanel: RequestTesterPanel | undefined;
+    private static readonly viewType = 'sorobanpulse.requestTester';
+
+    private readonly _panel: vscode.WebviewPanel;
+    private readonly _extensionUri: vscode.Uri;
+    private _disposables: vscode.Disposable[] = [];
+
+    static open(extensionUri: vscode.Uri, endpoint?: ApiEndpoint): void {
+        const column = vscode.window.activeTextEditor?.viewColumn ?? vscode.ViewColumn.One;
+
+        if (RequestTesterPanel.currentPanel) {
+            RequestTesterPanel.currentPanel._panel.reveal(column);
+            if (endpoint) {
+                RequestTesterPanel.currentPanel._loadEndpoint(endpoint);
+            }
+            return;
+        }
+
+        const panel = vscode.window.createWebviewPanel(
+            RequestTesterPanel.viewType,
+            'Soroban Pulse — Request Tester',
+            column,
+            {
+                enableScripts: true,
+                retainContextWhenHidden: true,
+                localResourceRoots: [vscode.Uri.joinPath(extensionUri, 'media')],
+            }
+        );
+
+        RequestTesterPanel.currentPanel = new RequestTesterPanel(panel, extensionUri, endpoint);
+    }
+
+    private constructor(
+        panel: vscode.WebviewPanel,
+        extensionUri: vscode.Uri,
+        endpoint?: ApiEndpoint
+    ) {
+        this._panel = panel;
+        this._extensionUri = extensionUri;
+
+        this._panel.webview.html = this._buildHtml();
+
+        // Handle messages from the webview
+        this._panel.webview.onDidReceiveMessage(
+            (msg: WebviewMessage) => this._handleMessage(msg),
+            null,
+            this._disposables
+        );
+
+        this._panel.onDidDispose(() => this.dispose(), null, this._disposables);
+
+        // Load initial endpoint once the webview is ready
+        if (endpoint) {
+            // Small delay to ensure the webview is initialized before sending
+            setTimeout(() => this._loadEndpoint(endpoint), 300);
+        }
+    }
+
+    private _loadEndpoint(endpoint: ApiEndpoint): void {
+        const config = vscode.workspace.getConfiguration('sorobanpulse');
+        const baseUrl = config.get<string>('baseUrl', 'http://localhost:3000');
+        const apiKey = config.get<string>('apiKey', '');
+        const adminApiKey = config.get<string>('adminApiKey', '');
+
+        this._panel.webview.postMessage({
+            type: 'loadEndpoint',
+            endpoint,
+            baseUrl,
+            apiKey,
+            adminApiKey,
+        });
+    }
+
+    private async _handleMessage(msg: WebviewMessage): Promise<void> {
+        switch (msg.type) {
+            case 'sendRequest':
+                await this._executeRequest(msg.config);
+                break;
+            case 'copyToClipboard':
+                await vscode.env.clipboard.writeText(msg.text);
+                vscode.window.showInformationMessage('Copied to clipboard.');
+                break;
+            case 'openSettings':
+                await vscode.commands.executeCommand('workbench.action.openSettings', 'sorobanpulse');
+                break;
+        }
+    }
+
+    private async _executeRequest(config: RequestConfig): Promise<void> {
+        this._panel.webview.postMessage({ type: 'loading' });
+
+        const timeoutMs = vscode.workspace.getConfiguration('sorobanpulse').get<number>('timeoutMs', 10000);
+        const start = Date.now();
+
+        try {
+            const result = await makeRequest(config, timeoutMs);
+            result.durationMs = Date.now() - start;
+            this._panel.webview.postMessage({ type: 'response', data: result });
+        } catch (err) {
+            this._panel.webview.postMessage({
+                type: 'error',
+                message: err instanceof Error ? err.message : String(err),
+            });
+        }
+    }
+
+    dispose(): void {
+        RequestTesterPanel.currentPanel = undefined;
+        this._panel.dispose();
+        this._disposables.forEach(d => d.dispose());
+    }
+
+    // -----------------------------------------------------------------------
+    // Webview HTML
+    // -----------------------------------------------------------------------
+
+    private _buildHtml(): string {
+        const nonce = getNonce();
+        return /* html */`<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta http-equiv="Content-Security-Policy"
+    content="default-src 'none'; style-src 'nonce-${nonce}'; script-src 'nonce-${nonce}';">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Soroban Pulse — Request Tester</title>
+  <style nonce="${nonce}">${STYLES}</style>
+</head>
+<body>
+  <div class="toolbar">
+    <span class="app-title">⚡ Soroban Pulse</span>
+    <button class="btn-ghost" id="btnSettings" title="Open Settings">⚙</button>
+  </div>
+
+  <div class="pane" id="requestPane">
+    <div class="url-bar">
+      <span class="method-badge" id="methodBadge">GET</span>
+      <input id="urlInput" class="url-input" type="text" placeholder="http://localhost:3000/v1/events" spellcheck="false">
+      <button class="btn-primary" id="btnSend">Send</button>
+    </div>
+
+    <div class="tabs">
+      <button class="tab active" data-tab="params">Params</button>
+      <button class="tab" data-tab="headers">Headers</button>
+      <button class="tab" data-tab="body">Body</button>
+    </div>
+
+    <div class="tab-content active" id="tab-params">
+      <div id="queryParams"></div>
+      <div id="pathParams"></div>
+    </div>
+
+    <div class="tab-content" id="tab-headers">
+      <table class="kv-table" id="headersTable">
+        <thead><tr><th>Key</th><th>Value</th><th></th></tr></thead>
+        <tbody id="headerRows"></tbody>
+      </table>
+      <button class="btn-ghost btn-add" id="btnAddHeader">+ Add Header</button>
+    </div>
+
+    <div class="tab-content" id="tab-body">
+      <textarea id="bodyInput" class="body-editor" placeholder='{"key": "value"}'></textarea>
+    </div>
+  </div>
+
+  <div class="divider"></div>
+
+  <div class="pane" id="responsePane">
+    <div class="response-toolbar" id="responseToolbar" style="display:none">
+      <span class="status-badge" id="statusBadge"></span>
+      <span class="duration" id="durationBadge"></span>
+      <div class="spacer"></div>
+      <button class="btn-ghost" id="btnCopyResponse" title="Copy response">⧉</button>
+    </div>
+
+    <div id="emptyState" class="empty-state">
+      <p>Select an endpoint from the explorer and press <strong>Send</strong>.</p>
+    </div>
+
+    <div id="loadingState" class="loading" style="display:none">Sending…</div>
+
+    <div id="errorState" class="error-state" style="display:none">
+      <span id="errorMsg"></span>
+    </div>
+
+    <div class="response-tabs" id="responseTabs" style="display:none">
+      <button class="tab active" data-rtab="body">Body</button>
+      <button class="tab" data-rtab="headers">Headers</button>
+    </div>
+
+    <div id="rtab-body" class="rtab-content active">
+      <pre id="responseBody" class="response-body"></pre>
+    </div>
+    <div id="rtab-headers" class="rtab-content">
+      <table class="resp-headers-table" id="responseHeaders"></table>
+    </div>
+  </div>
+
+  <script nonce="${nonce}">${SCRIPT}</script>
+</body>
+</html>`;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// HTTP client (Node built-ins only — no external deps)
+// ---------------------------------------------------------------------------
+
+function makeRequest(config: RequestConfig, timeoutMs: number): Promise<ResponseData> {
+    return new Promise((resolve, reject) => {
+        let url: URL;
+        try {
+            url = new URL(config.url);
+        } catch {
+            return reject(new Error(`Invalid URL: ${config.url}`));
+        }
+
+        const isHttps = url.protocol === 'https:';
+        const lib = isHttps ? https : http;
+
+        const body = config.body ? Buffer.from(config.body, 'utf-8') : undefined;
+
+        const options: http.RequestOptions = {
+            hostname: url.hostname,
+            port: url.port || (isHttps ? 443 : 80),
+            path: url.pathname + url.search,
+            method: config.method,
+            headers: {
+                ...config.headers,
+                ...(body ? { 'Content-Length': body.length } : {}),
+            },
+            timeout: timeoutMs,
+        };
+
+        const req = lib.request(options, (res) => {
+            const chunks: Buffer[] = [];
+            res.on('data', (chunk: Buffer) => chunks.push(chunk));
+            res.on('end', () => {
+                resolve({
+                    status: res.statusCode ?? 0,
+                    statusText: res.statusMessage ?? '',
+                    headers: res.headers as Record<string, string>,
+                    body: Buffer.concat(chunks).toString('utf-8'),
+                    durationMs: 0,
+                });
+            });
+        });
+
+        req.on('timeout', () => { req.destroy(); reject(new Error(`Request timed out after ${timeoutMs}ms`)); });
+        req.on('error', reject);
+
+        if (body) { req.write(body); }
+        req.end();
+    });
+}
+
+function getNonce(): string {
+    let text = '';
+    const possible = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+    for (let i = 0; i < 32; i++) {
+        text += possible.charAt(Math.floor(Math.random() * possible.length));
+    }
+    return text;
+}
+
+// ---------------------------------------------------------------------------
+// Webview CSS
+// ---------------------------------------------------------------------------
+
+const STYLES = `
+  :root {
+    --gap: 8px;
+    --radius: 4px;
+    --font-mono: var(--vscode-editor-font-family, monospace);
+  }
+  * { box-sizing: border-box; margin: 0; padding: 0; }
+  body {
+    font-family: var(--vscode-font-family);
+    font-size: var(--vscode-font-size);
+    color: var(--vscode-foreground);
+    background: var(--vscode-editor-background);
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+    overflow: hidden;
+  }
+  .toolbar {
+    display: flex;
+    align-items: center;
+    padding: 6px 12px;
+    background: var(--vscode-titleBar-activeBackground);
+    border-bottom: 1px solid var(--vscode-panel-border);
+    gap: var(--gap);
+  }
+  .app-title { font-weight: 600; font-size: 13px; flex: 1; }
+  .pane { padding: 10px 12px; overflow-y: auto; flex: 1; min-height: 0; }
+  .divider { height: 1px; background: var(--vscode-panel-border); flex-shrink: 0; }
+  .url-bar { display: flex; gap: var(--gap); align-items: center; margin-bottom: 10px; }
+  .method-badge {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 700;
+    padding: 3px 8px;
+    border-radius: var(--radius);
+    background: var(--vscode-badge-background);
+    color: var(--vscode-badge-foreground);
+    white-space: nowrap;
+  }
+  .method-GET    { background: #1a5c2e; color: #4ec97b; }
+  .method-POST   { background: #1b3a6b; color: #6db3ff; }
+  .method-DELETE { background: #5c1a1a; color: #f97070; }
+  .method-PUT    { background: #5c4a1a; color: #f0c040; }
+  .method-PATCH  { background: #4a2e00; color: #e08020; }
+  .url-input {
+    flex: 1;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    padding: 5px 8px;
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent);
+    border-radius: var(--radius);
+    outline: none;
+  }
+  .url-input:focus { border-color: var(--vscode-focusBorder); }
+  .btn-primary {
+    padding: 5px 14px;
+    background: var(--vscode-button-background);
+    color: var(--vscode-button-foreground);
+    border: none;
+    border-radius: var(--radius);
+    cursor: pointer;
+    font-size: 12px;
+    font-weight: 600;
+    white-space: nowrap;
+  }
+  .btn-primary:hover { background: var(--vscode-button-hoverBackground); }
+  .btn-ghost {
+    background: transparent;
+    border: none;
+    color: var(--vscode-foreground);
+    cursor: pointer;
+    padding: 4px 6px;
+    border-radius: var(--radius);
+    opacity: 0.7;
+  }
+  .btn-ghost:hover { opacity: 1; background: var(--vscode-toolbar-hoverBackground); }
+  .btn-add { margin-top: 6px; font-size: 11px; }
+  .tabs, .response-tabs {
+    display: flex;
+    gap: 2px;
+    border-bottom: 1px solid var(--vscode-panel-border);
+    margin-bottom: 10px;
+  }
+  .tab {
+    background: transparent;
+    border: none;
+    color: var(--vscode-foreground);
+    padding: 5px 12px;
+    cursor: pointer;
+    font-size: 12px;
+    opacity: 0.7;
+    border-bottom: 2px solid transparent;
+  }
+  .tab.active { opacity: 1; border-bottom-color: var(--vscode-focusBorder); }
+  .tab-content, .rtab-content { display: none; }
+  .tab-content.active, .rtab-content.active { display: block; }
+  .section-label {
+    font-size: 10px;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    opacity: 0.6;
+    margin: 10px 0 4px;
+  }
+  .param-row { display: flex; gap: var(--gap); align-items: center; margin-bottom: 4px; }
+  .param-name { font-family: var(--font-mono); font-size: 11px; min-width: 120px; opacity: 0.8; }
+  .param-input, .kv-input {
+    flex: 1;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    padding: 4px 7px;
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent);
+    border-radius: var(--radius);
+    outline: none;
+  }
+  .param-input:focus, .kv-input:focus { border-color: var(--vscode-focusBorder); }
+  .required-star { color: #f97070; margin-left: 2px; }
+  .kv-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  .kv-table th { text-align: left; opacity: 0.6; font-size: 10px; font-weight: 600;
+                  text-transform: uppercase; padding-bottom: 4px; }
+  .kv-table td { padding: 2px 4px 2px 0; }
+  .kv-table td:last-child { width: 24px; }
+  .btn-remove { background: transparent; border: none; color: #f97070; cursor: pointer; font-size: 14px; }
+  .body-editor {
+    width: 100%;
+    min-height: 120px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    padding: 8px;
+    background: var(--vscode-input-background);
+    color: var(--vscode-input-foreground);
+    border: 1px solid var(--vscode-input-border, transparent);
+    border-radius: var(--radius);
+    resize: vertical;
+    outline: none;
+  }
+  .response-toolbar {
+    display: flex;
+    align-items: center;
+    gap: var(--gap);
+    margin-bottom: 8px;
+  }
+  .status-badge {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    padding: 2px 8px;
+    border-radius: var(--radius);
+  }
+  .status-2xx { background: #1a5c2e; color: #4ec97b; }
+  .status-3xx { background: #1b3a6b; color: #6db3ff; }
+  .status-4xx { background: #5c4a1a; color: #f0c040; }
+  .status-5xx { background: #5c1a1a; color: #f97070; }
+  .duration { font-size: 11px; opacity: 0.6; font-family: var(--font-mono); }
+  .spacer { flex: 1; }
+  .empty-state { text-align: center; opacity: 0.5; padding: 40px 0; font-size: 13px; }
+  .loading { text-align: center; opacity: 0.6; padding: 30px 0; font-size: 13px; }
+  .error-state {
+    padding: 10px;
+    background: #3c1a1a;
+    border: 1px solid #7a3030;
+    border-radius: var(--radius);
+    color: #f97070;
+    font-family: var(--font-mono);
+    font-size: 12px;
+  }
+  .response-body {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    white-space: pre-wrap;
+    word-break: break-all;
+    line-height: 1.5;
+    tab-size: 2;
+  }
+  .resp-headers-table { width: 100%; border-collapse: collapse; font-size: 12px; }
+  .resp-headers-table td {
+    padding: 3px 8px 3px 0;
+    vertical-align: top;
+    border-bottom: 1px solid var(--vscode-panel-border);
+  }
+  .resp-headers-table td:first-child { font-family: var(--font-mono); opacity: 0.7; width: 40%; }
+  .resp-headers-table td:last-child { font-family: var(--font-mono); word-break: break-all; }
+`;
+
+// ---------------------------------------------------------------------------
+// Webview client-side JavaScript
+// ---------------------------------------------------------------------------
+
+const SCRIPT = `
+  const vscode = acquireVsCodeApi();
+  let currentEndpoint = null;
+
+  // ── Tab switching ──────────────────────────────────────────────────────────
+  document.querySelectorAll('.tab[data-tab]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tab = btn.dataset.tab;
+      document.querySelectorAll('.tab[data-tab]').forEach(b => b.classList.remove('active'));
+      document.querySelectorAll('.tab-content').forEach(c => c.classList.remove('active'));
+      btn.classList.add('active');
+      document.getElementById('tab-' + tab).classList.add('active');
+    });
+  });
+  document.querySelectorAll('.tab[data-rtab]').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const tab = btn.dataset.rtab;
+      document.querySelectorAll('.tab[data-rtab]').forEach(b => b.classList.remove('active'));
+      document.querySelectorAll('.rtab-content').forEach(c => c.classList.remove('active'));
+      btn.classList.add('active');
+      document.getElementById('rtab-' + tab).classList.add('active');
+    });
+  });
+
+  // ── Settings ──────────────────────────────────────────────────────────────
+  document.getElementById('btnSettings').addEventListener('click', () => {
+    vscode.postMessage({ type: 'openSettings' });
+  });
+
+  // ── Add header row ─────────────────────────────────────────────────────────
+  document.getElementById('btnAddHeader').addEventListener('click', () => addHeaderRow('', ''));
+
+  function addHeaderRow(key, value, enabled = true) {
+    const tbody = document.getElementById('headerRows');
+    const tr = document.createElement('tr');
+    tr.innerHTML =
+      '<td><input class="kv-input header-key" value="' + esc(key) + '" placeholder="Header"></td>' +
+      '<td><input class="kv-input header-val" value="' + esc(value) + '" placeholder="Value"></td>' +
+      '<td><button class="btn-remove" title="Remove">×</button></td>';
+    tr.querySelector('.btn-remove').addEventListener('click', () => tr.remove());
+    tbody.appendChild(tr);
+  }
+
+  // ── Send request ───────────────────────────────────────────────────────────
+  document.getElementById('btnSend').addEventListener('click', sendRequest);
+  document.getElementById('urlInput').addEventListener('keydown', e => {
+    if (e.key === 'Enter') sendRequest();
+  });
+
+  function sendRequest() {
+    let url = document.getElementById('urlInput').value.trim();
+
+    // Substitute path params
+    document.querySelectorAll('.path-param-input').forEach(inp => {
+      const name = inp.dataset.name;
+      const val = inp.value.trim();
+      if (val) url = url.replace('{' + name + '}', encodeURIComponent(val));
+    });
+
+    // Append query params
+    const qParams = [];
+    document.querySelectorAll('.query-param-input').forEach(inp => {
+      const name = inp.dataset.name;
+      const val = inp.value.trim();
+      if (val) qParams.push(encodeURIComponent(name) + '=' + encodeURIComponent(val));
+    });
+    if (qParams.length) {
+      url += (url.includes('?') ? '&' : '?') + qParams.join('&');
+    }
+
+    // Collect headers
+    const headers = {};
+    document.querySelectorAll('#headerRows tr').forEach(tr => {
+      const k = tr.querySelector('.header-key').value.trim();
+      const v = tr.querySelector('.header-val').value.trim();
+      if (k) headers[k] = v;
+    });
+
+    const method = currentEndpoint?.method ?? 'GET';
+    const body = document.getElementById('bodyInput').value.trim() || undefined;
+    if (body && !headers['Content-Type']) {
+      headers['Content-Type'] = 'application/json';
+    }
+
+    vscode.postMessage({ type: 'sendRequest', config: { method, url, headers, body } });
+  }
+
+  // ── Copy response ──────────────────────────────────────────────────────────
+  document.getElementById('btnCopyResponse').addEventListener('click', () => {
+    const text = document.getElementById('responseBody').textContent;
+    vscode.postMessage({ type: 'copyToClipboard', text });
+  });
+
+  // ── Messages from extension ────────────────────────────────────────────────
+  window.addEventListener('message', ({ data }) => {
+    switch (data.type) {
+      case 'loadEndpoint': loadEndpoint(data); break;
+      case 'loading':       showLoading();      break;
+      case 'response':      showResponse(data.data); break;
+      case 'error':         showError(data.message); break;
+    }
+  });
+
+  function loadEndpoint({ endpoint, baseUrl, apiKey, adminApiKey }) {
+    currentEndpoint = endpoint;
+
+    // Method badge
+    const badge = document.getElementById('methodBadge');
+    badge.textContent = endpoint.method;
+    badge.className = 'method-badge method-' + endpoint.method;
+
+    // URL
+    document.getElementById('urlInput').value = baseUrl.replace(/\\/$/, '') + endpoint.path;
+
+    // Body
+    document.getElementById('bodyInput').value = endpoint.bodyExample ?? '';
+
+    // Params
+    const qEl = document.getElementById('queryParams');
+    const pEl = document.getElementById('pathParams');
+    qEl.innerHTML = '';
+    pEl.innerHTML = '';
+
+    const pathParams = (endpoint.params ?? []).filter(p => p.in === 'path');
+    const queryParams = (endpoint.params ?? []).filter(p => p.in === 'query');
+
+    if (pathParams.length) {
+      pEl.innerHTML = '<div class="section-label">Path parameters</div>';
+      pathParams.forEach(p => pEl.appendChild(paramRow(p, 'path-param-input')));
+    }
+    if (queryParams.length) {
+      qEl.innerHTML = '<div class="section-label">Query parameters</div>';
+      queryParams.forEach(p => qEl.appendChild(paramRow(p, 'query-param-input')));
+    }
+    if (!pathParams.length && !queryParams.length) {
+      qEl.innerHTML = '<p style="opacity:0.5;font-size:12px;padding:10px 0">No parameters.</p>';
+    }
+
+    // Headers
+    document.getElementById('headerRows').innerHTML = '';
+    if (endpoint.auth === 'api-key') {
+      addHeaderRow('x-api-key', apiKey);
+    } else if (endpoint.auth === 'admin-key') {
+      addHeaderRow('x-api-key', adminApiKey);
+    }
+
+    // Reset response pane
+    hideResponse();
+  }
+
+  function paramRow(param, cls) {
+    const div = document.createElement('div');
+    div.className = 'param-row';
+    const star = param.required ? '<span class="required-star">*</span>' : '';
+    div.innerHTML =
+      '<span class="param-name">' + esc(param.name) + star + '</span>' +
+      '<input class="param-input ' + cls + '" data-name="' + esc(param.name) + '"' +
+      ' placeholder="' + esc(param.example ?? '') + '">';
+    return div;
+  }
+
+  function showLoading() {
+    document.getElementById('emptyState').style.display = 'none';
+    document.getElementById('errorState').style.display = 'none';
+    document.getElementById('responseToolbar').style.display = 'none';
+    document.getElementById('responseTabs').style.display = 'none';
+    document.getElementById('loadingState').style.display = 'block';
+    document.getElementById('rtab-body').classList.remove('active');
+    document.getElementById('rtab-headers').classList.remove('active');
+  }
+
+  function showResponse(data) {
+    document.getElementById('loadingState').style.display = 'none';
+    document.getElementById('errorState').style.display = 'none';
+    document.getElementById('emptyState').style.display = 'none';
+    document.getElementById('responseToolbar').style.display = 'flex';
+    document.getElementById('responseTabs').style.display = 'flex';
+    document.getElementById('rtab-body').classList.add('active');
+
+    // Status badge
+    const badge = document.getElementById('statusBadge');
+    const cls = data.status < 300 ? '2xx' : data.status < 400 ? '3xx' : data.status < 500 ? '4xx' : '5xx';
+    badge.className = 'status-badge status-' + cls;
+    badge.textContent = data.status + ' ' + data.statusText;
+
+    document.getElementById('durationBadge').textContent = data.durationMs + ' ms';
+
+    // Body — pretty-print JSON
+    let body = data.body;
+    try { body = JSON.stringify(JSON.parse(body), null, 2); } catch {}
+    document.getElementById('responseBody').textContent = body;
+
+    // Headers
+    const tbl = document.getElementById('responseHeaders');
+    tbl.innerHTML = '';
+    Object.entries(data.headers).forEach(([k, v]) => {
+      const tr = document.createElement('tr');
+      tr.innerHTML = '<td>' + esc(k) + '</td><td>' + esc(String(v)) + '</td>';
+      tbl.appendChild(tr);
+    });
+  }
+
+  function showError(msg) {
+    document.getElementById('loadingState').style.display = 'none';
+    document.getElementById('emptyState').style.display = 'none';
+    document.getElementById('errorState').style.display = 'block';
+    document.getElementById('responseToolbar').style.display = 'none';
+    document.getElementById('responseTabs').style.display = 'none';
+    document.getElementById('errorMsg').textContent = msg;
+  }
+
+  function hideResponse() {
+    document.getElementById('loadingState').style.display = 'none';
+    document.getElementById('errorState').style.display = 'none';
+    document.getElementById('responseToolbar').style.display = 'none';
+    document.getElementById('responseTabs').style.display = 'none';
+    document.getElementById('emptyState').style.display = 'block';
+    document.getElementById('rtab-body').classList.remove('active');
+    document.getElementById('rtab-headers').classList.remove('active');
+  }
+
+  function esc(str) {
+    return String(str)
+      .replace(/&/g, '&amp;').replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;').replace(/"/g, '&quot;');
+  }
+`;

--- a/vscode-extension/src/types.ts
+++ b/vscode-extension/src/types.ts
@@ -1,0 +1,52 @@
+export type HttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH';
+export type AuthType = 'none' | 'api-key' | 'admin-key';
+
+export interface EndpointParam {
+    name: string;
+    in: 'path' | 'query' | 'header';
+    required: boolean;
+    description?: string;
+    example?: string;
+}
+
+export interface ApiEndpoint {
+    method: HttpMethod;
+    path: string;
+    description: string;
+    auth: AuthType;
+    params?: EndpointParam[];
+    bodyExample?: string;
+    streaming?: boolean;
+    deprecated?: boolean;
+}
+
+export interface EndpointGroup {
+    label: string;
+    endpoints: ApiEndpoint[];
+}
+
+export interface RequestConfig {
+    method: HttpMethod;
+    url: string;
+    headers: Record<string, string>;
+    body?: string;
+}
+
+export interface ResponseData {
+    status: number;
+    statusText: string;
+    headers: Record<string, string>;
+    body: string;
+    durationMs: number;
+    error?: string;
+}
+
+export type WebviewMessage =
+    | { type: 'sendRequest'; config: RequestConfig }
+    | { type: 'copyToClipboard'; text: string }
+    | { type: 'openSettings' };
+
+export type ExtensionMessage =
+    | { type: 'response'; data: ResponseData }
+    | { type: 'loading' }
+    | { type: 'error'; message: string };

--- a/vscode-extension/tsconfig.json
+++ b/vscode-extension/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "ES2020",
+    "lib": ["ES2020"],
+    "outDir": "./out",
+    "rootDir": "./src",
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["src"],
+  "exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
## Summary

Adds a VS Code extension that lets developers browse all Soroban Pulse API endpoints, send test requests, and inspect responses without leaving the editor.

## Related Issue

Closes #596

## Changes

- Added `vscode-extension/src/apiData.ts` — all ~50 endpoints defined as structured data across 7 groups
- Added `vscode-extension/src/apiExplorer.ts` — sidebar tree view with colour-coded method badges and live text filter
- Added `vscode-extension/src/requestTester.ts` — webview panel with request form, built-in HTTP client, and response viewer
- Added `vscode-extension/src/extension.ts` — activation entry point wiring commands and the tree view
- Added `vscode-extension/package.json` — extension manifest with settings for base URL, API key, and admin key

## Testing

- [ ] `cargo test` passes
- [ ] `cargo clippy` reports no warnings
- [ ] Manually tested locally

## Notes

No external npm dependencies — HTTP requests use Node's built-in `http`/`https` modules. The webview is CSP-safe (nonce on all inline scripts and styles) and uses VS Code theme variables so it adapts to any light or dark theme.
