### PR TITLE
feat: implement ABI caching, ledger hash tracking, multi-chain support, and event compression

### DIFF
--- a/migrations/20260628000001_abi_caching.down.sql
+++ b/migrations/20260628000001_abi_caching.down.sql
@@ -1,0 +1,7 @@
+DROP TABLE IF EXISTS contract_abi_validation_log;
+DROP INDEX IF EXISTS idx_contract_abis_expires_at;
+ALTER TABLE contract_abis
+    DROP COLUMN IF EXISTS expires_at,
+    DROP COLUMN IF EXISTS fetched_at,
+    DROP COLUMN IF EXISTS abi_hash,
+    DROP COLUMN IF EXISTS is_valid;

--- a/migrations/20260628000001_abi_caching.sql
+++ b/migrations/20260628000001_abi_caching.sql
@@ -1,0 +1,22 @@
+-- Issue #607: Add TTL and fetch tracking to contract_abis for cache management.
+ALTER TABLE contract_abis
+    ADD COLUMN IF NOT EXISTS expires_at  TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS fetched_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    ADD COLUMN IF NOT EXISTS abi_hash    TEXT,
+    ADD COLUMN IF NOT EXISTS is_valid    BOOLEAN NOT NULL DEFAULT true;
+
+-- Index for TTL-based expiry sweeps.
+CREATE INDEX IF NOT EXISTS idx_contract_abis_expires_at
+    ON contract_abis(expires_at)
+    WHERE expires_at IS NOT NULL;
+
+-- ABI validation log for schema mismatch auditing.
+CREATE TABLE IF NOT EXISTS contract_abi_validation_log (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    contract_id TEXT NOT NULL,
+    error       TEXT NOT NULL,
+    logged_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_abi_validation_log_contract
+    ON contract_abi_validation_log(contract_id);

--- a/migrations/20260628000002_ledger_hashes_table.down.sql
+++ b/migrations/20260628000002_ledger_hashes_table.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS ledger_hashes;

--- a/migrations/20260628000002_ledger_hashes_table.sql
+++ b/migrations/20260628000002_ledger_hashes_table.sql
@@ -1,0 +1,10 @@
+-- Issue #608: Dedicated ledger_hashes table for proof-of-indexing and hash chain verification.
+CREATE TABLE IF NOT EXISTS ledger_hashes (
+    ledger      BIGINT      PRIMARY KEY,
+    hash        TEXT        NOT NULL,
+    prev_hash   TEXT,
+    indexed_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Index for range look-ups in the hash-chain verifier.
+CREATE INDEX IF NOT EXISTS idx_ledger_hashes_indexed_at ON ledger_hashes(indexed_at);

--- a/migrations/20260628000003_multi_chain.down.sql
+++ b/migrations/20260628000003_multi_chain.down.sql
@@ -1,0 +1,4 @@
+DROP TABLE IF EXISTS networks;
+DROP INDEX IF EXISTS idx_events_chain_contract;
+DROP INDEX IF EXISTS idx_events_chain_id;
+ALTER TABLE events DROP COLUMN IF EXISTS chain_id;

--- a/migrations/20260628000003_multi_chain.sql
+++ b/migrations/20260628000003_multi_chain.sql
@@ -1,0 +1,31 @@
+-- Issue #609: Multi-chain support — chain_id on events and networks registry.
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS chain_id TEXT NOT NULL DEFAULT 'mainnet';
+
+CREATE INDEX IF NOT EXISTS idx_events_chain_id ON events(chain_id);
+
+-- Combined index for the most common multi-chain query pattern.
+CREATE INDEX IF NOT EXISTS idx_events_chain_contract
+    ON events(chain_id, contract_id);
+
+-- Network registry: one row per indexable Soroban network.
+CREATE TABLE IF NOT EXISTS networks (
+    chain_id        TEXT        PRIMARY KEY,
+    display_name    TEXT        NOT NULL,
+    rpc_url         TEXT        NOT NULL,
+    passphrase      TEXT        NOT NULL,
+    is_enabled      BOOLEAN     NOT NULL DEFAULT true,
+    added_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_seen_at    TIMESTAMPTZ,
+    last_ledger     BIGINT,
+    health_status   TEXT        NOT NULL DEFAULT 'unknown'
+);
+
+INSERT INTO networks (chain_id, display_name, rpc_url, passphrase, is_enabled)
+VALUES (
+    'mainnet',
+    'Stellar Mainnet',
+    'https://mainnet.stellar.validationcloud.io/v1/soroban/rpc',
+    'Public Global Stellar Network ; September 2015',
+    true
+) ON CONFLICT (chain_id) DO NOTHING;

--- a/migrations/20260628000004_event_data_gzip.down.sql
+++ b/migrations/20260628000004_event_data_gzip.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS idx_events_uncompressed;
+ALTER TABLE events
+    DROP COLUMN IF EXISTS compression_algo,
+    DROP COLUMN IF EXISTS event_data_compressed;

--- a/migrations/20260628000004_event_data_gzip.sql
+++ b/migrations/20260628000004_event_data_gzip.sql
@@ -1,0 +1,11 @@
+-- Issue #610: Application-level gzip compression column for event_data.
+-- event_data_compressed holds the gzip-compressed JSON bytes when compression is enabled.
+-- When NULL the plain event_data column is the authoritative source.
+ALTER TABLE events
+    ADD COLUMN IF NOT EXISTS event_data_compressed BYTEA,
+    ADD COLUMN IF NOT EXISTS compression_algo       TEXT;
+
+-- Partial index so the migration worker can quickly find uncompressed rows.
+CREATE INDEX IF NOT EXISTS idx_events_uncompressed
+    ON events(id)
+    WHERE event_data_compressed IS NULL;

--- a/src/abi.rs
+++ b/src/abi.rs
@@ -1,6 +1,73 @@
 use serde_json::{json, Value};
 use sqlx::PgPool;
+use std::sync::Arc;
 use stellar_xdr::curr::ScVal;
+
+/// Default ABI cache TTL in seconds (24 hours).
+pub const DEFAULT_ABI_CACHE_TTL_SECS: u64 = 86_400;
+/// Maximum number of entries kept in the in-process LRU cache.
+pub const ABI_CACHE_MAX_ENTRIES: u64 = 10_000;
+
+pub type AbiCache = moka::future::Cache<String, Value>;
+
+/// Build an in-process ABI cache capped at `ABI_CACHE_MAX_ENTRIES`.
+pub fn build_abi_cache() -> AbiCache {
+    moka::future::Cache::builder()
+        .max_capacity(ABI_CACHE_MAX_ENTRIES)
+        .time_to_live(std::time::Duration::from_secs(DEFAULT_ABI_CACHE_TTL_SECS))
+        .eviction_listener(|_key, _val, _cause| {
+            crate::metrics::record_abi_cache_eviction();
+        })
+        .build()
+}
+
+/// Validate that an ABI value is a JSON array whose entries each have a "name" field.
+pub fn validate_abi(abi: &Value) -> Result<(), String> {
+    let entries = abi
+        .as_array()
+        .ok_or_else(|| "ABI must be a JSON array".to_string())?;
+    for (i, entry) in entries.iter().enumerate() {
+        if entry.get("name").and_then(Value::as_str).is_none() {
+            return Err(format!("ABI entry {i} is missing a \"name\" field"));
+        }
+    }
+    Ok(())
+}
+
+/// Fetch a contract ABI, using the in-process cache as the first layer and
+/// falling back to the database.  Cache hits / misses are recorded as metrics.
+pub async fn fetch_contract_abi(
+    pool: &PgPool,
+    cache: &AbiCache,
+    contract_id: &str,
+) -> Option<Value> {
+    if let Some(abi) = cache.get(contract_id).await {
+        crate::metrics::record_abi_cache_hit(contract_id);
+        return Some(abi);
+    }
+    crate::metrics::record_abi_cache_miss(contract_id);
+
+    let row = sqlx::query!(
+        "SELECT abi FROM contract_abis
+         WHERE contract_id = $1
+           AND (expires_at IS NULL OR expires_at > NOW())",
+        contract_id,
+    )
+    .fetch_optional(pool)
+    .await
+    .ok()
+    .flatten()?;
+
+    let abi = row.abi;
+    cache.insert(contract_id.to_string(), abi.clone()).await;
+    Some(abi)
+}
+
+/// Invalidate the in-process cache entry for `contract_id`.
+/// Called after an ABI is updated so the next read fetches fresh data.
+pub async fn invalidate_abi_cache(cache: &AbiCache, contract_id: &str) {
+    cache.invalidate(contract_id).await;
+}
 
 pub fn decode_event_data(abi: &Value, event_data: &Value) -> Option<Value> {
     let event_name = event_name_from_topic(event_data.get("topic")?)?;
@@ -30,6 +97,18 @@ pub fn decode_event_data(abi: &Value, event_data: &Value) -> Option<Value> {
     Some(Value::Object(decoded))
 }
 
+/// Decode using the cached ABI for `contract_id`.
+pub async fn decode_event_with_cached_abi(
+    pool: &PgPool,
+    cache: &AbiCache,
+    contract_id: &str,
+    event_data: &Value,
+) -> Option<Value> {
+    let abi = fetch_contract_abi(pool, cache, contract_id).await?;
+    decode_event_data(&abi, event_data)
+}
+
+/// Legacy version that hits the DB directly (kept for backwards compatibility).
 pub async fn decode_event_with_registered_abi(
     pool: &PgPool,
     contract_id: &str,
@@ -155,5 +234,21 @@ mod tests {
         let decoded = decode_event_data(&abi, &event_data).unwrap();
         assert_eq!(decoded["event"], "transfer");
         assert_eq!(decoded["amount"], "1000");
+    }
+
+    #[test]
+    fn validate_abi_rejects_non_array() {
+        assert!(validate_abi(&json!({"name": "foo"})).is_err());
+    }
+
+    #[test]
+    fn validate_abi_rejects_entry_without_name() {
+        assert!(validate_abi(&json!([{"inputs": []}])).is_err());
+    }
+
+    #[test]
+    fn validate_abi_accepts_well_formed() {
+        let abi = json!([{"name": "transfer", "inputs": []}]);
+        assert!(validate_abi(&abi).is_ok());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -368,6 +368,30 @@ pub struct Config {
     pub oncall_pagerduty_api_key: Option<SecretString>,
     pub oncall_schedule_id: Option<String>,
     pub oncall_schedule_cache_ttl_secs: u64,
+
+    // Issue #610: Application-level gzip compression for event_data
+    /// When true, event_data is gzip-compressed before writing to event_data_compressed.
+    pub event_compression_enabled: bool,
+    /// Batch size when migrating existing events to compressed format.
+    pub event_compression_migration_batch_size: i64,
+
+    // Issue #609: Multi-chain support
+    /// The chain_id this indexer instance stamps on indexed events (default "mainnet").
+    pub chain_id: String,
+    /// Comma-separated list of additional network chain_ids to spin up indexer workers for.
+    pub additional_chain_ids: Vec<String>,
+
+    // Issue #608: Ledger hash tracking
+    /// When true, store ledger hashes and verify continuity on startup.
+    pub ledger_hash_tracking_enabled: bool,
+    /// Number of ledgers to check during startup hash-chain validation.
+    pub ledger_hash_validation_depth: u64,
+
+    // Issue #607: Contract ABI caching
+    /// TTL in seconds for the in-process ABI cache (default 86400 = 24 h).
+    pub abi_cache_ttl_secs: u64,
+    /// Maximum number of ABIs kept in the in-process cache.
+    pub abi_cache_max_entries: u64,
 }
 
 impl Default for Config {
@@ -500,6 +524,14 @@ impl Default for Config {
             oncall_pagerduty_api_key: None,
             oncall_schedule_id: None,
             oncall_schedule_cache_ttl_secs: 300,
+            event_compression_enabled: false,
+            event_compression_migration_batch_size: 500,
+            chain_id: "mainnet".to_string(),
+            additional_chain_ids: Vec::new(),
+            ledger_hash_tracking_enabled: false,
+            ledger_hash_validation_depth: 1_000,
+            abi_cache_ttl_secs: crate::abi::DEFAULT_ABI_CACHE_TTL_SECS,
+            abi_cache_max_entries: crate::abi::ABI_CACHE_MAX_ENTRIES,
         }
     }
 }
@@ -1429,6 +1461,40 @@ impl Config {
             oncall_schedule_cache_ttl_secs: env_or_file("ONCALL_SCHEDULE_CACHE_TTL_SECS", &file)
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(300),
+            // Issue #610: Event compression
+            event_compression_enabled: env_or_file("EVENT_COMPRESSION_ENABLED", &file)
+                .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "y"))
+                .unwrap_or(false),
+            event_compression_migration_batch_size: env_or_file(
+                "EVENT_COMPRESSION_MIGRATION_BATCH_SIZE",
+                &file,
+            )
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(500),
+            // Issue #609: Multi-chain
+            chain_id: env_or_file_or("CHAIN_ID", &file, "mainnet"),
+            additional_chain_ids: env_or_file("ADDITIONAL_CHAIN_IDS", &file)
+                .map(|v| {
+                    v.split(',')
+                        .map(|s| s.trim().to_string())
+                        .filter(|s| !s.is_empty())
+                        .collect()
+                })
+                .unwrap_or_default(),
+            // Issue #608: Ledger hash tracking
+            ledger_hash_tracking_enabled: env_or_file("LEDGER_HASH_TRACKING_ENABLED", &file)
+                .map(|v| matches!(v.to_ascii_lowercase().as_str(), "true" | "1" | "yes" | "y"))
+                .unwrap_or(false),
+            ledger_hash_validation_depth: env_or_file("LEDGER_HASH_VALIDATION_DEPTH", &file)
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(1_000),
+            // Issue #607: ABI cache
+            abi_cache_ttl_secs: env_or_file("ABI_CACHE_TTL_SECS", &file)
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(crate::abi::DEFAULT_ABI_CACHE_TTL_SECS),
+            abi_cache_max_entries: env_or_file("ABI_CACHE_MAX_ENTRIES", &file)
+                .and_then(|v| v.parse().ok())
+                .unwrap_or(crate::abi::ABI_CACHE_MAX_ENTRIES),
         }
     }
 }

--- a/src/event_compression.rs
+++ b/src/event_compression.rs
@@ -1,0 +1,92 @@
+use flate2::{read::GzDecoder, write::GzEncoder, Compression};
+use serde_json::Value;
+use sqlx::PgPool;
+use std::io::{Read, Write};
+
+/// Gzip-compress the JSON representation of `value`.
+pub fn compress(value: &Value) -> Result<Vec<u8>, std::io::Error> {
+    let json_bytes = serde_json::to_vec(value)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+    let mut encoder = GzEncoder::new(Vec::new(), Compression::default());
+    encoder.write_all(&json_bytes)?;
+    encoder.finish()
+}
+
+/// Decompress gzip-compressed bytes back to a JSON `Value`.
+pub fn decompress(bytes: &[u8]) -> Result<Value, std::io::Error> {
+    let mut decoder = GzDecoder::new(bytes);
+    let mut decompressed = Vec::new();
+    decoder.read_to_end(&mut decompressed)?;
+    serde_json::from_slice(&decompressed)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+}
+
+#[derive(sqlx::FromRow)]
+struct EventRow {
+    id: uuid::Uuid,
+    event_data: serde_json::Value,
+}
+
+/// Migrate existing uncompressed events to gzip-compressed format.
+/// Processes rows in batches to avoid long-running transactions.
+pub async fn migrate_existing_events(pool: &PgPool, batch_size: i64) -> anyhow::Result<u64> {
+    let mut total_migrated: u64 = 0;
+    loop {
+        let rows: Vec<EventRow> = sqlx::query_as::<_, EventRow>(
+            "SELECT id, event_data FROM events
+             WHERE event_data_compressed IS NULL
+             LIMIT $1",
+        )
+        .bind(batch_size)
+        .fetch_all(pool)
+        .await?;
+
+        if rows.is_empty() {
+            break;
+        }
+
+        for row in &rows {
+            let compressed = match compress(&row.event_data) {
+                Ok(b) => b,
+                Err(e) => {
+                    tracing::warn!(event_id = %row.id, error = %e, "skipping compression for event");
+                    continue;
+                }
+            };
+            let original_len = row.event_data.to_string().len();
+            sqlx::query(
+                "UPDATE events
+                 SET event_data_compressed = $1, compression_algo = 'gzip'
+                 WHERE id = $2",
+            )
+            .bind(&compressed)
+            .bind(row.id)
+            .execute(pool)
+            .await?;
+            crate::metrics::record_compression_ratio(original_len, compressed.len());
+            total_migrated += 1;
+        }
+    }
+    Ok(total_migrated)
+}
+
+/// Read the canonical event_data for a row, preferring the compressed column.
+/// Returns `None` if decompression fails (with a metric bump and warning).
+pub fn read_event_data(
+    compressed: Option<&[u8]>,
+    algo: Option<&str>,
+    plain: &Value,
+) -> Value {
+    if let Some(bytes) = compressed {
+        if algo == Some("gzip") {
+            match decompress(bytes) {
+                Ok(v) => return v,
+                Err(e) => {
+                    tracing::warn!(error = %e, "decompression failed, falling back to plain event_data");
+                    crate::metrics::record_decompression_failure();
+                }
+            }
+        }
+    }
+    plain.clone()
+}

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -3825,8 +3825,10 @@ pub async fn register_contract_abi(
     Json(abi): Json<Value>,
 ) -> Result<Json<Value>, AppError> {
     validate_contract_id(&contract_id)?;
-    if !abi.is_array() {
-        return Err(AppError::Validation("ABI must be a JSON array".to_string()));
+    // Issue #607: validate ABI structure before persisting.
+    if let Err(e) = crate::abi::validate_abi(&abi) {
+        crate::metrics::record_abi_validation_failure(&contract_id);
+        return Err(AppError::Validation(e));
     }
     sqlx::query(
         "INSERT INTO contract_abis (contract_id, abi, updated_at)
@@ -3837,6 +3839,9 @@ pub async fn register_contract_abi(
     .bind(&abi)
     .execute(&state.pool)
     .await?;
+
+    // Issue #607: invalidate the in-process cache so the next read fetches fresh data.
+    crate::abi::invalidate_abi_cache(&state.abi_cache, &contract_id).await;
 
     let pool = state.pool.clone();
     let backfill_contract_id = contract_id.clone();
@@ -11383,6 +11388,196 @@ pub async fn get_feature_flag_audit(State(state): State<AppState>) -> Result<Jso
 
     let count = entries.len();
     Ok(Json(json!({ "entries": entries, "count": count })))
+}
+
+// ── Issue #609: GET /v1/networks ─────────────────────────────────────────────
+
+/// List all registered Soroban networks and their health status.
+///
+/// `GET /v1/networks`
+#[utoipa::path(
+    get,
+    path = "/v1/networks",
+    tag = "system",
+    responses(
+        (status = 200, description = "List of registered networks"),
+        (status = 500, description = "Internal server error"),
+    )
+)]
+pub async fn list_networks(
+    State(state): State<AppState>,
+) -> Result<Json<Value>, AppError> {
+    let networks = crate::networks::list_networks(&state.pool).await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok(Json(json!({
+        "count": networks.len(),
+        "networks": networks,
+    })))
+}
+
+// ── Issue #608: GET /v1/ledgers/{ledger}/hash ────────────────────────────────
+
+/// Return the indexed hash for a specific ledger sequence number.
+///
+/// `GET /v1/ledgers/{ledger}/hash`
+#[utoipa::path(
+    get,
+    path = "/v1/ledgers/{ledger}/hash",
+    tag = "events",
+    params(
+        ("ledger" = u64, Path, description = "Ledger sequence number"),
+    ),
+    responses(
+        (status = 200, description = "Ledger hash"),
+        (status = 404, description = "Ledger not found"),
+        (status = 500, description = "Internal server error"),
+    )
+)]
+pub async fn get_ledger_hash(
+    State(state): State<AppState>,
+    Path(ledger): Path<u64>,
+) -> Result<Json<Value>, AppError> {
+    match crate::ledger_hashes::get_ledger_hash(&state.pool, ledger).await {
+        Ok(Some(hash)) => Ok(Json(json!({ "ledger": ledger, "hash": hash }))),
+        Ok(None) => Err(AppError::NotFound),
+        Err(e) => Err(AppError::Internal(e.to_string())),
+    }
+}
+
+/// Verify the hash chain for a ledger range.
+///
+/// `GET /v1/ledgers/verify-chain?from={from}&to={to}`
+#[utoipa::path(
+    get,
+    path = "/v1/ledgers/verify-chain",
+    tag = "events",
+    params(
+        ("from" = u64, Query, description = "Start ledger (inclusive)"),
+        ("to"   = u64, Query, description = "End ledger (inclusive)"),
+    ),
+    responses(
+        (status = 200, description = "Hash chain verification result"),
+        (status = 500, description = "Internal server error"),
+    )
+)]
+pub async fn verify_ledger_hash_chain(
+    State(state): State<AppState>,
+    Query(params): Query<std::collections::HashMap<String, String>>,
+) -> Result<Json<Value>, AppError> {
+    let from: u64 = params
+        .get("from")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0);
+    let to: u64 = params
+        .get("to")
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(from);
+    let mismatches = crate::ledger_hashes::verify_hash_chain(&state.pool, from, to)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    Ok(Json(json!({
+        "from": from,
+        "to": to,
+        "mismatches": mismatches,
+        "ok": mismatches == 0,
+    })))
+}
+
+// ── Issue #610: GET /v1/admin/compression-stats ──────────────────────────────
+
+/// Return compression statistics and trigger a backfill migration when enabled.
+///
+/// `GET /v1/admin/compression-stats`
+#[utoipa::path(
+    get,
+    path = "/v1/admin/compression-stats",
+    tag = "admin",
+    responses(
+        (status = 200, description = "Compression statistics"),
+        (status = 500, description = "Internal server error"),
+    )
+)]
+pub async fn compression_stats(
+    State(state): State<AppState>,
+) -> Result<Json<Value>, AppError> {
+    let total: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM events")
+        .fetch_one(&state.pool)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+    let compressed: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM events WHERE event_data_compressed IS NOT NULL")
+            .fetch_one(&state.pool)
+            .await
+            .map_err(|e| AppError::Internal(e.to_string()))?;
+    let enabled = state.config.event_compression_enabled;
+    Ok(Json(json!({
+        "enabled": enabled,
+        "total_events": total,
+        "compressed_events": compressed,
+        "uncompressed_events": total - compressed,
+        "coverage_pct": if total > 0 { (compressed as f64 / total as f64) * 100.0 } else { 0.0 },
+    })))
+}
+
+/// Trigger a background migration that gzip-compresses all uncompressed events.
+///
+/// `POST /v1/admin/compression-migrate`
+#[utoipa::path(
+    post,
+    path = "/v1/admin/compression-migrate",
+    tag = "admin",
+    responses(
+        (status = 202, description = "Migration started"),
+        (status = 400, description = "Compression is disabled"),
+    )
+)]
+pub async fn start_compression_migration(
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    if !state.config.event_compression_enabled {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(json!({ "error": "EVENT_COMPRESSION_ENABLED is false" })),
+        );
+    }
+    let pool = state.pool.clone();
+    let batch = state.config.event_compression_migration_batch_size;
+    tokio::spawn(async move {
+        match crate::event_compression::migrate_existing_events(&pool, batch).await {
+            Ok(n) => tracing::info!(migrated = n, "compression migration complete"),
+            Err(e) => tracing::error!(error = %e, "compression migration failed"),
+        }
+    });
+    (StatusCode::ACCEPTED, Json(json!({ "status": "started" })))
+}
+
+// ── Issue #607: GET /v1/contracts/{contract_id}/abi (cached) ─────────────────
+
+/// Return the cached ABI for a contract (cache-backed, with hit/miss metrics).
+///
+/// `GET /v1/contracts/{contract_id}/abi/cached`
+#[utoipa::path(
+    get,
+    path = "/v1/contracts/{contract_id}/abi/cached",
+    tag = "events",
+    params(
+        ("contract_id" = String, Path, description = "Contract ID"),
+    ),
+    responses(
+        (status = 200, description = "Contract ABI"),
+        (status = 404, description = "ABI not found"),
+    )
+)]
+pub async fn get_contract_abi_cached(
+    State(state): State<AppState>,
+    Path(contract_id): Path<String>,
+) -> Result<Json<Value>, AppError> {
+    match crate::abi::fetch_contract_abi(&state.pool, &state.abi_cache, &contract_id).await {
+        Some(abi) => Ok(Json(json!({ "contract_id": contract_id, "abi": abi }))),
+        None => Err(AppError::NotFound),
+    }
+}
+
 #[cfg(test)]
 mod temporal_tests {
     use super::*;

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -459,6 +459,11 @@ impl<R: RpcClient> Indexer<R> {
             metrics::record_indexer_is_leader(false);
         }
 
+        // Issue #608: validate ledger hash chain on startup when enabled.
+        if self.config.ledger_hash_tracking_enabled {
+            crate::ledger_hashes::startup_hash_chain_validation(&self.pool).await;
+        }
+
         // Run the actual indexing loop; release lock on exit.
         self.run_loop().await;
 
@@ -1122,9 +1127,29 @@ impl<R: RpcClient> Indexer<R> {
             None
         };
 
+        // Issue #610: gzip-compress event_data when enabled.
+        let (compressed_bytes, compression_algo): (Option<Vec<u8>>, Option<&str>) =
+            if self.config.event_compression_enabled {
+                match crate::event_compression::compress(&event_data) {
+                    Ok(b) => {
+                        crate::metrics::record_compression_ratio(serialized.len(), b.len());
+                        (Some(b), Some("gzip"))
+                    }
+                    Err(e) => {
+                        tracing::warn!(error = %e, "compression failed, storing plain event_data");
+                        (None, None)
+                    }
+                }
+            } else {
+                (None, None)
+            };
+
+        // Issue #609: stamp chain_id on every inserted event.
+        let chain_id = &self.config.chain_id;
+
         let result = sqlx::query(
-            r#"INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data, ledger_hash, in_successful_call, event_data_decoded, tenant_id, fingerprint)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+            r#"INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data, ledger_hash, in_successful_call, event_data_decoded, tenant_id, fingerprint, event_data_compressed, compression_algo, chain_id)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
                ON CONFLICT (tx_hash, contract_id, event_type) DO NOTHING"#,
         )
         .bind(&event.contract_id)
@@ -1138,6 +1163,9 @@ impl<R: RpcClient> Indexer<R> {
         .bind(event_data_decoded)
         .bind(tenant_id)
         .bind(&fingerprint)
+        .bind(compressed_bytes.as_deref())
+        .bind(compression_algo)
+        .bind(chain_id)
         .execute(&mut **tx)
         .await?;
 
@@ -1147,6 +1175,26 @@ impl<R: RpcClient> Indexer<R> {
             // Record in bloom filter after successful insert
             if let Some(ref bloom) = self.bloom_filter {
                 bloom.set(&event.tx_hash, &event.contract_id, &event.event_type);
+            }
+            // Issue #608: persist ledger hash when tracking is enabled.
+            if self.config.ledger_hash_tracking_enabled {
+                if let Some(ref hash) = event.ledger_hash {
+                    let pool = self.pool.clone();
+                    let ledger_num = event.ledger;
+                    let hash_owned = hash.clone();
+                    tokio::spawn(async move {
+                        if let Err(e) = crate::ledger_hashes::store_ledger_hash(
+                            &pool,
+                            ledger_num,
+                            &hash_owned,
+                            None,
+                        )
+                        .await
+                        {
+                            tracing::warn!(error = %e, ledger = ledger_num, "failed to store ledger hash");
+                        }
+                    });
+                }
             }
         }
         Ok(rows)

--- a/src/ledger_hashes.rs
+++ b/src/ledger_hashes.rs
@@ -1,0 +1,110 @@
+use sqlx::PgPool;
+use tracing::{error, info, warn};
+
+/// Persist a ledger hash.  `prev_hash` is the hash of `ledger - 1` (if known).
+pub async fn store_ledger_hash(
+    pool: &PgPool,
+    ledger: u64,
+    hash: &str,
+    prev_hash: Option<&str>,
+) -> sqlx::Result<()> {
+    sqlx::query(
+        "INSERT INTO ledger_hashes (ledger, hash, prev_hash)
+         VALUES ($1, $2, $3)
+         ON CONFLICT (ledger) DO UPDATE
+             SET hash      = EXCLUDED.hash,
+                 prev_hash = EXCLUDED.prev_hash",
+    )
+    .bind(ledger as i64)
+    .bind(hash)
+    .bind(prev_hash)
+    .execute(pool)
+    .await?;
+    crate::metrics::update_ledger_hash_chain_height(ledger);
+    crate::metrics::record_ledger_hash_verified();
+    Ok(())
+}
+
+/// Fetch the hash for a specific ledger.
+pub async fn get_ledger_hash(pool: &PgPool, ledger: u64) -> sqlx::Result<Option<String>> {
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT hash FROM ledger_hashes WHERE ledger = $1",
+    )
+    .bind(ledger as i64)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|(h,)| h))
+}
+
+#[derive(sqlx::FromRow)]
+struct LedgerHashRow {
+    ledger: i64,
+    hash: String,
+    prev_hash: Option<String>,
+}
+
+/// Verify hash-chain continuity for the range `[from_ledger, to_ledger]`.
+/// Logs a warning and bumps the mismatch metric for each broken link.
+/// Returns the number of mismatches found.
+pub async fn verify_hash_chain(
+    pool: &PgPool,
+    from_ledger: u64,
+    to_ledger: u64,
+) -> sqlx::Result<u64> {
+    let rows: Vec<LedgerHashRow> = sqlx::query_as::<_, LedgerHashRow>(
+        "SELECT ledger, hash, prev_hash
+         FROM ledger_hashes
+         WHERE ledger BETWEEN $1 AND $2
+         ORDER BY ledger",
+    )
+    .bind(from_ledger as i64)
+    .bind(to_ledger as i64)
+    .fetch_all(pool)
+    .await?;
+
+    let mut mismatches: u64 = 0;
+    let mut prev: Option<(i64, String)> = None;
+
+    for row in rows {
+        if let Some((prev_ledger, ref prev_hash)) = prev {
+            if row.ledger == prev_ledger + 1 {
+                if row.prev_hash.as_deref() != Some(prev_hash.as_str()) {
+                    warn!(
+                        ledger = row.ledger,
+                        expected_prev = %prev_hash,
+                        actual_prev = ?row.prev_hash,
+                        "ledger hash chain break detected"
+                    );
+                    crate::metrics::record_ledger_hash_mismatch(row.ledger as u64);
+                    mismatches += 1;
+                }
+            }
+        }
+        prev = Some((row.ledger, row.hash));
+    }
+
+    Ok(mismatches)
+}
+
+/// On startup, validate the last 1 000 ledgers for hash continuity.
+pub async fn startup_hash_chain_validation(pool: &PgPool) {
+    let latest: Option<i64> = sqlx::query_as::<_, (Option<i64>,)>(
+        "SELECT MAX(ledger) FROM ledger_hashes",
+    )
+    .fetch_one(pool)
+    .await
+    .ok()
+    .and_then(|(v,)| v);
+
+    let Some(latest) = latest else {
+        info!("no ledger hashes recorded yet — skipping continuity check");
+        return;
+    };
+
+    let from = (latest as u64).saturating_sub(1_000);
+    match verify_hash_chain(pool, from, latest as u64).await {
+        Ok(0) => info!(from, to = latest, "ledger hash chain OK"),
+        Ok(n) => error!(mismatches = n, from, to = latest, "ledger hash chain has gaps"),
+        Err(e) => error!(error = %e, "failed to verify ledger hash chain"),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,8 @@
 pub mod abi;
 pub mod codegen;
+pub mod event_compression;
+pub mod ledger_hashes;
+pub mod networks;
 pub mod audit_logging;
 pub mod bloom_filter;
 pub mod capacity_planning;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -406,6 +406,98 @@ pub fn update_notification_rate_per_minute(channel: &str, rate: f64) {
     .set(rate);
 }
 
+// ── Issue #607: Contract ABI cache metrics ───────────────────────────────────
+
+pub fn record_abi_cache_hit(contract_id: &str) {
+    m::counter!(
+        "soroban_pulse_abi_cache_hits_total",
+        "contract_id" => contract_id.to_string()
+    )
+    .increment(1);
+}
+
+pub fn record_abi_cache_miss(contract_id: &str) {
+    m::counter!(
+        "soroban_pulse_abi_cache_misses_total",
+        "contract_id" => contract_id.to_string()
+    )
+    .increment(1);
+}
+
+pub fn record_abi_validation_failure(contract_id: &str) {
+    m::counter!(
+        "soroban_pulse_abi_validation_failures_total",
+        "contract_id" => contract_id.to_string()
+    )
+    .increment(1);
+}
+
+pub fn record_abi_cache_eviction() {
+    m::counter!("soroban_pulse_abi_cache_evictions_total").increment(1);
+}
+
+// ── Issue #608: Ledger hash metrics ─────────────────────────────────────────
+
+pub fn record_ledger_hash_mismatch(ledger: u64) {
+    m::counter!(
+        "soroban_pulse_ledger_hash_mismatches_total",
+        "ledger" => ledger.to_string()
+    )
+    .increment(1);
+}
+
+pub fn record_ledger_hash_verified() {
+    m::counter!("soroban_pulse_ledger_hashes_verified_total").increment(1);
+}
+
+pub fn update_ledger_hash_chain_height(ledger: u64) {
+    m::gauge!("soroban_pulse_ledger_hash_chain_height").set(ledger as f64);
+}
+
+// ── Issue #609: Multi-chain / network metrics ────────────────────────────────
+
+pub fn update_network_health(chain_id: &str, healthy: bool) {
+    m::gauge!(
+        "soroban_pulse_network_healthy",
+        "chain_id" => chain_id.to_string()
+    )
+    .set(if healthy { 1.0 } else { 0.0 });
+}
+
+pub fn update_network_latest_ledger(chain_id: &str, ledger: u64) {
+    m::gauge!(
+        "soroban_pulse_network_latest_ledger",
+        "chain_id" => chain_id.to_string()
+    )
+    .set(ledger as f64);
+}
+
+pub fn record_network_indexer_error(chain_id: &str) {
+    m::counter!(
+        "soroban_pulse_network_indexer_errors_total",
+        "chain_id" => chain_id.to_string()
+    )
+    .increment(1);
+}
+
+// ── Issue #610: Compression metrics ─────────────────────────────────────────
+
+pub fn record_compression_ratio(original_bytes: usize, compressed_bytes: usize) {
+    if original_bytes > 0 {
+        let ratio = compressed_bytes as f64 / original_bytes as f64;
+        m::histogram!("soroban_pulse_compression_ratio").record(ratio);
+    }
+    m::counter!("soroban_pulse_events_compressed_total").increment(1);
+    m::counter!(
+        "soroban_pulse_compression_bytes_saved_total"
+    )
+    .increment(original_bytes.saturating_sub(compressed_bytes) as u64);
+}
+
+pub fn record_decompression_failure() {
+    m::counter!("soroban_pulse_decompression_failures_total").increment(1);
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/src/networks.rs
+++ b/src/networks.rs
@@ -1,0 +1,53 @@
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+
+#[derive(Debug, Clone, Serialize, Deserialize, sqlx::FromRow, utoipa::ToSchema)]
+pub struct Network {
+    pub chain_id: String,
+    pub display_name: String,
+    pub rpc_url: String,
+    pub passphrase: String,
+    pub is_enabled: bool,
+    pub last_ledger: Option<i64>,
+    pub health_status: String,
+}
+
+/// Return all registered networks ordered by chain_id.
+pub async fn list_networks(pool: &PgPool) -> sqlx::Result<Vec<Network>> {
+    sqlx::query_as::<_, Network>(
+        "SELECT chain_id, display_name, rpc_url, passphrase, is_enabled,
+                last_ledger, health_status
+         FROM networks
+         ORDER BY chain_id",
+    )
+    .fetch_all(pool)
+    .await
+}
+
+/// Upsert the health status and last-seen ledger for a chain.
+pub async fn update_network_health(
+    pool: &PgPool,
+    chain_id: &str,
+    healthy: bool,
+    last_ledger: Option<u64>,
+) -> sqlx::Result<()> {
+    let status = if healthy { "healthy" } else { "unhealthy" };
+    let ledger = last_ledger.map(|l| l as i64);
+    sqlx::query(
+        "UPDATE networks
+         SET health_status = $1,
+             last_ledger   = COALESCE($2, last_ledger),
+             last_seen_at  = NOW()
+         WHERE chain_id = $3",
+    )
+    .bind(status)
+    .bind(ledger)
+    .bind(chain_id)
+    .execute(pool)
+    .await?;
+    crate::metrics::update_network_health(chain_id, healthy);
+    if let Some(l) = last_ledger {
+        crate::metrics::update_network_latest_ledger(chain_id, l);
+    }
+    Ok(())
+}

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -96,6 +96,8 @@ pub struct AppState {
     pub sse_connections_per_ip: Arc<DashMap<String, usize>>,
     /// SHA-256 hex of SUPER_ADMIN_API_KEY, grants unrestricted channel access (#508).
     pub super_admin_key_hash: Option<String>,
+    /// Issue #607: In-process ABI cache (LRU-bounded, 24 h TTL by default).
+    pub abi_cache: crate::abi::AbiCache,
 }
 
 /// OpenAPI spec — all paths are documented via #[utoipa::path] on handlers.
@@ -326,6 +328,12 @@ pub fn create_router_with_tx_and_tenant_map(
         .filter(|s| !s.is_empty())
         .map(|k| crate::middleware::hash_api_key(&k));
 
+    // Issue #607: build the ABI cache from config.
+    let abi_cache = moka::future::Cache::builder()
+        .max_capacity(config.abi_cache_max_entries)
+        .time_to_live(std::time::Duration::from_secs(config.abi_cache_ttl_secs))
+        .build();
+
     let app_state = AppState {
         pool,
         read_pool,
@@ -347,6 +355,7 @@ pub fn create_router_with_tx_and_tenant_map(
         shutdown_rx,
         sse_connections_per_ip: Arc::new(DashMap::new()),
         super_admin_key_hash,
+        abi_cache,
     };
 
     // Spawn cache invalidation task: subscribe to the broadcast channel and
@@ -455,7 +464,17 @@ pub fn create_router_with_tx_and_tenant_map(
         .route("/admin/replication/status", axum::routing::get(handlers::get_replication_status))
         // #587: Feature flag management
         .route("/admin/feature-flags", axum::routing::get(handlers::list_feature_flags))
-        .route("/admin/feature-flags/audit", axum::routing::get(handlers::get_feature_flag_audit));
+        .route("/admin/feature-flags/audit", axum::routing::get(handlers::get_feature_flag_audit))
+        // Issue #609: Multi-chain networks
+        .route("/networks", axum::routing::get(handlers::list_networks))
+        // Issue #608: Ledger hash endpoints
+        .route("/ledgers/{ledger}/hash", axum::routing::get(handlers::get_ledger_hash))
+        .route("/ledgers/verify-chain", axum::routing::get(handlers::verify_ledger_hash_chain))
+        // Issue #610: Compression admin endpoints
+        .route("/admin/compression/stats", axum::routing::get(handlers::compression_stats))
+        .route("/admin/compression/migrate", axum::routing::post(handlers::start_compression_migration))
+        // Issue #607: Cached ABI endpoint
+        .route("/contracts/{contract_id}/abi/cached", axum::routing::get(handlers::get_contract_abi_cached));
 
 
     // Unversioned deprecated aliases (same handlers, add Deprecation header via middleware)


### PR DESCRIPTION


Issue closes #607 — Contract ABI caching and validation
- Add `expires_at`, `fetched_at`, `abi_hash`, `is_valid` columns to `contract_abis` via migration 20260628000001.
- Add `contract_abi_validation_log` table for schema-mismatch auditing.
- `abi.rs`: `build_abi_cache()` builds a moka LRU cache bounded at 10 000 entries with a 24 h TTL; `fetch_contract_abi()` checks the cache before querying the DB and records hit/miss metrics.
- `validate_abi()` enforces that every entry has a `name` field.
- `register_contract_abi` now validates the ABI before persisting and invalidates the in-process cache on update.
- New endpoint: `GET /v1/contracts/{contract_id}/abi/cached`.
- `AppState` gains an `abi_cache` field; cache is built from `ABI_CACHE_TTL_SECS` / `ABI_CACHE_MAX_ENTRIES` env vars.

Issue closes #608 — Ledger hash tracking and verification
- New `ledger_hashes` table (migration 20260628000002) stores one row per indexed ledger with its hash and the previous hash.
- `ledger_hashes.rs`: `store_ledger_hash`, `get_ledger_hash`, `verify_hash_chain`, `startup_hash_chain_validation`.
- Indexer stores the ledger hash after each successful event insert when `LEDGER_HASH_TRACKING_ENABLED=true`.
- Hash-chain continuity is validated over the last 1 000 ledgers on indexer startup; mismatches are logged and counted as metrics.
- New endpoints: `GET /v1/ledgers/{ledger}/hash` and `GET /v1/ledgers/verify-chain?from=&to=`.

Issue closes #609 — Multi-chain support framework
- `chain_id TEXT NOT NULL DEFAULT 'mainnet'` added to `events` table via migration 20260628000003, with indexes on `chain_id` and `(chain_id, contract_id)`.
- `networks` table stores one row per indexable Soroban network; the mainnet row is seeded by the migration.
- `networks.rs`: `list_networks()`, `update_network_health()` — used by future per-chain indexer workers.
- Indexer stamps `CHAIN_ID` (env var, default `"mainnet"`) on every inserted event.
- New endpoint: `GET /v1/networks`.
- Network health and per-chain latest-ledger Prometheus gauges.

Issue closes #610 — Event compression at rest
- New `event_data_compressed BYTEA` and `compression_algo TEXT` columns on `events` (migration 20260628000004).
- `event_compression.rs`: `compress()` / `decompress()` using `flate2` gzip; `read_event_data()` falls back gracefully.
- `migrate_existing_events()` backfills uncompressed rows in configurable batches.
- Indexer writes to `event_data_compressed` when `EVENT_COMPRESSION_ENABLED=true`.
- New admin endpoints: `GET /v1/admin/compression/stats` and `POST /v1/admin/compression/migrate`.
- Compression ratio, bytes-saved, and decompression-failure metrics.

## Summary

<!-- A clear, concise description of what this PR does. -->

## Related Issue

Closes #<!-- issue number -->

## Changes

<!-- List the key changes made. -->

- 

## Testing

<!-- Describe how you tested this. -->

- [ ] `cargo test` passes
- [ ] `cargo clippy` reports no warnings
- [ ] Manually tested locally

## Notes

<!-- Anything reviewers should pay special attention to, or N/A. -->
