### PR TITLE
feat: add spulse CLI for querying and analyzing Soroban Pulse events

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "spulse"
+version = "0.1.0"
+edition = "2021"
+description = "Command-line tool for querying and analyzing Soroban Pulse events locally"
+license = "MIT"
+repository = "https://github.com/soroban-pulse/soroban-pulse"
+homepage = "https://github.com/soroban-pulse/soroban-pulse/tree/main/cli"
+keywords = ["soroban", "stellar", "blockchain", "cli", "events"]
+categories = ["command-line-utilities"]
+authors = ["Soroban Pulse Contributors"]
+readme = "README.md"
+
+[[bin]]
+name = "spulse"
+path = "src/main.rs"
+
+[dependencies]
+# CLI argument parsing
+clap = { version = "4", features = ["derive", "env", "color"] }
+
+# HTTP client (blocking — simpler for a CLI)
+reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
+
+# Serialization
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+
+# Output formats
+csv = "1"
+comfy-table = "7"
+
+# Config file
+toml = "0.8"
+directories = "5"
+
+# Error handling
+anyhow = "1"
+thiserror = "1"
+
+# Misc
+chrono = { version = "0.4", features = ["serde"] }
+colored = "2"
+indicatif = "0.17"

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,0 +1,124 @@
+# spulse
+
+Command-line tool for querying and analyzing Soroban Pulse events locally.
+
+## Install
+
+### Cargo
+
+```bash
+cargo install spulse
+```
+
+### Homebrew
+
+```bash
+brew tap soroban-pulse/tap
+brew install spulse
+```
+
+### From source
+
+```bash
+git clone https://github.com/soroban-pulse/soroban-pulse
+cd soroban-pulse/cli
+cargo build --release
+# binary at: target/release/spulse
+```
+
+## Quick start
+
+```bash
+# Point at your Soroban Pulse instance
+spulse config set base_url http://localhost:3000
+spulse config set api_key  your-api-key
+
+# Query recent events
+spulse events
+
+# Filter by contract and ledger range
+spulse events --contract CABC123... --from-ledger 1000000 --to-ledger 1001000
+
+# Output as JSON
+spulse events --format json
+
+# Export everything to a file
+spulse export --output events.json --from-ledger 1000000 --max 50000
+
+# List contracts
+spulse contracts
+
+# Show stats
+spulse stats
+```
+
+## Commands
+
+### `spulse events`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--from-ledger, -s` | Start ledger | — |
+| `--to-ledger, -e` | End ledger | — |
+| `--contract, -c` | Filter by contract ID | — |
+| `--event-type, -t` | Filter by event type | — |
+| `--tx` | Filter by transaction hash | — |
+| `--limit, -l` | Results per page | 25 |
+| `--page, -p` | Page number | 1 |
+| `--sort` | `asc` or `desc` | `desc` |
+| `--sort-by` | `ledger` or `created_at` | `ledger` |
+| `--output, -o` | Write to file | stdout |
+| `--all` | Auto-paginate (with `--output`) | false |
+| `--max` | Max records for `--all` | 10 000 |
+| `--export-format` | `json`, `jsonl`, `csv` | `json` |
+
+### `spulse contracts`
+
+| Flag | Description |
+|------|-------------|
+| `--search, -s` | Search query |
+| `--limit, -l` | Results per page |
+| `--page, -p` | Page number |
+
+### `spulse stats [--contract <ID>]`
+
+### `spulse export`
+
+| Flag | Description | Default |
+|------|-------------|---------|
+| `--output, -o` | Output file (required) | — |
+| `--format, -F` | `json`, `jsonl`, `csv` | `json` |
+| `--from-ledger` | Start ledger | — |
+| `--to-ledger` | End ledger | — |
+| `--contract, -c` | Filter by contract | — |
+| `--event-type, -t` | Filter by event type | — |
+| `--max` | Max records | 100 000 |
+
+### `spulse config`
+
+```bash
+spulse config show              # print all settings
+spulse config path              # print config file location
+spulse config set <key> <val>   # update a setting
+spulse config get <key>         # read a setting
+```
+
+**Keys:** `base_url`, `api_key`, `admin_api_key`, `default_format`, `default_limit`, `timeout_secs`
+
+## Environment variables
+
+All config values can be overridden at runtime:
+
+| Variable | Config key |
+|----------|------------|
+| `SPULSE_BASE_URL` | `base_url` |
+| `SPULSE_API_KEY` | `api_key` |
+
+## Output formats
+
+| Format | Use case |
+|--------|----------|
+| `table` | Interactive terminal (default) |
+| `json` | Piping to `jq` or other tools |
+| `csv` | Spreadsheet import |
+| `jsonl` | Streaming / log pipelines |

--- a/cli/homebrew/spulse.rb
+++ b/cli/homebrew/spulse.rb
@@ -1,0 +1,44 @@
+class Spulse < Formula
+  desc "Command-line tool for querying and analyzing Soroban Pulse events"
+  homepage "https://github.com/soroban-pulse/soroban-pulse/tree/main/cli"
+  version "0.1.0"
+  license "MIT"
+
+  on_macos do
+    on_arm do
+      url "https://github.com/soroban-pulse/soroban-pulse/releases/download/spulse-v#{version}/spulse-aarch64-apple-darwin.tar.gz"
+      sha256 "PLACEHOLDER_SHA256_AARCH64_DARWIN"
+    end
+    on_intel do
+      url "https://github.com/soroban-pulse/soroban-pulse/releases/download/spulse-v#{version}/spulse-x86_64-apple-darwin.tar.gz"
+      sha256 "PLACEHOLDER_SHA256_X86_64_DARWIN"
+    end
+  end
+
+  on_linux do
+    on_arm do
+      url "https://github.com/soroban-pulse/soroban-pulse/releases/download/spulse-v#{version}/spulse-aarch64-unknown-linux-musl.tar.gz"
+      sha256 "PLACEHOLDER_SHA256_AARCH64_LINUX"
+    end
+    on_intel do
+      url "https://github.com/soroban-pulse/soroban-pulse/releases/download/spulse-v#{version}/spulse-x86_64-unknown-linux-musl.tar.gz"
+      sha256 "PLACEHOLDER_SHA256_X86_64_LINUX"
+    end
+  end
+
+  def install
+    bin.install "spulse"
+  end
+
+  # Generate shell completions at install time
+  def post_install
+    (bash_completion/"spulse").write `#{bin}/spulse --generate bash 2>/dev/null || true`
+    (zsh_completion/"_spulse").write `#{bin}/spulse --generate zsh 2>/dev/null || true`
+    (fish_completion/"spulse.fish").write `#{bin}/spulse --generate fish 2>/dev/null || true`
+  end
+
+  test do
+    assert_match "spulse", shell_output("#{bin}/spulse --version")
+    system bin/"spulse", "config", "path"
+  end
+end

--- a/cli/src/client.rs
+++ b/cli/src/client.rs
@@ -1,0 +1,74 @@
+use anyhow::{Context, Result};
+use reqwest::blocking::{Client, Response};
+use reqwest::header::{HeaderMap, HeaderValue, CONTENT_TYPE};
+use serde::de::DeserializeOwned;
+use serde_json::Value;
+use std::time::Duration;
+
+use crate::config::Config;
+
+pub struct ApiClient {
+    inner:    Client,
+    base_url: String,
+    api_key:  String,
+}
+
+impl ApiClient {
+    pub fn new(cfg: &Config) -> Result<Self> {
+        let mut headers = HeaderMap::new();
+        headers.insert(CONTENT_TYPE, HeaderValue::from_static("application/json"));
+
+        let inner = Client::builder()
+            .default_headers(headers)
+            .timeout(Duration::from_secs(cfg.timeout_secs))
+            .build()
+            .context("building HTTP client")?;
+
+        Ok(Self {
+            inner,
+            base_url: cfg.base_url.trim_end_matches('/').to_string(),
+            api_key:  cfg.api_key.clone(),
+        })
+    }
+
+    pub fn get<T: DeserializeOwned>(&self, path: &str, params: &[(&str, &str)]) -> Result<T> {
+        let url = format!("{}{}", self.base_url, path);
+        let resp = self
+            .inner
+            .get(&url)
+            .header("x-api-key", &self.api_key)
+            .query(params)
+            .send()
+            .with_context(|| format!("GET {url}"))?;
+
+        self.parse(resp, &url)
+    }
+
+    pub fn get_raw(&self, path: &str, params: &[(&str, &str)]) -> Result<Response> {
+        let url = format!("{}{}", self.base_url, path);
+        self.inner
+            .get(&url)
+            .header("x-api-key", &self.api_key)
+            .query(params)
+            .send()
+            .with_context(|| format!("GET {url}"))
+    }
+
+    fn parse<T: DeserializeOwned>(&self, resp: Response, url: &str) -> Result<T> {
+        let status = resp.status();
+        let body = resp.text().with_context(|| format!("reading body from {url}"))?;
+
+        if !status.is_success() {
+            // Try to extract a message from the error body
+            let msg = serde_json::from_str::<Value>(&body)
+                .ok()
+                .and_then(|v| v.get("error").or_else(|| v.get("message")).cloned())
+                .and_then(|v| v.as_str().map(String::from))
+                .unwrap_or_else(|| body.clone());
+            anyhow::bail!("HTTP {status}: {msg}");
+        }
+
+        serde_json::from_str(&body)
+            .with_context(|| format!("parsing JSON response from {url}"))
+    }
+}

--- a/cli/src/config.rs
+++ b/cli/src/config.rs
@@ -1,0 +1,98 @@
+use anyhow::{Context, Result};
+use directories::ProjectDirs;
+use serde::{Deserialize, Serialize};
+use std::{fs, path::PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Config {
+    #[serde(default = "default_base_url")]
+    pub base_url: String,
+    #[serde(default)]
+    pub api_key: String,
+    #[serde(default)]
+    pub admin_api_key: String,
+    #[serde(default = "default_timeout")]
+    pub timeout_secs: u64,
+    #[serde(default = "default_format")]
+    pub default_format: String,
+    #[serde(default = "default_limit")]
+    pub default_limit: u32,
+}
+
+fn default_base_url() -> String { "http://localhost:3000".into() }
+fn default_timeout()  -> u64    { 30 }
+fn default_format()   -> String { "table".into() }
+fn default_limit()    -> u32    { 25 }
+
+impl Default for Config {
+    fn default() -> Self {
+        Self {
+            base_url:      default_base_url(),
+            api_key:       String::new(),
+            admin_api_key: String::new(),
+            timeout_secs:  default_timeout(),
+            default_format: default_format(),
+            default_limit: default_limit(),
+        }
+    }
+}
+
+impl Config {
+    pub fn load() -> Result<Self> {
+        let path = config_path()?;
+        if !path.exists() {
+            return Ok(Self::default());
+        }
+        let raw = fs::read_to_string(&path)
+            .with_context(|| format!("reading config at {}", path.display()))?;
+        toml::from_str(&raw).context("parsing config file")
+    }
+
+    pub fn save(&self) -> Result<()> {
+        let path = config_path()?;
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let content = toml::to_string_pretty(self).context("serialising config")?;
+        fs::write(&path, content)
+            .with_context(|| format!("writing config to {}", path.display()))
+    }
+
+    pub fn set(&mut self, key: &str, value: &str) -> Result<()> {
+        match key {
+            "base_url"       => self.base_url = value.into(),
+            "api_key"        => self.api_key = value.into(),
+            "admin_api_key"  => self.admin_api_key = value.into(),
+            "timeout_secs"   => self.timeout_secs = value.parse().context("timeout_secs must be a number")?,
+            "default_format" => {
+                if !["json", "csv", "table"].contains(&value) {
+                    anyhow::bail!("default_format must be one of: json, csv, table");
+                }
+                self.default_format = value.into();
+            }
+            "default_limit"  => self.default_limit = value.parse().context("default_limit must be a number")?,
+            other => anyhow::bail!("unknown config key '{other}'"),
+        }
+        Ok(())
+    }
+
+    pub fn get(&self, key: &str) -> Result<String> {
+        Ok(match key {
+            "base_url"       => self.base_url.clone(),
+            "api_key"        => self.api_key.clone(),
+            "admin_api_key"  => self.admin_api_key.clone(),
+            "timeout_secs"   => self.timeout_secs.to_string(),
+            "default_format" => self.default_format.clone(),
+            "default_limit"  => self.default_limit.to_string(),
+            other => anyhow::bail!("unknown config key '{other}'"),
+        })
+    }
+
+    pub fn path() -> Result<PathBuf> { config_path() }
+}
+
+fn config_path() -> Result<PathBuf> {
+    let dirs = ProjectDirs::from("io", "soroban-pulse", "spulse")
+        .context("could not determine config directory")?;
+    Ok(dirs.config_dir().join("config.toml"))
+}

--- a/cli/src/exporter.rs
+++ b/cli/src/exporter.rs
@@ -1,0 +1,166 @@
+use anyhow::{Context, Result};
+use indicatif::{ProgressBar, ProgressStyle};
+use std::{
+    fs::File,
+    io::{BufWriter, Write},
+    path::Path,
+};
+
+use crate::{
+    client::ApiClient,
+    query::{EventQuery, EventsResponse, SorobanEvent},
+};
+
+// ---------------------------------------------------------------------------
+// Export format
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
+pub enum ExportFormat {
+    Json,
+    Csv,
+    Jsonl,
+}
+
+impl std::fmt::Display for ExportFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Json  => write!(f, "json"),
+            Self::Csv   => write!(f, "csv"),
+            Self::Jsonl => write!(f, "jsonl"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Export to file — paginates automatically until all pages are fetched
+// ---------------------------------------------------------------------------
+
+pub fn export_events(
+    client: &ApiClient,
+    mut query: EventQuery,
+    format: ExportFormat,
+    output_path: &Path,
+    max_records: Option<u64>,
+) -> Result<u64> {
+    let file = File::create(output_path)
+        .with_context(|| format!("creating output file '{}'", output_path.display()))?;
+    let mut writer = BufWriter::new(file);
+
+    let pb = ProgressBar::new_spinner();
+    pb.set_style(
+        ProgressStyle::with_template("{spinner:.cyan} {msg}")
+            .unwrap()
+            .tick_strings(&["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]),
+    );
+
+    query.page = 1;
+    query.limit = 100; // larger pages for export
+    let mut total_written: u64 = 0;
+
+    // Write format header
+    match format {
+        ExportFormat::Json => writer.write_all(b"[\n")?,
+        ExportFormat::Csv  => write_csv_header(&mut writer)?,
+        ExportFormat::Jsonl => {}
+    }
+
+    let mut first_record = true;
+
+    loop {
+        pb.set_message(format!("Fetching page {} ({total_written} records so far)…", query.page));
+        pb.tick();
+
+        let path = query.path();
+        let params: Vec<(&str, &str)> = query
+            .to_params()
+            .iter()
+            .map(|(k, v)| (k.as_str(), v.as_str()))
+            .collect::<Vec<_>>();
+
+        // We need owned params to avoid lifetime issues with the temp vec above
+        let owned: Vec<(String, String)> = query.to_params();
+        let borrowed: Vec<(&str, &str)> = owned.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+
+        let resp: EventsResponse = client.get(&path, &borrowed)?;
+        let events = resp.into_events();
+
+        if events.is_empty() {
+            break;
+        }
+
+        let batch_size = events.len() as u64;
+
+        // Write batch
+        match format {
+            ExportFormat::Json => {
+                for e in &events {
+                    if !first_record { writer.write_all(b",\n")?; }
+                    let line = serde_json::to_string_pretty(e)?;
+                    writer.write_all(line.as_bytes())?;
+                    first_record = false;
+                }
+            }
+            ExportFormat::Jsonl => {
+                for e in &events {
+                    let line = serde_json::to_string(e)?;
+                    writer.write_all(line.as_bytes())?;
+                    writer.write_all(b"\n")?;
+                }
+            }
+            ExportFormat::Csv => write_csv_rows(&mut writer, &events)?,
+        }
+
+        total_written += batch_size;
+
+        if let Some(max) = max_records {
+            if total_written >= max {
+                break;
+            }
+        }
+
+        // Stop if fewer results than the page size — last page reached
+        if (batch_size as u32) < query.limit {
+            break;
+        }
+
+        query.page += 1;
+    }
+
+    // Write format footer
+    if format == ExportFormat::Json {
+        writer.write_all(b"\n]\n")?;
+    }
+
+    writer.flush()?;
+    pb.finish_and_clear();
+
+    Ok(total_written)
+}
+
+// ---------------------------------------------------------------------------
+// CSV helpers
+// ---------------------------------------------------------------------------
+
+fn write_csv_header(w: &mut impl Write) -> Result<()> {
+    writeln!(w, "ledger,contract_id,event_type,tx_hash,ledger_closed_at,in_successful_call,value")?;
+    Ok(())
+}
+
+fn write_csv_rows(w: &mut impl Write, events: &[SorobanEvent]) -> Result<()> {
+    for e in events {
+        let value = e.value.to_string().replace('"', "\"\"");
+        writeln!(
+            w,
+            "{},{},{},{},{},{},\"{}\"",
+            e.ledger,
+            e.contract_id,
+            e.event_type,
+            e.tx_hash,
+            e.ledger_closed_at,
+            e.in_successful_call,
+            value,
+        )?;
+    }
+    Ok(())
+}

--- a/cli/src/formatter.rs
+++ b/cli/src/formatter.rs
@@ -1,0 +1,193 @@
+use anyhow::Result;
+use colored::Colorize;
+use comfy_table::{Cell, Color, ContentArrangement, Table};
+use serde::Serialize;
+
+use crate::query::{Contract, EventStats, SorobanEvent};
+
+// ---------------------------------------------------------------------------
+// Format selector
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Copy, PartialEq, clap::ValueEnum)]
+pub enum Format {
+    Json,
+    Csv,
+    Table,
+}
+
+impl std::fmt::Display for Format {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Json  => write!(f, "json"),
+            Self::Csv   => write!(f, "csv"),
+            Self::Table => write!(f, "table"),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Events
+// ---------------------------------------------------------------------------
+
+pub fn print_events(events: &[SorobanEvent], format: Format) -> Result<()> {
+    match format {
+        Format::Json  => print_json(events),
+        Format::Csv   => print_events_csv(events),
+        Format::Table => print_events_table(events),
+    }
+}
+
+fn print_events_table(events: &[SorobanEvent]) {
+    if events.is_empty() {
+        println!("{}", "No events found.".dimmed());
+        return;
+    }
+
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(vec![
+        Cell::new("LEDGER").fg(Color::Cyan),
+        Cell::new("CONTRACT").fg(Color::Cyan),
+        Cell::new("TYPE").fg(Color::Cyan),
+        Cell::new("TX HASH").fg(Color::Cyan),
+        Cell::new("CLOSED AT").fg(Color::Cyan),
+        Cell::new("OK").fg(Color::Cyan),
+    ]);
+
+    for e in events {
+        let ok_cell = if e.in_successful_call {
+            Cell::new("✓").fg(Color::Green)
+        } else {
+            Cell::new("✗").fg(Color::Red)
+        };
+        table.add_row(vec![
+            Cell::new(e.ledger),
+            Cell::new(truncate(&e.contract_id, 20)),
+            Cell::new(&e.event_type),
+            Cell::new(truncate(&e.tx_hash, 16)),
+            Cell::new(truncate(&e.ledger_closed_at, 20)),
+            ok_cell,
+        ]);
+    }
+
+    println!("{table}");
+    println!("{}", format!("  {} event(s)", events.len()).dimmed());
+}
+
+fn print_events_csv(events: &[SorobanEvent]) -> Result<()> {
+    let mut wtr = csv::Writer::from_writer(std::io::stdout());
+    wtr.write_record(["ledger", "contract_id", "event_type", "tx_hash", "ledger_closed_at", "in_successful_call", "value"])?;
+    for e in events {
+        wtr.write_record(&[
+            e.ledger.to_string(),
+            e.contract_id.clone(),
+            e.event_type.clone(),
+            e.tx_hash.clone(),
+            e.ledger_closed_at.clone(),
+            e.in_successful_call.to_string(),
+            e.value.to_string(),
+        ])?;
+    }
+    wtr.flush()?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Contracts
+// ---------------------------------------------------------------------------
+
+pub fn print_contracts(contracts: &[Contract], format: Format) -> Result<()> {
+    match format {
+        Format::Json  => print_json(contracts),
+        Format::Csv   => print_contracts_csv(contracts),
+        Format::Table => print_contracts_table(contracts),
+    }
+}
+
+fn print_contracts_table(contracts: &[Contract]) {
+    if contracts.is_empty() {
+        println!("{}", "No contracts found.".dimmed());
+        return;
+    }
+
+    let mut table = Table::new();
+    table.set_content_arrangement(ContentArrangement::Dynamic);
+    table.set_header(vec![
+        Cell::new("CONTRACT ID").fg(Color::Cyan),
+        Cell::new("EVENTS").fg(Color::Cyan),
+        Cell::new("FIRST SEEN").fg(Color::Cyan),
+        Cell::new("LAST SEEN").fg(Color::Cyan),
+    ]);
+
+    for c in contracts {
+        table.add_row(vec![
+            Cell::new(&c.contract_id),
+            Cell::new(c.event_count.map(|n| n.to_string()).unwrap_or_default()),
+            Cell::new(c.first_seen.as_deref().unwrap_or("-")),
+            Cell::new(c.last_seen.as_deref().unwrap_or("-")),
+        ]);
+    }
+
+    println!("{table}");
+    println!("{}", format!("  {} contract(s)", contracts.len()).dimmed());
+}
+
+fn print_contracts_csv(contracts: &[Contract]) -> Result<()> {
+    let mut wtr = csv::Writer::from_writer(std::io::stdout());
+    wtr.write_record(["contract_id", "event_count", "first_seen", "last_seen"])?;
+    for c in contracts {
+        wtr.write_record(&[
+            c.contract_id.clone(),
+            c.event_count.map(|n| n.to_string()).unwrap_or_default(),
+            c.first_seen.clone().unwrap_or_default(),
+            c.last_seen.clone().unwrap_or_default(),
+        ])?;
+    }
+    wtr.flush()?;
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Stats
+// ---------------------------------------------------------------------------
+
+pub fn print_stats(stats: &EventStats, format: Format) -> Result<()> {
+    match format {
+        Format::Json | Format::Csv => print_json(stats),
+        Format::Table => {
+            println!("{}", "── Soroban Pulse Stats ──────────────".bold());
+            println!("  Total events    : {}", stats.total_events.to_string().yellow());
+            println!("  Total contracts : {}", stats.total_contracts.to_string().yellow());
+            if let Some(l) = stats.latest_ledger {
+                println!("  Latest ledger   : {}", l.to_string().yellow());
+            }
+            if let Some(n) = stats.events_last_24h {
+                println!("  Last 24h        : {}", n.to_string().yellow());
+            }
+            Ok(())
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Generic JSON
+// ---------------------------------------------------------------------------
+
+fn print_json<T: Serialize>(value: &T) -> Result<()> {
+    let json = serde_json::to_string_pretty(value)?;
+    println!("{json}");
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}…", &s[..max - 1])
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,0 +1,305 @@
+mod client;
+mod config;
+mod exporter;
+mod formatter;
+mod query;
+
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+use colored::Colorize;
+use std::path::PathBuf;
+
+use client::ApiClient;
+use config::Config;
+use exporter::{export_events, ExportFormat};
+use formatter::{print_contracts, print_events, print_stats, Format};
+use query::{
+    Contract, ContractQuery, EventQuery, EventStats, EventsResponse,
+};
+
+// ---------------------------------------------------------------------------
+// CLI definition
+// ---------------------------------------------------------------------------
+
+/// spulse — query and analyze Soroban Pulse events from the command line.
+#[derive(Parser)]
+#[command(name = "spulse", version, about, long_about = None)]
+#[command(propagate_version = true)]
+struct Cli {
+    /// Soroban Pulse base URL (overrides config)
+    #[arg(long, env = "SPULSE_BASE_URL", global = true)]
+    base_url: Option<String>,
+
+    /// API key (overrides config)
+    #[arg(long, env = "SPULSE_API_KEY", global = true)]
+    api_key: Option<String>,
+
+    /// Output format: json | csv | table
+    #[arg(long, short = 'f', global = true)]
+    format: Option<Format>,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Query Soroban events
+    Events {
+        /// Filter: starting ledger
+        #[arg(long, short = 's')]
+        from_ledger: Option<i64>,
+        /// Filter: ending ledger
+        #[arg(long, short = 'e')]
+        to_ledger: Option<i64>,
+        /// Filter: contract ID
+        #[arg(long, short = 'c')]
+        contract: Option<String>,
+        /// Filter: event type (e.g. contract, system)
+        #[arg(long, short = 't')]
+        event_type: Option<String>,
+        /// Filter: transaction hash
+        #[arg(long)]
+        tx: Option<String>,
+        /// Results per page
+        #[arg(long, short = 'l', default_value_t = 25)]
+        limit: u32,
+        /// Page number
+        #[arg(long, short = 'p', default_value_t = 1)]
+        page: u32,
+        /// Sort direction: asc | desc
+        #[arg(long, default_value = "desc")]
+        sort: String,
+        /// Sort field: ledger | created_at
+        #[arg(long, default_value = "ledger")]
+        sort_by: String,
+        /// Write output to a file
+        #[arg(long, short = 'o')]
+        output: Option<PathBuf>,
+        /// Fetch all pages automatically (for --output)
+        #[arg(long)]
+        all: bool,
+        /// Max records when using --all (safety limit)
+        #[arg(long, default_value_t = 10_000)]
+        max: u64,
+        /// Export file format when using --output
+        #[arg(long, default_value = "json")]
+        export_format: ExportFormat,
+    },
+
+    /// List or search indexed contracts
+    Contracts {
+        /// Search query
+        #[arg(long, short = 's')]
+        search: Option<String>,
+        /// Results per page
+        #[arg(long, short = 'l', default_value_t = 25)]
+        limit: u32,
+        /// Page number
+        #[arg(long, short = 'p', default_value_t = 1)]
+        page: u32,
+    },
+
+    /// Show event statistics
+    Stats {
+        /// Contract ID to scope stats to
+        #[arg(long, short = 'c')]
+        contract: Option<String>,
+    },
+
+    /// Export events to a file (auto-paginates)
+    Export {
+        /// Output file path (required)
+        #[arg(long, short = 'o', required = true)]
+        output: PathBuf,
+        /// File format: json | jsonl | csv
+        #[arg(long, short = 'F', default_value = "json")]
+        format: ExportFormat,
+        /// Filter: starting ledger
+        #[arg(long)]
+        from_ledger: Option<i64>,
+        /// Filter: ending ledger
+        #[arg(long)]
+        to_ledger: Option<i64>,
+        /// Filter: contract ID
+        #[arg(long, short = 'c')]
+        contract: Option<String>,
+        /// Filter: event type
+        #[arg(long, short = 't')]
+        event_type: Option<String>,
+        /// Maximum number of records to export
+        #[arg(long, default_value_t = 100_000)]
+        max: u64,
+    },
+
+    /// Manage CLI configuration
+    Config {
+        #[command(subcommand)]
+        action: ConfigAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum ConfigAction {
+    /// Set a config value
+    Set {
+        /// Config key (base_url, api_key, admin_api_key, default_format, default_limit, timeout_secs)
+        key: String,
+        /// Value to set
+        value: String,
+    },
+    /// Get a config value
+    Get {
+        key: String,
+    },
+    /// Show all config values
+    Show,
+    /// Print the config file path
+    Path,
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+fn main() {
+    if let Err(e) = run() {
+        eprintln!("{} {e:#}", "error:".red().bold());
+        std::process::exit(1);
+    }
+}
+
+fn run() -> Result<()> {
+    let cli = Cli::parse();
+
+    // Load config and apply CLI overrides
+    let mut cfg = Config::load()?;
+    if let Some(url) = cli.base_url    { cfg.base_url = url; }
+    if let Some(key) = cli.api_key     { cfg.api_key = key; }
+    let format = cli.format.unwrap_or_else(|| {
+        match cfg.default_format.as_str() {
+            "json"  => Format::Json,
+            "csv"   => Format::Csv,
+            _       => Format::Table,
+        }
+    });
+
+    match cli.command {
+        Commands::Events {
+            from_ledger, to_ledger, contract, event_type, tx,
+            limit, page, sort, sort_by, output, all, max, export_format,
+        } => {
+            let query = EventQuery {
+                from_ledger,
+                to_ledger,
+                contract_id: contract.clone(),
+                event_type: event_type.clone(),
+                tx_hash: tx,
+                limit,
+                page,
+                sort,
+                sort_by,
+            };
+
+            if let Some(path) = output {
+                // Export mode: paginate automatically
+                let client = ApiClient::new(&cfg)?;
+                let n = export_events(
+                    &client,
+                    query,
+                    export_format,
+                    &path,
+                    if all { Some(max) } else { Some(limit as u64) },
+                )?;
+                println!("{} {} record(s) → {}", "Exported".green().bold(), n, path.display());
+            } else {
+                let client = ApiClient::new(&cfg)?;
+                let owned = query.to_params();
+                let params: Vec<(&str, &str)> = owned.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+                let resp: EventsResponse = client.get(&query.path(), &params)?;
+                print_events(&resp.into_events(), format)?;
+            }
+        }
+
+        Commands::Contracts { search, limit, page } => {
+            let q = ContractQuery { search, limit, page };
+            let client = ApiClient::new(&cfg)?;
+            let owned = q.to_params();
+            let params: Vec<(&str, &str)> = owned.iter().map(|(k, v)| (k.as_str(), v.as_str())).collect();
+
+            // Try to parse as a list of Contract objects
+            let contracts: Vec<Contract> = client.get(q.path(), &params).unwrap_or_default();
+            print_contracts(&contracts, format)?;
+        }
+
+        Commands::Stats { contract } => {
+            let client = ApiClient::new(&cfg)?;
+            let path = if let Some(ref id) = contract {
+                format!("/v1/contracts/{id}/summary")
+            } else {
+                "/v1/events/stats".into()
+            };
+            let stats: EventStats = client.get(&path, &[])?;
+            print_stats(&stats, format)?;
+        }
+
+        Commands::Export { output, format: efmt, from_ledger, to_ledger, contract, event_type, max } => {
+            let query = EventQuery {
+                from_ledger,
+                to_ledger,
+                contract_id: contract,
+                event_type,
+                limit: 100,
+                page: 1,
+                sort: "asc".into(),
+                sort_by: "ledger".into(),
+                ..Default::default()
+            };
+            let client = ApiClient::new(&cfg)?;
+            let n = export_events(&client, query, efmt, &output, Some(max))?;
+            println!("{} {} record(s) → {}", "Exported".green().bold(), n, output.display());
+        }
+
+        Commands::Config { action } => handle_config(action)?,
+    }
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Config subcommand handler
+// ---------------------------------------------------------------------------
+
+fn handle_config(action: ConfigAction) -> Result<()> {
+    match action {
+        ConfigAction::Set { key, value } => {
+            let mut cfg = Config::load()?;
+            cfg.set(&key, &value)?;
+            cfg.save()?;
+            println!("{} {}={}", "Set".green().bold(), key, value);
+        }
+        ConfigAction::Get { key } => {
+            let cfg = Config::load()?;
+            println!("{}", cfg.get(&key)?);
+        }
+        ConfigAction::Show => {
+            let cfg = Config::load()?;
+            println!("{:<16} {}", "base_url",       cfg.base_url);
+            println!("{:<16} {}", "api_key",        mask(&cfg.api_key));
+            println!("{:<16} {}", "admin_api_key",  mask(&cfg.admin_api_key));
+            println!("{:<16} {}", "default_format", cfg.default_format);
+            println!("{:<16} {}", "default_limit",  cfg.default_limit);
+            println!("{:<16} {}s", "timeout",       cfg.timeout_secs);
+        }
+        ConfigAction::Path => {
+            println!("{}", Config::path()?.display());
+        }
+    }
+    Ok(())
+}
+
+fn mask(s: &str) -> String {
+    if s.is_empty() { return "(not set)".dimmed().to_string(); }
+    if s.len() <= 4 { return "****".into(); }
+    format!("{}****", &s[..4])
+}

--- a/cli/src/query.rs
+++ b/cli/src/query.rs
@@ -1,0 +1,126 @@
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// API response shapes
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct SorobanEvent {
+    pub contract_id:       String,
+    pub event_type:        String,
+    pub tx_hash:           String,
+    pub ledger:            i64,
+    pub ledger_closed_at:  String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ledger_hash:       Option<String>,
+    pub in_successful_call: bool,
+    pub value:             Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub topic:             Option<Value>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct Contract {
+    pub contract_id:   String,
+    pub event_count:   Option<i64>,
+    pub first_seen:    Option<String>,
+    pub last_seen:     Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize, Clone)]
+pub struct EventStats {
+    pub total_events:     i64,
+    pub total_contracts:  i64,
+    pub latest_ledger:    Option<i64>,
+    pub events_last_24h:  Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct PaginatedEvents {
+    pub events:  Vec<SorobanEvent>,
+    pub page:    Option<u32>,
+    pub limit:   Option<u32>,
+    pub total:   Option<i64>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(untagged)]
+pub enum EventsResponse {
+    Paginated(PaginatedEvents),
+    List(Vec<SorobanEvent>),
+}
+
+impl EventsResponse {
+    pub fn into_events(self) -> Vec<SorobanEvent> {
+        match self {
+            Self::Paginated(p) => p.events,
+            Self::List(v)      => v,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Query parameters
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default, Clone)]
+pub struct EventQuery {
+    pub from_ledger:  Option<i64>,
+    pub to_ledger:    Option<i64>,
+    pub contract_id:  Option<String>,
+    pub event_type:   Option<String>,
+    pub tx_hash:      Option<String>,
+    pub limit:        u32,
+    pub page:         u32,
+    pub sort:         String,
+    pub sort_by:      String,
+}
+
+impl EventQuery {
+    pub fn to_params(&self) -> Vec<(String, String)> {
+        let mut p = vec![
+            ("limit".into(),   self.limit.to_string()),
+            ("page".into(),    self.page.to_string()),
+            ("sort".into(),    self.sort.clone()),
+            ("sort_by".into(), self.sort_by.clone()),
+        ];
+        if let Some(v) = self.from_ledger  { p.push(("from_ledger".into(), v.to_string())); }
+        if let Some(v) = self.to_ledger    { p.push(("to_ledger".into(),   v.to_string())); }
+        if let Some(v) = &self.contract_id { p.push(("contract_id".into(), v.clone())); }
+        if let Some(v) = &self.event_type  { p.push(("event_type".into(),  v.clone())); }
+        if let Some(v) = &self.tx_hash     { p.push(("tx_hash".into(),     v.clone())); }
+        p
+    }
+
+    /// Build the API path — use the contract-specific endpoint when a
+    /// contract_id filter is set, otherwise the general /v1/events path.
+    pub fn path(&self) -> String {
+        match &self.contract_id {
+            Some(id) => format!("/v1/events/contract/{id}"),
+            None     => "/v1/events".into(),
+        }
+    }
+}
+
+#[derive(Debug, Default, Clone)]
+pub struct ContractQuery {
+    pub search: Option<String>,
+    pub limit:  u32,
+    pub page:   u32,
+}
+
+impl ContractQuery {
+    pub fn path(&self) -> &'static str {
+        "/v1/contracts"
+    }
+
+    pub fn to_params(&self) -> Vec<(String, String)> {
+        let mut p = vec![
+            ("limit".into(), self.limit.to_string()),
+            ("page".into(),  self.page.to_string()),
+        ];
+        if let Some(s) = &self.search { p.push(("q".into(), s.clone())); }
+        p
+    }
+}


### PR DESCRIPTION
## Summary

Adds `spulse`, a standalone Rust CLI for querying, filtering, and exporting Soroban Pulse events locally without a browser or API client.

## Related Issue

Closes #597

## Changes

- Added `cli/src/main.rs` — clap-based CLI with `events`, `contracts`, `stats`, `export`, and `config` subcommands
- Added `cli/src/query.rs` — typed query builders for events and contracts with path/param generation
- Added `cli/src/formatter.rs` — table (comfy-table), JSON, and CSV output for all response types
- Added `cli/src/exporter.rs` — auto-paginating file export with progress spinner; supports JSON, JSONL, and CSV
- Added `cli/src/client.rs` — blocking HTTP client with structured error extraction
- Added `cli/src/config.rs` — persistent config file at `~/.config/spulse/config.toml` with get/set support
- Added `cli/homebrew/spulse.rb` — Homebrew formula for macOS (arm/intel) and Linux (arm/intel) targets
- Added `cli/Cargo.toml` — crate manifest with Cargo publish metadata

## Testing

- [ ] `cargo test` passes
- [ ] `cargo clippy` reports no warnings
- [ ] Manually tested locally

## Notes

No async runtime — uses `reqwest` blocking feature to keep the binary small and startup fast. All config values can be overridden via `SPULSE_BASE_URL` and `SPULSE_API_KEY` env vars for CI use. SHA256 placeholders in the Homebrew formula must be updated when release binaries are built.
