### PR TITLE
feat: event encryption at rest and multi-tenancy support

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -299,3 +299,39 @@ NOTIFICATION_AUDIT_LOG_RETENTION_DAYS=90
 NOTIFICATION_HEALTH_CHECK_INTERVAL_SECS=300
 # Optional: email address to use as the target for email channel health checks.
 # NOTIFICATION_HEALTH_CHECK_EMAIL=health-check@example.com
+
+# ── Issue #584: Event encryption at rest ─────────────────────────────────────
+# AES-256-GCM encryption key for event_data (requires the `encryption` feature).
+# Must be exactly 64 hex characters (32 bytes). When set, all newly stored
+# event_data fields are encrypted before being written to the database.
+# Generate with: openssl rand -hex 32
+# EVENT_DATA_ENCRYPTION_KEY=<64-hex-chars>
+
+# Previous encryption key used during key rotation.
+# Keep the old key here while running POST /v1/admin/reencrypt so that events
+# encrypted with the old key can still be decrypted. Remove once re-encryption
+# is complete.
+# EVENT_DATA_ENCRYPTION_KEY_OLD=<64-hex-chars>
+
+# ── Issue #583: Multi-tenancy ─────────────────────────────────────────────────
+# Enable multi-tenant mode. When true, every API key must be mapped to a
+# tenant_id in the api_key_tenants table and all event queries are automatically
+# scoped to the resolved tenant. Disabled by default (single-tenant behaviour).
+# MULTI_TENANT=false
+
+# Per-tenant request rate limit (requests per minute).
+# When set and MULTI_TENANT=true, each API key gets this independent quota
+# instead of sharing the global RATE_LIMIT_PER_MINUTE pool.
+# Default: falls back to RATE_LIMIT_PER_MINUTE when unset.
+# TENANT_RATE_LIMIT_PER_MINUTE=120
+
+# Tenant ID stamped on every event this indexer instance inserts.
+# Only meaningful when MULTI_TENANT=true. Each indexer instance serving a
+# specific tenant should set this to the matching tenant identifier.
+# INDEXER_TENANT_ID=tenant-a
+
+# Per-tenant contract filter for the indexer (semicolon-separated list of
+# "tenant_id:contract1,contract2" pairs). When set, the indexer only stores
+# events whose contract_id is in the allow-list for the matching tenant.
+# Empty = index all contracts for all tenants.
+# TENANT_CONTRACT_FILTER=tenant-a:CABC...,CDEF...;tenant-b:CXYZ...

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -1,0 +1,103 @@
+# Event Encryption at Rest
+
+SorobanPulse supports optional AES-256-GCM encryption of the `event_data` field before it is written to the database (issue #584).
+
+## What is encrypted
+
+Only the `event_data` JSON column is encrypted. Indexed fields used for querying (`contract_id`, `tx_hash`, `ledger`, `event_type`, `topic`, `tenant_id`, etc.) remain in plaintext so normal queries continue to work without decryption at the query layer.
+
+Each encrypted value is stored as a JSON envelope:
+
+```json
+{"encrypted": true, "data": "<base64-ciphertext>", "nonce": "<base64-nonce>"}
+```
+
+## Prerequisites
+
+Build with the `encryption` feature flag:
+
+```bash
+cargo build --release --features encryption
+```
+
+The feature enables the `aes-gcm` dependency. When the feature is disabled all encrypt/decrypt calls are no-ops (plaintext pass-through).
+
+## Configuration
+
+### Generate a key
+
+```bash
+openssl rand -hex 32
+```
+
+This produces a 64-character hex string representing a 32-byte key.
+
+### Environment variables
+
+| Variable | Required | Description |
+|---|---|---|
+| `EVENT_DATA_ENCRYPTION_KEY` | Yes (to enable encryption) | 64-char hex AES-256 key |
+| `EVENT_DATA_ENCRYPTION_KEY_OLD` | Only during key rotation | Previous key, kept until re-encryption completes |
+
+Add these to your `.env` or Kubernetes secret:
+
+```bash
+EVENT_DATA_ENCRYPTION_KEY=aabbcc...  # 64 hex chars
+```
+
+## How it works
+
+1. **Write path** — The indexer calls `encryption::encrypt(key, &event_data)` before inserting each row. The ciphertext envelope replaces the plaintext `event_data` value in the database.
+2. **Read path** — Handlers call `encryption::decrypt(key, old_key, &event_data)` after fetching rows. Non-encrypted rows (envelope missing `"encrypted": true`) are passed through unchanged, allowing gradual migration.
+3. **SSE / WebSocket streams** — Decryption is applied to each event before it is broadcast to subscribers.
+
+## Key rotation
+
+Rotating the encryption key is a two-step process with zero downtime.
+
+### Step 1 — Add the new key alongside the old one
+
+```bash
+EVENT_DATA_ENCRYPTION_KEY=<new-64-hex>
+EVENT_DATA_ENCRYPTION_KEY_OLD=<old-64-hex>
+```
+
+Restart the service. New events are encrypted with the new key. Existing events encrypted with the old key are still readable because `decrypt()` falls back to `EVENT_DATA_ENCRYPTION_KEY_OLD` when the primary key fails.
+
+### Step 2 — Re-encrypt existing events
+
+Trigger the background re-encryption job via the admin API:
+
+```bash
+curl -X POST https://your-host/v1/admin/reencrypt \
+  -H "Authorization: Bearer $ADMIN_API_KEY"
+```
+
+The job fetches all rows where `event_data->>'encrypted' = 'true'`, decrypts each with the old key, and re-encrypts with the new key in configurable batches. Progress is tracked in the `soroban_pulse_reencrypt_rows_remaining` Prometheus metric.
+
+### Step 3 — Remove the old key
+
+Once the job completes (metric reaches 0), remove `EVENT_DATA_ENCRYPTION_KEY_OLD` and restart.
+
+## Encrypted query support
+
+All query handlers transparently decrypt `event_data` on read. No changes to query parameters are required. Filters on indexed columns (`contract_id`, `ledger`, etc.) work without modification because those columns are never encrypted.
+
+## Verifying encryption
+
+You can confirm rows are encrypted by querying the database directly:
+
+```sql
+SELECT id, event_data->>'encrypted' AS is_encrypted
+FROM events
+LIMIT 5;
+```
+
+Encrypted rows return `'true'`; plaintext rows return `NULL`.
+
+## Security notes
+
+- Each row uses a unique random 12-byte nonce. Nonce reuse is probabilistically impossible.
+- The authentication tag provided by AES-256-GCM detects any tampering with stored ciphertext.
+- Keys are never logged or exposed in metrics.
+- Use a secrets manager (Kubernetes Secrets, AWS Secrets Manager, HashiCorp Vault) to inject `EVENT_DATA_ENCRYPTION_KEY` at runtime rather than committing it to environment files.

--- a/docs/multi-tenancy.md
+++ b/docs/multi-tenancy.md
@@ -1,0 +1,181 @@
+# Multi-Tenancy Deployment
+
+SorobanPulse supports isolating event data between multiple tenants in a single deployment (issue #583). Each tenant sees only their own events; queries, streams, and exports are automatically scoped by the resolved tenant identity.
+
+## Architecture
+
+```
+Client (API key A) ──► auth middleware ──► resolves tenant-a ──► events WHERE tenant_id = 'tenant-a'
+Client (API key B) ──► auth middleware ──► resolves tenant-b ──► events WHERE tenant_id = 'tenant-b'
+Admin  (admin key) ──► auth middleware ──► no tenant scope  ──► all events
+```
+
+Tenant identity is derived from the API key: the SHA-256 hash of the raw API key is looked up in the `api_key_tenants` table, which maps key hashes to tenant identifiers. The plaintext key is never stored in the database.
+
+## Schema
+
+The `events` table gains a `tenant_id TEXT` column (migration `20260430000000_add_tenant_id.sql`). A `NULL` value means the row belongs to the default single-tenant deployment.
+
+The `api_key_tenants` table maps key hashes to tenants:
+
+```sql
+CREATE TABLE api_key_tenants (
+    key_hash  TEXT PRIMARY KEY,   -- SHA-256(raw_api_key) hex
+    tenant_id TEXT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+## Configuration
+
+### Environment variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `MULTI_TENANT` | `false` | Set to `true` to enable multi-tenant mode |
+| `TENANT_RATE_LIMIT_PER_MINUTE` | `RATE_LIMIT_PER_MINUTE` | Independent per-tenant request quota |
+| `INDEXER_TENANT_ID` | — | Tenant stamped on events by this indexer instance |
+| `TENANT_CONTRACT_FILTER` | — | Per-tenant contract allowlist for the indexer |
+
+### Enable multi-tenant mode
+
+```bash
+MULTI_TENANT=true
+```
+
+When enabled:
+- Every non-admin API key must have a row in `api_key_tenants`.
+- A key with no tenant mapping returns `403 Forbidden`.
+- All event queries are automatically filtered to the resolved `tenant_id`.
+- The indexer stamps every inserted event with `INDEXER_TENANT_ID`.
+
+### Register a tenant API key
+
+Insert the SHA-256 hash of the raw key (SorobanPulse uses the same hashing function):
+
+```bash
+KEY="your-tenant-api-key"
+KEY_HASH=$(echo -n "$KEY" | sha256sum | awk '{print $1}')
+
+psql "$DATABASE_URL" -c "
+  INSERT INTO api_key_tenants (key_hash, tenant_id)
+  VALUES ('$KEY_HASH', 'tenant-a')
+  ON CONFLICT (key_hash) DO UPDATE SET tenant_id = EXCLUDED.tenant_id;
+"
+```
+
+After inserting, restart the service so the in-memory tenant map is reloaded (or set `MULTI_TENANT=true` before the first start to load from the database at startup).
+
+## Tenant routing middleware
+
+The `auth_middleware` in `src/middleware.rs` handles tenant resolution:
+
+1. Extracts the raw API key from `Authorization: Bearer <key>` or `X-Api-Key`.
+2. Computes `SHA-256(key)`.
+3. Looks up the hash in the in-memory `tenant_map` (loaded from `api_key_tenants` at startup).
+4. Injects a `TenantId` extension into the request for downstream handlers.
+
+Admin keys (configured via `ADMIN_API_KEY`) bypass tenant resolution and can access all tenant data.
+
+## Tenant isolation validation
+
+All event query handlers read the `TenantId` extension and append a `tenant_id = $N` condition to every SQL query. This is enforced in:
+
+- `GET /v1/events`
+- `GET /v1/events/contract/:id`
+- `GET /v1/events/tx/:hash`
+- `GET /v1/events/stream` (SSE)
+- `GET /v1/events/stream/multi` (SSE)
+- `GET /v1/events/export`
+- `GET /v1/events/stats`
+
+Events broadcast on SSE channels are additionally filtered in the streaming loop: events whose `tenant_id` does not match the subscriber's resolved tenant are dropped before delivery.
+
+## Per-tenant rate limiting
+
+When `MULTI_TENANT=true`, the HTTP rate limiter keys on the API key rather than the client IP address. This gives each tenant an independent quota so one tenant cannot exhaust the shared IP-based limit.
+
+Set the per-tenant quota independently from the global IP rate limit:
+
+```bash
+MULTI_TENANT=true
+TENANT_RATE_LIMIT_PER_MINUTE=120   # each tenant gets 120 req/min
+RATE_LIMIT_PER_MINUTE=60           # fallback if TENANT_RATE_LIMIT_PER_MINUTE is unset
+```
+
+When `TENANT_RATE_LIMIT_PER_MINUTE` is unset, the value of `RATE_LIMIT_PER_MINUTE` is used for each tenant bucket.
+
+## Per-tenant contract filtering (indexer)
+
+Use `TENANT_CONTRACT_FILTER` to restrict which contracts the indexer stores per tenant:
+
+```bash
+TENANT_CONTRACT_FILTER=tenant-a:CABC...,CDEF...;tenant-b:CXYZ...
+```
+
+Events whose `contract_id` is not in the tenant's allowlist are dropped before storage. An empty allowlist means all contracts are indexed for that tenant.
+
+## Multi-indexer deployment
+
+Run one indexer instance per tenant, each writing to the same shared database:
+
+```yaml
+# indexer-tenant-a
+env:
+  - name: MULTI_TENANT
+    value: "true"
+  - name: INDEXER_TENANT_ID
+    value: tenant-a
+  - name: TENANT_CONTRACT_FILTER
+    value: "tenant-a:CABC...,CDEF..."
+
+# indexer-tenant-b
+env:
+  - name: MULTI_TENANT
+    value: "true"
+  - name: INDEXER_TENANT_ID
+    value: tenant-b
+  - name: TENANT_CONTRACT_FILTER
+    value: "tenant-b:CXYZ..."
+```
+
+A single API tier serves all tenants; the indexers write to isolated rows in the shared `events` table.
+
+## Kubernetes example
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: soroban-pulse-tenant-keys
+stringData:
+  tenant-a-key: "your-tenant-a-api-key"
+  tenant-b-key: "your-tenant-b-api-key"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: soroban-pulse-api
+spec:
+  template:
+    spec:
+      containers:
+        - name: api
+          env:
+            - name: MULTI_TENANT
+              value: "true"
+            - name: TENANT_RATE_LIMIT_PER_MINUTE
+              value: "120"
+            - name: API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: soroban-pulse-tenant-keys
+                  key: tenant-a-key
+```
+
+## Security considerations
+
+- API key hashes (SHA-256) are stored instead of plaintext keys. A compromised database does not expose raw keys.
+- The `tenant_id` filter is applied unconditionally at the SQL layer; a missing or invalid `TenantId` extension results in no results returned (not an error) to prevent data leakage.
+- Admin keys are the only path to cross-tenant data; protect them with `ADMIN_API_KEY` and restrict access to admin routes.
+- Combine multi-tenancy with event encryption (`EVENT_DATA_ENCRYPTION_KEY`) for defence-in-depth: even if a tenant's `event_data` rows are accessed by another tenant via a misconfiguration, the payload remains encrypted.

--- a/src/config.rs
+++ b/src/config.rs
@@ -271,6 +271,10 @@ pub struct Config {
     /// tenant_id in the api_key_tenants table and all queries are scoped to that
     /// tenant.  Disabled by default to preserve single-tenant behaviour.
     pub multi_tenant: bool,
+    /// Per-tenant request rate limit (requests per minute).
+    /// When set and multi_tenant is true, each API key (tenant) gets this quota
+    /// instead of sharing the global RATE_LIMIT_PER_MINUTE pool.
+    pub tenant_rate_limit_per_minute: Option<u32>,
     /// Per-tenant contract filter for the indexer.
     /// Format: "tenant1:CABC...,CDEF...;tenant2:CXYZ..."
     /// When set, the indexer only stores events whose contract_id appears in the
@@ -427,6 +431,7 @@ impl Default for Config {
             contract_count_cache_ttl_secs: 30,
             indexer_lock_retry_secs: 30,
             multi_tenant: false,
+            tenant_rate_limit_per_minute: None,
             tenant_contract_filter: std::collections::HashMap::new(),
             indexer_tenant_id: None,
             email_smtp_host: None,
@@ -1235,6 +1240,9 @@ impl Config {
             multi_tenant: env_or_file("MULTI_TENANT", &file)
                 .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "y"))
                 .unwrap_or(false),
+            tenant_rate_limit_per_minute: env_or_file("TENANT_RATE_LIMIT_PER_MINUTE", &file)
+                .and_then(|v| v.trim().parse::<u32>().ok())
+                .filter(|n| *n > 0),
             tenant_contract_filter: parse_tenant_contract_filter(),
             indexer_tenant_id: env_or_file("INDEXER_TENANT_ID", &file),
             email_smtp_host: env_or_file("EMAIL_SMTP_HOST", &file),

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -9,10 +9,36 @@ use std::sync::Arc;
 use std::time::Instant;
 use tokio::sync::broadcast;
 use tower_governor::{
+    errors::GovernorError,
     governor::GovernorConfigBuilder,
-    key_extractor::{PeerIpKeyExtractor, SmartIpKeyExtractor},
+    key_extractor::{KeyExtractor, PeerIpKeyExtractor, SmartIpKeyExtractor},
     GovernorLayer,
 };
+
+/// Rate-limit key extractor for multi-tenant mode.
+/// Uses the raw API key from Authorization or X-Api-Key as the bucket key so
+/// each tenant gets an independent quota regardless of IP address.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct ApiKeyExtractor;
+
+impl KeyExtractor for ApiKeyExtractor {
+    type Key = String;
+
+    fn extract<T>(&self, req: &axum::http::Request<T>) -> Result<Self::Key, GovernorError> {
+        let bearer = req
+            .headers()
+            .get("Authorization")
+            .and_then(|h| h.to_str().ok())
+            .and_then(|s| s.strip_prefix("Bearer "))
+            .map(|s| s.to_string());
+        let x_api_key = req
+            .headers()
+            .get("X-Api-Key")
+            .and_then(|h| h.to_str().ok())
+            .map(|s| s.to_string());
+        bearer.or(x_api_key).ok_or(GovernorError::UnableToExtractKey)
+    }
+}
 use tower_http::{
     compression::CompressionLayer,
     cors::CorsLayer,
@@ -480,7 +506,41 @@ pub fn create_router_with_tx_and_tenant_map(
         .route("/metrics", get(handlers::metrics));
 
     // All other routes — subject to rate limiting.
-    let rate_limited_routes = if behind_proxy {
+    let rate_limited_routes = if config.multi_tenant {
+        // In multi-tenant mode rate-limit per API key so each tenant has an
+        // independent quota regardless of IP (tenants may share egress IPs).
+        let effective_limit = config
+            .tenant_rate_limit_per_minute
+            .unwrap_or(rate_limit_per_minute);
+        let replenish_ms_t = 60_000u64 / u64::from(effective_limit.max(1));
+        let burst_t = effective_limit.max(1);
+        let governor_conf = Arc::new(
+            GovernorConfigBuilder::default()
+                .per_millisecond(replenish_ms_t)
+                .burst_size(burst_t)
+                .key_extractor(ApiKeyExtractor)
+                .use_headers()
+                .finish()
+                .expect("invalid governor config"),
+        );
+        Router::new()
+            .route("/status", get(handlers::status))
+            .route("/openapi.json", get(handlers::openapi_json))
+            .route("/docs", get(handlers::swagger_ui))
+            .nest("/v1", v1)
+            .merge(deprecated)
+            .layer(axum::middleware::from_fn(
+                |req: Request<Body>, next: axum::middleware::Next| async move {
+                    let resp = next.run(req).await;
+                    if resp.status() == axum::http::StatusCode::TOO_MANY_REQUESTS {
+                        metrics::record_rate_limit_rejected();
+                        return rate_limit_json_response(resp);
+                    }
+                    resp
+                },
+            ))
+            .layer(GovernorLayer::new(governor_conf))
+    } else if behind_proxy {
         let governor_conf = Arc::new(
             GovernorConfigBuilder::default()
                 .per_millisecond(replenish_ms)


### PR DESCRIPTION
## Summary

- **#584 — Event encryption at rest**: Adds `docs/encryption.md` covering AES-256-GCM field-level encryption configuration, key generation, key rotation procedure, re-encryption admin endpoint usage, and encrypted query support. Adds `EVENT_DATA_ENCRYPTION_KEY` / `EVENT_DATA_ENCRYPTION_KEY_OLD` entries to `.env.example`.
- **#583 — Multi-tenancy support**: Implements per-tenant rate limiting via a new `ApiKeyExtractor` — when `MULTI_TENANT=true`, the HTTP rate limiter keys on the API key instead of client IP so each tenant gets an independent quota. Adds `TENANT_RATE_LIMIT_PER_MINUTE` config field and env var. Adds `docs/multi-tenancy.md` documenting schema, tenant routing middleware, isolation validation, per-tenant rate limiting, contract filtering, and Kubernetes deployment patterns. Adds all multi-tenancy env vars to `.env.example`.

## Changes

| File | Purpose |
|---|---|
| `src/routes.rs` | `ApiKeyExtractor` + multi-tenant rate-limit branch |
| `src/config.rs` | `tenant_rate_limit_per_minute` field + parsing |
| `docs/encryption.md` | Encryption setup and key rotation guide |
| `docs/multi-tenancy.md` | Multi-tenancy deployment guide |
| `.env.example` | Encryption and multi-tenancy env var documentation |

closes #583
closes #584