### PR TITLE
feat: webhook retry queue, Prometheus monitoring, and supporting docs

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,5 +35,21 @@ services:
       retries: 5
       start_period: 30s
 
+  prometheus:
+    image: prom/prometheus:v2.52.0
+    command:
+      - "--config.file=/etc/prometheus/prometheus.yml"
+      - "--storage.tsdb.path=/prometheus"
+      - "--web.enable-lifecycle"
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - promdata:/prometheus
+    depends_on:
+      app:
+        condition: service_healthy
+
 volumes:
   pgdata:
+  promdata:

--- a/docs/contract-event-schemas.md
+++ b/docs/contract-event-schemas.md
@@ -1,0 +1,187 @@
+# Contract Event Schemas
+
+Reference for Soroban contract event patterns and their XDR representations.
+
+## Event Structure
+
+Every event emitted by a Soroban contract is captured by SorobanPulse with the following fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `contract_id` | `string` | Strkey-encoded contract address (`C…`) |
+| `event_type` | `string` | `contract`, `system`, or `diagnostic` |
+| `tx_hash` | `string` | Hex-encoded transaction hash |
+| `ledger` | `integer` | Ledger sequence number |
+| `ledger_closed_at` | `string` | RFC 3339 timestamp of ledger close |
+| `ledger_hash` | `string \| null` | Hex-encoded ledger hash (when tracked) |
+| `in_successful_call` | `boolean` | Whether the event came from a successful invocation |
+| `value` | `object` | Decoded event data (JSON) |
+| `topic` | `array \| null` | Array of XDR-encoded topic segments |
+| `tenant_id` | `string \| null` | Tenant identifier (multi-tenant deployments) |
+
+## Common Contract Event Patterns
+
+### Transfer Event
+
+Emitted by SEP-41 compliant token contracts when tokens move between accounts.
+
+**Topics:**
+```
+[Symbol("transfer"), Address(from), Address(to)]
+```
+
+**Data:**
+```json
+{
+  "amount": "1000000000",
+  "asset": "native"
+}
+```
+
+**Full example:**
+```json
+{
+  "contract_id": "CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC",
+  "event_type": "contract",
+  "tx_hash": "3389e9f0f1a65f19736cacf544c2e825313e8447f569233bb8db39aa607c8889",
+  "ledger": 5432100,
+  "ledger_closed_at": "2026-06-29T12:00:00Z",
+  "in_successful_call": true,
+  "value": {
+    "amount": "1000000000",
+    "asset": "native"
+  },
+  "topic": [
+    "AAAADwAAAAh0cmFuc2Zlcg==",
+    "AAAABQAAAAAAAAAA...",
+    "AAAABQAAAAAAAAAB..."
+  ]
+}
+```
+
+### Mint Event
+
+Emitted when new tokens are minted.
+
+**Topics:**
+```
+[Symbol("mint"), Address(admin), Address(to)]
+```
+
+**Data:**
+```json
+{
+  "amount": "500000000"
+}
+```
+
+### Burn Event
+
+Emitted when tokens are destroyed.
+
+**Topics:**
+```
+[Symbol("burn"), Address(from)]
+```
+
+**Data:**
+```json
+{
+  "amount": "250000000"
+}
+```
+
+### Approve Event
+
+Emitted when a spender allowance is set.
+
+**Topics:**
+```
+[Symbol("approve"), Address(owner), Address(spender)]
+```
+
+**Data:**
+```json
+{
+  "amount": "10000000000",
+  "expiration_ledger": 5532100
+}
+```
+
+## XDR Format
+
+Soroban contract events use XDR (External Data Representation) to encode topics and data. SorobanPulse decodes these into JSON but also exposes the raw base64-encoded XDR in the `topic` array.
+
+### ScVal Types
+
+The most common XDR `ScVal` types and their JSON equivalents:
+
+| XDR Type | JSON representation |
+|----------|---------------------|
+| `ScvSymbol` | `"string_value"` |
+| `ScvI128` | `"123456789"` (string to avoid precision loss) |
+| `ScvU128` | `"123456789"` |
+| `ScvBool` | `true` / `false` |
+| `ScvAddress` | Strkey string (`G…` or `C…`) |
+| `ScvBytes` | Base64-encoded string |
+| `ScvMap` | JSON object |
+| `ScvVec` | JSON array |
+
+### Decoding Topics Manually
+
+Topics are base64-encoded XDR `ScVal` values. To decode them:
+
+```bash
+# Decode a single topic segment
+echo "AAAADwAAAAh0cmFuc2Zlcg==" | base64 -d | xxd
+
+# Using the Stellar SDK (JavaScript)
+const xdr = StellarSdk.xdr;
+const val = xdr.ScVal.fromXDR(Buffer.from(base64Topic, 'base64'));
+console.log(val.value().toString());  // "transfer"
+```
+
+```rust
+// Using stellar-xdr crate
+use stellar_xdr::curr::{ScVal, ReadXdr};
+
+let bytes = base64::decode(topic_b64).unwrap();
+let val = ScVal::from_xdr_base64(topic_b64, stellar_xdr::curr::Limits::none()).unwrap();
+```
+
+### Topic Filtering
+
+SorobanPulse indexes `topic[0]` as `topic_0_sym` for fast equality filtering. Use the `topic_0` query parameter to filter by event name:
+
+```bash
+# Fetch all transfer events for a contract
+GET /v1/events?contract_id=C...&topic_0=transfer
+
+# Fetch all mint and burn events
+GET /v1/events?contract_id=C...&topic_0=mint
+GET /v1/events?contract_id=C...&topic_0=burn
+```
+
+## System Events
+
+System events are emitted by the Stellar network itself rather than user contracts.
+
+| `event_type` | Trigger |
+|---|---|
+| `system` | Protocol-level operations (e.g., fee bumps) |
+| `diagnostic` | Debug events emitted during contract execution |
+
+Filter out diagnostic events in most production integrations:
+```bash
+GET /v1/events?event_type=contract
+```
+
+## Event Data Size Limits
+
+- Maximum `event_data` JSON size: `MAX_EVENT_DATA_BYTES` (default 64 KiB)
+- Events exceeding this limit are logged and skipped
+- The `soroban_pulse_events_oversized_total` counter tracks skipped events
+
+## Versioning
+
+The event schema is tied to the Soroban protocol version. Breaking changes are announced in `CHANGELOG.md` and the `schema_version` column in the database tracks the protocol version in effect when each event was stored.

--- a/docs/multi-deployment-architecture.md
+++ b/docs/multi-deployment-architecture.md
@@ -1,0 +1,212 @@
+# Multi-Deployment Architecture Guide
+
+Guidance for running SorobanPulse across multiple regions or cloud providers to achieve high availability and geo-redundancy.
+
+## Overview
+
+A multi-deployment setup runs two or more SorobanPulse instances in separate failure domains (regions, availability zones, or cloud providers). Each instance maintains its own database replica, but event indexing is coordinated via an advisory lock so only one instance writes new events at a time.
+
+```
+┌──────────────────────┐      ┌──────────────────────┐
+│   Region A (Primary) │      │  Region B (Standby)  │
+│                      │      │                      │
+│  ┌────────────────┐  │      │  ┌────────────────┐  │
+│  │  SorobanPulse  │  │      │  │  SorobanPulse  │  │
+│  │  (Indexer +    │  │      │  │  (HTTP only    │  │
+│  │   HTTP)        │  │      │  │   + standby)   │  │
+│  └───────┬────────┘  │      │  └───────┬────────┘  │
+│          │           │      │          │           │
+│  ┌───────▼────────┐  │ Repl │  ┌───────▼────────┐  │
+│  │   PostgreSQL   │◄─┼──────┼──│   PostgreSQL   │  │
+│  │   (Primary)    │  │      │  │   (Replica)    │  │
+│  └────────────────┘  │      │  └────────────────┘  │
+└──────────────────────┘      └──────────────────────┘
+         ▲                              ▲
+         └──────────── DNS / LB ────────┘
+```
+
+## Geo-Redundancy Patterns
+
+### Pattern 1: Active-Passive with Streaming Replication
+
+The simplest production setup. One region is active (holds the advisory lock and indexes events); the other is passive (read-only HTTP, ready to promote).
+
+**Setup:**
+1. Configure PostgreSQL streaming replication from Region A → Region B.
+2. Deploy SorobanPulse in both regions with identical configuration.
+3. Both instances connect to their local database. Region B connects to the replica in read-only mode.
+4. Region A wins the advisory lock on startup; Region B serves HTTP from the replica.
+
+**Failover:** When Region A becomes unavailable, promote the Region B replica and restart its SorobanPulse instance. It will acquire the advisory lock and begin indexing.
+
+### Pattern 2: Active-Active with Read Distribution
+
+Both regions serve HTTP traffic. Indexing remains in one region (lock holder), but read queries are distributed across both replicas via a load balancer.
+
+**Setup:**
+1. Configure streaming replication as above.
+2. Deploy SorobanPulse in both regions.
+3. Place a global load balancer (AWS Route 53, Cloudflare, GCP GLB) in front of both regions.
+4. Use health checks to route write-path traffic only to the primary region.
+
+**Trade-offs:**
+- Reads are distributed, improving throughput.
+- Replication lag can cause stale reads on the replica. Use `PGRST_DB_USE_LEGACY_GUCS=false` and `SET TRANSACTION READ ONLY` if consistency is critical.
+
+### Pattern 3: Multi-Cloud Active-Passive
+
+Same as Pattern 1 but across different cloud providers (e.g., AWS + GCP) for maximum blast-radius isolation.
+
+**Considerations:**
+- Cross-cloud replication incurs egress costs and higher latency (~20–50 ms typical).
+- Use a VPN or dedicated interconnect (AWS Direct Connect / GCP Interconnect) for the replication channel.
+- Certificate pinning and mutual TLS between the replication endpoints is strongly recommended.
+
+## Failover Documentation
+
+### Automated Failover (Patroni / pg_auto_failover)
+
+For production deployments, manage promotion automatically with a tool like [Patroni](https://patroni.readthedocs.io/) or [pg_auto_failover](https://pg-auto-failover.readthedocs.io/).
+
+```yaml
+# Example Patroni config snippet
+bootstrap:
+  dcs:
+    ttl: 30
+    loop_wait: 10
+    retry_timeout: 10
+    maximum_lag_on_failover: 1048576  # 1 MB
+```
+
+When Patroni promotes the replica, SorobanPulse's database connection pool will see a connection error, reconnect, and re-attempt the advisory lock. The first instance to reconnect to the new primary will acquire the lock and resume indexing.
+
+### Manual Failover Procedure
+
+1. **Confirm primary is down:**
+   ```bash
+   psql $DATABASE_URL_REGION_A -c "SELECT 1"
+   ```
+
+2. **Promote the replica:**
+   ```bash
+   # On the Region B PostgreSQL host
+   pg_ctl promote -D /var/lib/postgresql/data
+   # Or for managed databases:
+   aws rds failover-db-cluster --db-cluster-identifier soroban-pulse
+   ```
+
+3. **Update `DATABASE_URL` in Region B** to point to the now-promoted instance.
+
+4. **Restart the Region B SorobanPulse instance.** It will acquire the advisory lock and start indexing from the last checkpoint stored in `indexer_checkpoints`.
+
+5. **Verify recovery:**
+   ```bash
+   curl https://region-b.pulse.example.com/healthz/ready
+   curl https://region-b.pulse.example.com/v1/metrics | grep soroban_pulse_indexer_lag
+   ```
+
+6. **Update DNS** (if not managed automatically) to point traffic to Region B.
+
+### Recovery Time Objectives
+
+| Scenario | RTO (manual) | RTO (automated) |
+|---|---|---|
+| App process crash | < 30 s (restart) | < 10 s (Kubernetes) |
+| Single AZ outage | 5–10 min | 1–2 min (Patroni) |
+| Full region outage | 10–20 min | 2–5 min |
+| Cloud provider outage | 20–60 min | 10–15 min |
+
+## Cross-Region Sync
+
+### Database Replication
+
+SorobanPulse relies on standard PostgreSQL logical or physical replication. Physical (streaming) replication is recommended for most deployments:
+
+```sql
+-- On the primary, create a replication slot
+SELECT pg_create_physical_replication_slot('region_b_slot');
+
+-- On the replica, set recovery.conf / postgresql.auto.conf
+primary_conninfo = 'host=db-primary.region-a.internal port=5432 user=replicator password=...'
+primary_slot_name = 'region_b_slot'
+```
+
+**Replication lag monitoring:** The `soroban_pulse_indexer_lag` metric tracks how far behind the indexer is from the chain tip. A separate lag metric from the replica itself (`pg_wal_lsn_diff`) should be monitored via the Prometheus job scraping the replica's `pg_stat_replication`.
+
+### Configuration Sync
+
+Sync these configuration items across regions:
+
+| Item | Sync method |
+|---|---|
+| `API_KEY` / `ADMIN_API_KEY` | Secret manager (AWS Secrets Manager, GCP Secret Manager) |
+| `WEBHOOK_SECRET` | Secret manager |
+| `EVENT_DATA_ENCRYPTION_KEY` | Secret manager — **must be identical across regions** |
+| `config.toml` | Git (deploy via CI/CD) |
+| Notification channel config | Stored in the database; replicated automatically |
+
+### Subscription and Webhook Consistency
+
+Subscriptions and webhook channel registrations are stored in the PostgreSQL database and replicated to all standby nodes. When failing over:
+
+- Active SSE connections to the failed region will drop and clients will reconnect (standard EventSource retry).
+- Webhook deliveries in-flight at the time of failure will be retried from the `webhook_retry_queue` table, which is replicated and becomes writable on the new primary.
+- No manual intervention is required for subscriptions.
+
+## Kubernetes Multi-Region Deployment
+
+```yaml
+# Region A deployment (indexer + HTTP)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: soroban-pulse
+  namespace: soroban-pulse
+spec:
+  replicas: 2
+  template:
+    spec:
+      containers:
+      - name: soroban-pulse
+        image: soroban-pulse:latest
+        env:
+        - name: DATABASE_URL
+          valueFrom:
+            secretKeyRef:
+              name: soroban-pulse-secrets
+              key: database-url-region-a
+        - name: STELLAR_RPC_URL
+          value: "https://soroban-mainnet.stellar.org"
+```
+
+```yaml
+# Region B deployment (HTTP-only standby)
+# Same spec but DATABASE_URL points to the read replica.
+# When Region A fails, update DATABASE_URL to the promoted primary and scale replicas.
+```
+
+## Health Checks and Observability
+
+Both regions should scrape the same Prometheus metrics. Use an alert to detect replication lag exceeding a threshold:
+
+```yaml
+# docs/alerts.yml addition
+- alert: ReplicationLagHigh
+  expr: pg_replication_lag_seconds > 30
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: "PostgreSQL replication lag is {{ $value }}s"
+```
+
+Monitor cross-region readiness with:
+```bash
+# Check both regions are healthy
+curl https://region-a.pulse.example.com/healthz/ready
+curl https://region-b.pulse.example.com/healthz/ready
+
+# Confirm only one region is actively indexing
+curl https://region-a.pulse.example.com/v1/metrics | grep soroban_pulse_indexer_is_leader
+curl https://region-b.pulse.example.com/v1/metrics | grep soroban_pulse_indexer_is_leader
+```

--- a/migrations/20260629000001_webhook_retry_queue.down.sql
+++ b/migrations/20260629000001_webhook_retry_queue.down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS webhook_retry_queue;

--- a/migrations/20260629000001_webhook_retry_queue.sql
+++ b/migrations/20260629000001_webhook_retry_queue.sql
@@ -1,0 +1,21 @@
+CREATE TABLE IF NOT EXISTS webhook_retry_queue (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    url TEXT NOT NULL,
+    payload JSONB NOT NULL,
+    secret_hash TEXT,
+    attempt INT NOT NULL DEFAULT 0,
+    max_attempts INT NOT NULL DEFAULT 5,
+    next_retry_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_error TEXT,
+    status TEXT NOT NULL DEFAULT 'pending'
+        CHECK (status IN ('pending', 'processing', 'succeeded', 'failed')),
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_webhook_retry_queue_status_next_retry
+    ON webhook_retry_queue (status, next_retry_at)
+    WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_webhook_retry_queue_created_at
+    ON webhook_retry_queue (created_at DESC);

--- a/src/retry_policy.rs
+++ b/src/retry_policy.rs
@@ -25,10 +25,10 @@ impl Default for RetryPolicy {
 impl RetryPolicy {
     pub fn webhook_default() -> Self {
         Self {
-            max_attempts: 3,
+            max_attempts: 5,
             initial_backoff_ms: 1000,
             backoff_multiplier: 2.0,
-            max_backoff_ms: 8000,
+            max_backoff_ms: 600_000,
         }
     }
 


### PR DESCRIPTION
## Summary

- **Webhook retry queue**: adds `webhook_retry_queue` migration with `pending / processing / succeeded / failed` status tracking, a composite index on `(status, next_retry_at)` for efficient polling, and a descending `created_at` index for auditing. Includes a `down` migration for rollback.
- **RetryPolicy hardening**: bumps `max_attempts` from 3 → 5 and `max_backoff_ms` from 8 s → 600 s (10 min) to align with the durable retry queue semantics.
- **Prometheus**: adds a `prometheus` service to `docker-compose.yml` with a persistent `promdata` volume, lifecycle reload enabled, and a health-gate on the `app` service.
- **Docs**: adds `docs/contract-event-schemas.md` (XDR field reference + common event patterns) and `docs/multi-deployment-architecture.md` (active-passive geo-redundancy guide with ASCII topology diagram).

## Test plan

- [ ] Run `docker compose up` and confirm Prometheus is reachable at `http://localhost:9090`
- [ ] Apply migration: `sqlx migrate run` — verify `webhook_retry_queue` table and indexes exist
- [ ] Roll back: `sqlx migrate revert` — verify table is dropped cleanly
- [ ] Confirm `RetryPolicy::webhook_default()` returns `max_attempts = 5` and `max_backoff_ms = 600_000` in unit tests
- [ ] Review docs render correctly on GitHub

closes #603 closes #602 closes #606  closes #599