### PR TITLE
feat: implement schema validation, anonymization pipeline, dedup, and…

### DIFF
--- a/migrations/20260630000002_schema_versioning_and_metrics.sql
+++ b/migrations/20260630000002_schema_versioning_and_metrics.sql
@@ -1,0 +1,37 @@
+-- Issue #617: Schema versioning for contract_schemas table
+-- Adds a version counter that increments on each update, allowing clients to
+-- detect stale cached schemas and replay validation failures by version.
+
+ALTER TABLE contract_schemas
+    ADD COLUMN IF NOT EXISTS version INTEGER NOT NULL DEFAULT 1,
+    ADD COLUMN IF NOT EXISTS description TEXT;
+
+-- Bump version automatically on every UPDATE
+CREATE OR REPLACE FUNCTION increment_schema_version()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.version := OLD.version + 1;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_schema_version ON contract_schemas;
+CREATE TRIGGER trg_schema_version
+    BEFORE UPDATE ON contract_schemas
+    FOR EACH ROW EXECUTE FUNCTION increment_schema_version();
+
+-- Index for listing schemas by version (useful for sync/audit)
+CREATE INDEX IF NOT EXISTS idx_contract_schemas_version ON contract_schemas(version);
+
+-- schema_validation_metrics: aggregated pass/fail counters per contract
+-- Updated by the application layer; provides a persistent audit trail
+-- independent of the Prometheus in-process counters (which reset on restart).
+CREATE TABLE IF NOT EXISTS schema_validation_metrics (
+    contract_id  TEXT PRIMARY KEY REFERENCES contract_schemas(contract_id) ON DELETE CASCADE,
+    pass_count   BIGINT NOT NULL DEFAULT 0,
+    fail_count   BIGINT NOT NULL DEFAULT 0,
+    last_checked TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE schema_validation_metrics IS
+    'Persistent pass/fail counters for JSON Schema validation per contract (issue #617).';

--- a/migrations/20260630000003_anonymization_rules.sql
+++ b/migrations/20260630000003_anonymization_rules.sql
@@ -1,0 +1,40 @@
+-- Issue #618: Anonymization rules configuration table.
+-- Stores regex-based PII detection patterns and their replacements.
+-- When empty, the application falls back to built-in default patterns.
+
+CREATE TABLE IF NOT EXISTS anonymization_rules (
+    id          SERIAL PRIMARY KEY,
+    name        TEXT NOT NULL UNIQUE,
+    pattern     TEXT NOT NULL,
+    replacement TEXT NOT NULL DEFAULT '[REDACTED]',
+    enabled     BOOLEAN NOT NULL DEFAULT TRUE,
+    description TEXT,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMENT ON TABLE anonymization_rules IS
+    'Regex-based PII anonymization rules for event data (issue #618).';
+
+COMMENT ON COLUMN anonymization_rules.pattern IS
+    'POSIX/PCRE regex pattern matched against string values in event_data JSON.';
+
+COMMENT ON COLUMN anonymization_rules.replacement IS
+    'Replacement string — may include $1 capture-group references.';
+
+-- Pre-populate with the same built-in patterns the Rust module uses,
+-- so operators can see and override them via the /v1/config/anonymization API.
+INSERT INTO anonymization_rules (name, pattern, replacement, description) VALUES
+    ('email',       '[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}',
+                    '[REDACTED:email]',     'Email addresses'),
+    ('phone',       '\+?[0-9]{7,15}',
+                    '[REDACTED:phone]',     'Phone numbers (7–15 digits, optional leading +)'),
+    ('ssn',         '\b\d{3}-\d{2}-\d{4}\b',
+                    '[REDACTED:ssn]',       'US Social Security Numbers'),
+    ('ipv4',        '\b(?:\d{1,3}\.){3}\d{1,3}\b',
+                    '[REDACTED:ipv4]',      'IPv4 addresses'),
+    ('credit_card', '\b(?:\d[ \-]?){13,16}\b',
+                    '[REDACTED:credit_card]', 'Credit / debit card numbers')
+ON CONFLICT (name) DO NOTHING;
+
+CREATE INDEX IF NOT EXISTS idx_anonymization_rules_enabled ON anonymization_rules(enabled);

--- a/src/anonymization.rs
+++ b/src/anonymization.rs
@@ -1,0 +1,589 @@
+//! Issue #618: Event data anonymization pipeline for privacy-sensitive deployments.
+//!
+//! ## Overview
+//!
+//! This module provides:
+//! - **Anonymization rules** — regex-based patterns that identify PII fields.
+//! - **PII detection** — scans event_data JSON trees for values matching any rule.
+//! - **Anonymization** — replaces matched values with a redacted placeholder.
+//! - **Anonymization worker** — background task that processes un-anonymized events.
+//! - **Audit trail** — every anonymization action is recorded in `audit_logs`.
+//! - **Metrics** — Prometheus counters for detections and applied redactions.
+//!
+//! ## Anonymization patterns
+//!
+//! | Pattern name | Regex                                         | Example match         |
+//! |-------------|-----------------------------------------------|-----------------------|
+//! | `email`     | `[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}` | `user@example.com`   |
+//! | `phone`     | `\+?[0-9]{7,15}`                              | `+14155552671`        |
+//! | `ssn`       | `\b\d{3}-\d{2}-\d{4}\b`                       | `123-45-6789`         |
+//! | `ipv4`      | `\b(?:\d{1,3}\.){3}\d{1,3}\b`                 | `192.168.1.1`         |
+//! | `credit_card` | `\b(?:\d[ -]?){13,16}\b`                   | `4111 1111 1111 1111` |
+
+use regex::Regex;
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+use sqlx::PgPool;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tracing::{debug, info, warn};
+use uuid::Uuid;
+
+use crate::metrics;
+
+// ── Anonymization rule model ─────────────────────────────────────────────────
+
+/// A single anonymization rule: a named regex pattern applied to string values.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AnonymizationRule {
+    pub id: Option<i32>,
+    pub name: String,
+    pub pattern: String,
+    pub replacement: String,
+    pub enabled: bool,
+    pub description: Option<String>,
+}
+
+impl AnonymizationRule {
+    /// Compile the rule's pattern into a `Regex`.
+    pub fn compile(&self) -> Result<Regex, regex::Error> {
+        Regex::new(&self.pattern)
+    }
+}
+
+/// Request body for creating/updating a rule via the API.
+#[derive(Debug, Deserialize, Serialize)]
+pub struct AnonymizationRuleRequest {
+    pub name: String,
+    pub pattern: String,
+    pub replacement: Option<String>,
+    pub enabled: Option<bool>,
+    pub description: Option<String>,
+}
+
+// ── Built-in default patterns ────────────────────────────────────────────────
+
+/// Return the built-in PII detection rules used when no custom rules are configured.
+pub fn default_rules() -> Vec<AnonymizationRule> {
+    vec![
+        AnonymizationRule {
+            id: None,
+            name: "email".into(),
+            pattern: r"[a-zA-Z0-9._%+\-]+@[a-zA-Z0-9.\-]+\.[a-zA-Z]{2,}".into(),
+            replacement: "[REDACTED:email]".into(),
+            enabled: true,
+            description: Some("Email addresses".into()),
+        },
+        AnonymizationRule {
+            id: None,
+            name: "phone".into(),
+            pattern: r"\+?[0-9]{7,15}".into(),
+            replacement: "[REDACTED:phone]".into(),
+            enabled: true,
+            description: Some("Phone numbers (7–15 digits, optional leading +)".into()),
+        },
+        AnonymizationRule {
+            id: None,
+            name: "ssn".into(),
+            pattern: r"\b\d{3}-\d{2}-\d{4}\b".into(),
+            replacement: "[REDACTED:ssn]".into(),
+            enabled: true,
+            description: Some("US Social Security Numbers".into()),
+        },
+        AnonymizationRule {
+            id: None,
+            name: "ipv4".into(),
+            pattern: r"\b(?:\d{1,3}\.){3}\d{1,3}\b".into(),
+            replacement: "[REDACTED:ipv4]".into(),
+            enabled: true,
+            description: Some("IPv4 addresses".into()),
+        },
+        AnonymizationRule {
+            id: None,
+            name: "credit_card".into(),
+            pattern: r"\b(?:\d[ \-]?){13,16}\b".into(),
+            replacement: "[REDACTED:credit_card]".into(),
+            enabled: true,
+            description: Some("Credit / debit card numbers".into()),
+        },
+    ]
+}
+
+// ── PII scanner ──────────────────────────────────────────────────────────────
+
+/// Result of scanning a single JSON value for PII.
+#[derive(Debug)]
+pub struct PiiScanResult {
+    /// Field path(s) where PII was detected (dot-separated JSON path).
+    pub detections: Vec<PiiDetection>,
+}
+
+#[derive(Debug)]
+pub struct PiiDetection {
+    pub field_path: String,
+    pub rule_name: String,
+}
+
+/// Recursively walk a JSON value and detect PII string matches.
+pub fn scan_for_pii(value: &Value, rules: &[(String, Regex)]) -> PiiScanResult {
+    let mut detections = Vec::new();
+    scan_recursive(value, "", rules, &mut detections);
+    PiiScanResult { detections }
+}
+
+fn scan_recursive(
+    value: &Value,
+    path: &str,
+    rules: &[(String, Regex)],
+    out: &mut Vec<PiiDetection>,
+) {
+    match value {
+        Value::String(s) => {
+            for (name, re) in rules {
+                if re.is_match(s) {
+                    metrics::record_pii_detected(name);
+                    out.push(PiiDetection {
+                        field_path: path.to_string(),
+                        rule_name: name.clone(),
+                    });
+                }
+            }
+        }
+        Value::Object(map) => {
+            for (k, v) in map {
+                let child_path = if path.is_empty() {
+                    k.clone()
+                } else {
+                    format!("{path}.{k}")
+                };
+                scan_recursive(v, &child_path, rules, out);
+            }
+        }
+        Value::Array(arr) => {
+            for (i, v) in arr.iter().enumerate() {
+                let child_path = format!("{path}[{i}]");
+                scan_recursive(v, &child_path, rules, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+// ── Anonymizer ────────────────────────────────────────────────────────────────
+
+/// Apply anonymization rules to a JSON value, replacing PII strings in-place.
+///
+/// Returns the mutated value and the list of rules that were applied.
+pub fn anonymize_value(value: Value, rules: &[(String, Regex, String)]) -> (Value, Vec<String>) {
+    let mut applied = Vec::new();
+    let result = anonymize_recursive(value, rules, &mut applied);
+    (result, applied)
+}
+
+fn anonymize_recursive(
+    value: Value,
+    rules: &[(String, Regex, String)],
+    applied: &mut Vec<String>,
+) -> Value {
+    match value {
+        Value::String(s) => {
+            let mut current = s;
+            for (name, re, replacement) in rules {
+                if re.is_match(&current) {
+                    let replaced = re.replace_all(&current, replacement.as_str()).to_string();
+                    if replaced != current {
+                        if !applied.contains(name) {
+                            applied.push(name.clone());
+                        }
+                        current = replaced;
+                    }
+                }
+            }
+            Value::String(current)
+        }
+        Value::Object(map) => {
+            let new_map = map
+                .into_iter()
+                .map(|(k, v)| (k, anonymize_recursive(v, rules, applied)))
+                .collect();
+            Value::Object(new_map)
+        }
+        Value::Array(arr) => {
+            Value::Array(
+                arr.into_iter()
+                    .map(|v| anonymize_recursive(v, rules, applied))
+                    .collect(),
+            )
+        }
+        other => other,
+    }
+}
+
+// ── Configuration manager ─────────────────────────────────────────────────────
+
+/// Manages anonymization rules loaded from the database with an in-memory cache.
+#[derive(Clone)]
+pub struct AnonymizationConfig {
+    pool: PgPool,
+    rules: Arc<RwLock<Vec<AnonymizationRule>>>,
+}
+
+impl AnonymizationConfig {
+    pub fn new(pool: PgPool) -> Self {
+        Self {
+            pool,
+            rules: Arc::new(RwLock::new(default_rules())),
+        }
+    }
+
+    /// Load rules from the `anonymization_rules` table, falling back to defaults if empty.
+    pub async fn load(&self) -> Result<(), sqlx::Error> {
+        let rows = sqlx::query_as::<_, (i32, String, String, String, bool, Option<String>)>(
+            "SELECT id, name, pattern, replacement, enabled, description \
+             FROM anonymization_rules ORDER BY id",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        if rows.is_empty() {
+            debug!("No anonymization rules found in DB, using built-in defaults");
+            return Ok(());
+        }
+
+        let rules: Vec<AnonymizationRule> = rows
+            .into_iter()
+            .map(|(id, name, pattern, replacement, enabled, description)| AnonymizationRule {
+                id: Some(id),
+                name,
+                pattern,
+                replacement,
+                enabled,
+                description,
+            })
+            .collect();
+
+        *self.rules.write().await = rules;
+        Ok(())
+    }
+
+    /// Upsert a rule in the database and refresh the cache.
+    pub async fn upsert_rule(&self, req: &AnonymizationRuleRequest) -> Result<AnonymizationRule, anyhow::Error> {
+        // Validate the regex compiles
+        Regex::new(&req.pattern)
+            .map_err(|e| anyhow::anyhow!("Invalid regex pattern: {}", e))?;
+
+        let replacement = req.replacement.clone().unwrap_or_else(|| "[REDACTED]".into());
+        let enabled = req.enabled.unwrap_or(true);
+
+        let row = sqlx::query_as::<_, (i32, String, String, String, bool, Option<String>)>(
+            r#"
+            INSERT INTO anonymization_rules (name, pattern, replacement, enabled, description)
+            VALUES ($1, $2, $3, $4, $5)
+            ON CONFLICT (name) DO UPDATE
+                SET pattern = EXCLUDED.pattern,
+                    replacement = EXCLUDED.replacement,
+                    enabled = EXCLUDED.enabled,
+                    description = COALESCE(EXCLUDED.description, anonymization_rules.description),
+                    updated_at = NOW()
+            RETURNING id, name, pattern, replacement, enabled, description
+            "#,
+        )
+        .bind(&req.name)
+        .bind(&req.pattern)
+        .bind(&replacement)
+        .bind(enabled)
+        .bind(&req.description)
+        .fetch_one(&self.pool)
+        .await?;
+
+        let rule = AnonymizationRule {
+            id: Some(row.0),
+            name: row.1,
+            pattern: row.2,
+            replacement: row.3,
+            enabled: row.4,
+            description: row.5,
+        };
+
+        // Refresh cache
+        self.load().await.map_err(|e| anyhow::anyhow!("{}", e))?;
+        Ok(rule)
+    }
+
+    /// Delete a rule by name.
+    pub async fn delete_rule(&self, name: &str) -> Result<bool, sqlx::Error> {
+        let result = sqlx::query("DELETE FROM anonymization_rules WHERE name = $1")
+            .bind(name)
+            .execute(&self.pool)
+            .await?;
+        if result.rows_affected() > 0 {
+            self.load().await?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    /// Get current rules (cloned snapshot).
+    pub async fn get_rules(&self) -> Vec<AnonymizationRule> {
+        self.rules.read().await.clone()
+    }
+
+    /// Compile all enabled rules into (name, regex, replacement) triples.
+    pub async fn compile_rules(&self) -> Vec<(String, Regex, String)> {
+        self.rules
+            .read()
+            .await
+            .iter()
+            .filter(|r| r.enabled)
+            .filter_map(|r| {
+                Regex::new(&r.pattern)
+                    .ok()
+                    .map(|re| (r.name.clone(), re, r.replacement.clone()))
+            })
+            .collect()
+    }
+
+    /// Compile all enabled rules into (name, regex) pairs for detection only.
+    pub async fn compile_detection_rules(&self) -> Vec<(String, Regex)> {
+        self.rules
+            .read()
+            .await
+            .iter()
+            .filter(|r| r.enabled)
+            .filter_map(|r| Regex::new(&r.pattern).ok().map(|re| (r.name.clone(), re)))
+            .collect()
+    }
+}
+
+// ── Audit logging ─────────────────────────────────────────────────────────────
+
+/// Record an anonymization action in the audit_logs table.
+pub async fn audit_anonymization(
+    pool: &PgPool,
+    event_id: &str,
+    applied_rules: &[String],
+    actor: &str,
+) -> Result<(), sqlx::Error> {
+    let changes = serde_json::json!({
+        "applied_rules": applied_rules,
+    });
+
+    sqlx::query(
+        "INSERT INTO audit_logs \
+             (event_type, action, resource_type, resource_id, created_by, changes, severity) \
+         VALUES ('ANONYMIZE', 'anonymize_event', 'event', $1, $2, $3, 'INFO')",
+    )
+    .bind(event_id)
+    .bind(actor)
+    .bind(&changes)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+// ── Background worker ─────────────────────────────────────────────────────────
+
+/// Background worker that scans un-anonymized events and redacts PII.
+///
+/// Runs in a loop, processing up to `batch_size` events per tick.
+/// Stops when the shutdown signal fires.
+pub async fn run_anonymization_worker(
+    pool: PgPool,
+    config: AnonymizationConfig,
+    batch_size: i64,
+    interval: std::time::Duration,
+    mut shutdown_rx: tokio::sync::watch::Receiver<bool>,
+) {
+    info!("Anonymization worker started (batch_size={batch_size})");
+    let mut ticker = tokio::time::interval(interval);
+
+    loop {
+        tokio::select! {
+            _ = ticker.tick() => {
+                match process_batch(&pool, &config, batch_size).await {
+                    Ok(processed) if processed > 0 => {
+                        info!(processed = processed, "Anonymization worker: batch complete");
+                    }
+                    Ok(_) => {}
+                    Err(e) => {
+                        warn!(error = %e, "Anonymization worker: batch error");
+                    }
+                }
+            }
+            _ = shutdown_rx.changed() => {
+                if *shutdown_rx.borrow() {
+                    info!("Anonymization worker shutting down");
+                    break;
+                }
+            }
+        }
+    }
+}
+
+async fn process_batch(
+    pool: &PgPool,
+    config: &AnonymizationConfig,
+    batch_size: i64,
+) -> Result<u64, anyhow::Error> {
+    let detection_rules = config.compile_detection_rules().await;
+    if detection_rules.is_empty() {
+        return Ok(0);
+    }
+
+    // Fetch a batch of non-anonymized events
+    let rows: Vec<(Uuid, serde_json::Value)> = sqlx::query_as(
+        "SELECT id, event_data FROM events \
+         WHERE anonymized = FALSE \
+         ORDER BY created_at ASC \
+         LIMIT $1",
+    )
+    .bind(batch_size)
+    .fetch_all(pool)
+    .await?;
+
+    if rows.is_empty() {
+        return Ok(0);
+    }
+
+    let compile_rules = config.compile_rules().await;
+    let mut total_anonymized: u64 = 0;
+
+    for (id, event_data) in rows {
+        let scan = scan_for_pii(&event_data, &detection_rules);
+        if scan.detections.is_empty() {
+            continue;
+        }
+
+        let (redacted, applied) = anonymize_value(event_data, &compile_rules);
+
+        if !applied.is_empty() {
+            sqlx::query(
+                "UPDATE events SET event_data = $1, anonymized = TRUE WHERE id = $2",
+            )
+            .bind(&redacted)
+            .bind(id)
+            .execute(pool)
+            .await?;
+
+            // Audit trail
+            if let Err(e) = audit_anonymization(pool, &id.to_string(), &applied, "worker").await {
+                warn!(event_id = %id, error = %e, "Failed to write anonymization audit log");
+            }
+
+            for rule_name in &applied {
+                metrics::record_anonymization_applied(rule_name);
+            }
+
+            total_anonymized += 1;
+        }
+    }
+
+    Ok(total_anonymized)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn compile(rules: Vec<AnonymizationRule>) -> Vec<(String, Regex, String)> {
+        rules
+            .iter()
+            .filter(|r| r.enabled)
+            .filter_map(|r| {
+                Regex::new(&r.pattern)
+                    .ok()
+                    .map(|re| (r.name.clone(), re, r.replacement.clone()))
+            })
+            .collect()
+    }
+
+    fn detect(rules: &[(String, Regex, String)]) -> Vec<(String, Regex)> {
+        rules
+            .iter()
+            .map(|(n, re, _)| (n.clone(), re.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn detects_email_in_string_value() {
+        let rules = compile(default_rules());
+        let detect_rules = detect(&rules);
+        let v = json!({"contact": "user@example.com"});
+        let result = scan_for_pii(&v, &detect_rules);
+        assert!(!result.detections.is_empty());
+        assert_eq!(result.detections[0].rule_name, "email");
+        assert_eq!(result.detections[0].field_path, "contact");
+    }
+
+    #[test]
+    fn no_pii_returns_empty_detections() {
+        let rules = compile(default_rules());
+        let detect_rules = detect(&rules);
+        let v = json!({"amount": 42, "token": "USDC"});
+        let result = scan_for_pii(&v, &detect_rules);
+        assert!(result.detections.is_empty());
+    }
+
+    #[test]
+    fn anonymize_replaces_email() {
+        let rules = compile(default_rules());
+        let v = json!({"email": "alice@example.com"});
+        let (out, applied) = anonymize_value(v, &rules);
+        assert_eq!(out["email"], "[REDACTED:email]");
+        assert!(applied.contains(&"email".to_string()));
+    }
+
+    #[test]
+    fn anonymize_nested_value() {
+        let rules = compile(default_rules());
+        let v = json!({"user": {"contact": "bob@test.org", "amount": 100}});
+        let (out, applied) = anonymize_value(v, &rules);
+        assert_eq!(out["user"]["contact"], "[REDACTED:email]");
+        assert_eq!(out["user"]["amount"], 100);
+        assert!(applied.contains(&"email".to_string()));
+    }
+
+    #[test]
+    fn anonymize_array_value() {
+        let rules = compile(default_rules());
+        let v = json!({"contacts": ["alice@a.com", "not-an-email"]});
+        let (out, applied) = anonymize_value(v, &rules);
+        assert_eq!(out["contacts"][0], "[REDACTED:email]");
+        assert_eq!(out["contacts"][1], "not-an-email");
+        assert!(applied.contains(&"email".to_string()));
+    }
+
+    #[test]
+    fn non_pii_value_unchanged() {
+        let rules = compile(default_rules());
+        let v = json!({"tx": "abc123", "amount": 999});
+        let (out, applied) = anonymize_value(v, &rules);
+        assert_eq!(out["tx"], "abc123");
+        assert!(applied.is_empty());
+    }
+
+    #[test]
+    fn default_rules_all_enabled() {
+        let rules = default_rules();
+        assert!(rules.iter().all(|r| r.enabled));
+    }
+
+    #[test]
+    fn default_rules_compile_ok() {
+        for rule in default_rules() {
+            rule.compile().expect(&format!("Rule '{}' pattern should compile", rule.name));
+        }
+    }
+
+    #[test]
+    fn scan_detects_ssn() {
+        let rules = compile(default_rules());
+        let detect_rules = detect(&rules);
+        let v = json!({"id": "123-45-6789"});
+        let result = scan_for_pii(&v, &detect_rules);
+        assert!(result.detections.iter().any(|d| d.rule_name == "ssn"));
+    }
+}

--- a/src/bloom_filter.rs
+++ b/src/bloom_filter.rs
@@ -1,9 +1,19 @@
 //! Issue #266: Bloom filter deduplication pre-filter.
+//! Issue #615: Session-level Bloom filter for per-RPC-poll deduplication with ledger-reset.
 //!
 //! Stores hashes of `(tx_hash, contract_id, event_type)` tuples to skip
 //! database inserts for events that are very likely already indexed.
 //! False positives cause a missed insert (the DB unique constraint is the
 //! authoritative guard); false negatives are impossible by design.
+//!
+//! ## Deduplication layers
+//!
+//! 1. **Session Bloom filter** (`SessionBloomFilter`): reset every time a new ledger is
+//!    detected. Catches duplicates within a single RPC poll session — e.g. overlapping
+//!    cursors returning the same event twice in the same batch.
+//! 2. **Persistent Bloom filter** (`EventBloomFilter`): seeded from recent DB rows at
+//!    startup; survives across poll cycles. Catches events already persisted to the DB.
+//! 3. **DB `ON CONFLICT DO NOTHING`**: the authoritative guard for all cases.
 
 use bloomfilter::Bloom;
 use std::sync::Mutex;
@@ -11,6 +21,61 @@ use std::time::{SystemTime, UNIX_EPOCH};
 use std::collections::HashSet;
 
 use crate::metrics;
+
+// ── Issue #615: Session-level Bloom filter ───────────────────────────────────
+
+/// A per-poll-session Bloom filter that resets when a new ledger sequence is detected.
+///
+/// Unlike `EventBloomFilter` (which is long-lived and seeded from the DB), this filter
+/// is scoped to a single indexer poll cycle. It is reset on every new ledger, so its
+/// memory footprint is bounded by the number of events in one ledger.
+pub struct SessionBloomFilter {
+    inner: Mutex<Bloom<String>>,
+    /// The ledger sequence at which the filter was last reset.
+    current_ledger: Mutex<u64>,
+    capacity: usize,
+    fp_rate: f64,
+}
+
+impl SessionBloomFilter {
+    /// Create a session filter sized for `capacity` events per ledger.
+    pub fn new(capacity: usize, fp_rate: f64) -> Self {
+        let bloom = Bloom::new_for_fp_rate(capacity, fp_rate)
+            .expect("Failed to create session bloom filter");
+        Self {
+            inner: Mutex::new(bloom),
+            current_ledger: Mutex::new(0),
+            capacity,
+            fp_rate,
+        }
+    }
+
+    /// Check whether this event was already seen in the current session.
+    ///
+    /// Automatically resets the filter when `ledger` advances beyond the last-seen ledger,
+    /// then records the event. Returns `true` (duplicate) only when the same ledger is active.
+    pub fn check_and_set(&self, tx_hash: &str, contract_id: &str, event_type: &str, ledger: u64) -> bool {
+        let key = format!("{tx_hash}:{contract_id}:{event_type}");
+
+        let mut current = self.current_ledger.lock().expect("session bloom ledger lock poisoned");
+        if ledger > *current {
+            // New ledger detected — reset the filter.
+            let new_bloom = Bloom::new_for_fp_rate(self.capacity, self.fp_rate)
+                .expect("Failed to recreate session bloom filter");
+            *self.inner.lock().expect("session bloom inner lock poisoned") = new_bloom;
+            *current = ledger;
+            metrics::record_session_bloom_reset();
+        }
+
+        let mut guard = self.inner.lock().expect("session bloom inner lock poisoned");
+        if guard.check(&key) {
+            metrics::record_session_bloom_hit();
+            return true;
+        }
+        guard.set(&key);
+        false
+    }
+}
 
 /// Thread-safe bloom filter for event deduplication.
 pub struct EventBloomFilter {
@@ -184,27 +249,24 @@ pub async fn restore_state(
 
     match row {
         Some((capacity, fp_rate, bitmap_bytes)) => {
-            let mut bloom = Bloom::new_for_fp_rate(capacity as usize, fp_rate)
+            let bloom = Bloom::new_for_fp_rate(capacity as usize, fp_rate)
                 .expect("Failed to create bloom filter from persisted state");
+
+            // Bitmap restoration is deferred to DB re-seeding; the persisted state
+            // is used only to restore capacity/fp_rate parameters.
+            let _ = &bitmap_bytes;
             
-            // Restore bitmap
-            let bitmap_u8: Vec<u8> = bitmap_bytes.iter().map(|&b| b as u8).collect();
-            for (i, &byte) in bitmap_u8.iter().enumerate() {
-                if byte != 0 {
-                    // Reconstruct bitmap by setting bits
-                    for bit in 0..8 {
-                        if (byte & (1 << bit)) != 0 {
-                            // This is a simplified approach; ideally we'd have direct bitmap access
-                            // For now, we'll just return None and let it reseed from DB
-                        }
-                    }
-                }
-            }
-            
+            let contract_bloom = Bloom::new_for_fp_rate(
+                (capacity as usize).max(100) / 10,
+                fp_rate,
+            )
+            .expect("Failed to create contract bloom from persisted state");
             Ok(Some(EventBloomFilter {
                 inner: Mutex::new(bloom),
                 capacity: capacity as usize,
                 fp_rate,
+                contract_filter: Mutex::new(contract_bloom),
+                known_contracts: Mutex::new(HashSet::new()),
             }))
         }
         None => Ok(None),
@@ -274,5 +336,58 @@ mod tests {
         let f = EventBloomFilter::new(5000, 0.01);
         assert_eq!(f.capacity, 5000);
         assert_eq!(f.fp_rate, 0.01);
+    }
+
+    // ── Issue #615: SessionBloomFilter tests ─────────────────────────────────
+
+    fn make_session_filter() -> SessionBloomFilter {
+        SessionBloomFilter::new(10_000, 0.001)
+    }
+
+    #[test]
+    fn session_filter_first_event_not_duplicate() {
+        let f = make_session_filter();
+        assert!(!f.check_and_set("tx1", "c1", "contract", 100));
+    }
+
+    #[test]
+    fn session_filter_second_same_event_is_duplicate() {
+        let f = make_session_filter();
+        f.check_and_set("tx1", "c1", "contract", 100);
+        assert!(f.check_and_set("tx1", "c1", "contract", 100));
+    }
+
+    #[test]
+    fn session_filter_different_tx_hash_not_duplicate() {
+        let f = make_session_filter();
+        f.check_and_set("tx1", "c1", "contract", 100);
+        assert!(!f.check_and_set("tx2", "c1", "contract", 100));
+    }
+
+    #[test]
+    fn session_filter_resets_on_new_ledger() {
+        let f = make_session_filter();
+        // Set in ledger 100
+        f.check_and_set("tx1", "c1", "contract", 100);
+        assert!(f.check_and_set("tx1", "c1", "contract", 100)); // duplicate
+
+        // Advance to ledger 101 — filter resets, event is no longer cached
+        assert!(!f.check_and_set("tx1", "c1", "contract", 101));
+    }
+
+    #[test]
+    fn session_filter_same_ledger_detects_dups_across_calls() {
+        let f = make_session_filter();
+        for _ in 0..3 {
+            f.check_and_set("txA", "cA", "contract", 50);
+        }
+        // After the first call above, subsequent ones should all be duplicates.
+        // The first call returns false; the next two return true.
+        // We can verify by resetting and doing a controlled sequence:
+        let f2 = make_session_filter();
+        let first = f2.check_and_set("txA", "cA", "contract", 50);
+        let second = f2.check_and_set("txA", "cA", "contract", 50);
+        assert!(!first);
+        assert!(second);
     }
 }

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -10455,6 +10455,8 @@ pub async fn list_archive(State(state): State<AppState>) -> Result<Json<Value>, 
 pub struct RegisterSchemaRequest {
     /// JSON Schema definition (Draft 7)
     pub schema: Value,
+    /// Optional human-readable description of this schema (issue #617 versioning)
+    pub description: Option<String>,
 }
 
 /// Register or update a JSON Schema for a contract
@@ -10489,17 +10491,55 @@ pub async fn register_contract_schema(
         .ok_or_else(|| AppError::Internal("Schema validator not initialized".to_string()))?;
 
     validator
-        .register_schema(&contract_id, &payload.schema)
+        .register_schema_described(
+            &contract_id,
+            &payload.schema,
+            payload.description.as_deref(),
+        )
         .await
         .map_err(|e| AppError::Validation(format!("Invalid schema: {}", e)))?;
 
+    // Return the current version after registration
+    let info = validator.get_schema_info(&contract_id).await;
     Ok((
         StatusCode::OK,
         Json(json!({
             "status": "ok",
-            "message": "Schema registered successfully"
+            "message": "Schema registered successfully",
+            "contract_id": contract_id,
+            "version": info.map(|i| i.version).unwrap_or(1),
         })),
     ))
+}
+
+/// List all registered JSON Schemas (metadata only, no schema body)
+#[utoipa::path(
+    get,
+    path = "/v1/admin/schemas",
+    tag = "admin",
+    responses(
+        (status = 200, description = "List of registered schemas"),
+        (status = 401, description = "Unauthorized"),
+        (status = 500, description = "Internal server error")
+    ),
+    security(
+        ("api_key" = [])
+    )
+)]
+pub async fn list_contract_schemas(
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, AppError> {
+    let validator = state
+        .schema_validator
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("Schema validator not initialized".to_string()))?;
+
+    let schemas = validator
+        .list_schemas()
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    Ok((StatusCode::OK, Json(json!({ "schemas": schemas }))))
 }
 
 /// Get the JSON Schema for a contract
@@ -12252,4 +12292,143 @@ pub struct ConfigReloadRequest {
     /// New slow query threshold in milliseconds
     #[serde(default)]
     pub slow_query_threshold_ms: Option<u64>,
+}
+
+// ── Issue #618: Anonymization pipeline API handlers ──────────────────────────
+
+use crate::anonymization::AnonymizationRuleRequest;
+
+/// List all configured anonymization rules
+#[utoipa::path(
+    get,
+    path = "/v1/config/anonymization",
+    tag = "config",
+    responses(
+        (status = 200, description = "List of anonymization rules"),
+        (status = 500, description = "Internal server error")
+    ),
+    security(("api_key" = []))
+)]
+pub async fn get_anonymization_config(
+    State(state): State<AppState>,
+) -> Result<impl IntoResponse, AppError> {
+    match state.anonymization_config.as_ref() {
+        Some(cfg) => {
+            let rules = cfg.get_rules().await;
+            Ok(Json(json!({ "rules": rules })))
+        }
+        None => {
+            let defaults = crate::anonymization::default_rules();
+            Ok(Json(json!({ "rules": defaults, "source": "built_in_defaults" })))
+        }
+    }
+}
+
+/// Create or update an anonymization rule
+#[utoipa::path(
+    post,
+    path = "/v1/config/anonymization/rules",
+    tag = "config",
+    request_body = serde_json::Value,
+    responses(
+        (status = 200, description = "Rule created or updated"),
+        (status = 400, description = "Invalid rule"),
+        (status = 401, description = "Unauthorized"),
+        (status = 500, description = "Internal server error")
+    ),
+    security(("api_key" = []))
+)]
+pub async fn upsert_anonymization_rule(
+    State(state): State<AppState>,
+    Json(payload): Json<AnonymizationRuleRequest>,
+) -> Result<impl IntoResponse, AppError> {
+    let cfg = state
+        .anonymization_config
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("Anonymization config not initialized".to_string()))?;
+
+    let rule = cfg
+        .upsert_rule(&payload)
+        .await
+        .map_err(|e| AppError::Validation(e.to_string()))?;
+
+    Ok((StatusCode::OK, Json(json!({ "status": "ok", "rule": rule }))))
+}
+
+/// Delete an anonymization rule by name
+#[utoipa::path(
+    delete,
+    path = "/v1/config/anonymization/rules/{name}",
+    tag = "config",
+    params(
+        ("name" = String, Path, description = "Rule name")
+    ),
+    responses(
+        (status = 200, description = "Rule deleted"),
+        (status = 404, description = "Rule not found"),
+        (status = 401, description = "Unauthorized"),
+        (status = 500, description = "Internal server error")
+    ),
+    security(("api_key" = []))
+)]
+pub async fn delete_anonymization_rule(
+    State(state): State<AppState>,
+    Path(name): Path<String>,
+) -> Result<impl IntoResponse, AppError> {
+    let cfg = state
+        .anonymization_config
+        .as_ref()
+        .ok_or_else(|| AppError::Internal("Anonymization config not initialized".to_string()))?;
+
+    let deleted = cfg
+        .delete_rule(&name)
+        .await
+        .map_err(|e| AppError::Internal(e.to_string()))?;
+
+    if deleted {
+        Ok((StatusCode::OK, Json(json!({ "status": "ok", "deleted": name }))))
+    } else {
+        Err(AppError::NotFound)
+    }
+}
+
+/// Scan a single event's data for PII (dry-run, does not modify the event)
+#[utoipa::path(
+    post,
+    path = "/v1/config/anonymization/scan",
+    tag = "config",
+    request_body = serde_json::Value,
+    responses(
+        (status = 200, description = "PII scan result"),
+        (status = 401, description = "Unauthorized"),
+        (status = 500, description = "Internal server error")
+    ),
+    security(("api_key" = []))
+)]
+pub async fn scan_event_for_pii(
+    State(state): State<AppState>,
+    Json(event_data): Json<serde_json::Value>,
+) -> Result<impl IntoResponse, AppError> {
+    let detection_rules = match state.anonymization_config.as_ref() {
+        Some(cfg) => cfg.compile_detection_rules().await,
+        None => {
+            crate::anonymization::default_rules()
+                .iter()
+                .filter(|r| r.enabled)
+                .filter_map(|r| Regex::new(&r.pattern).ok().map(|re| (r.name.clone(), re)))
+                .collect()
+        }
+    };
+
+    let result = crate::anonymization::scan_for_pii(&event_data, &detection_rules);
+    let detections: Vec<serde_json::Value> = result
+        .detections
+        .iter()
+        .map(|d| json!({ "field": d.field_path, "rule": d.rule_name }))
+        .collect();
+
+    Ok(Json(json!({
+        "pii_detected": !detections.is_empty(),
+        "detections": detections,
+    })))
 }

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -9,7 +9,7 @@ use tokio::time::sleep;
 use tracing::{error, info, instrument, span, warn, Level};
 
 use crate::{
-    bloom_filter::EventBloomFilter,
+    bloom_filter::{EventBloomFilter, SessionBloomFilter},
     config::{Config, HealthState, IndexerState},
     kinesis::KinesisPublisher,
     metrics,
@@ -299,6 +299,8 @@ pub struct Indexer<R: RpcClient> {
     event_tx: Option<broadcast::Sender<SorobanEvent>>,
     event_counter: AtomicU64,
     bloom_filter: Option<Arc<EventBloomFilter>>,
+    /// Issue #615: session-level bloom filter reset on each new ledger.
+    session_bloom: SessionBloomFilter,
     kinesis_publisher: Option<Arc<dyn KinesisPublisher>>,
     pubsub_publisher: Option<Arc<dyn PubSubPublisher>>,
     sse_ring_buffer: Option<Arc<crate::sse_ring_buffer::SseRingBuffer>>,
@@ -327,6 +329,7 @@ impl<R: RpcClient> Indexer<R> {
             event_tx: None,
             event_counter: AtomicU64::new(0),
             bloom_filter: None,
+            session_bloom: SessionBloomFilter::new(50_000, 0.001),
             kinesis_publisher: None,
             pubsub_publisher: None,
             sse_ring_buffer: None,
@@ -1060,7 +1063,17 @@ impl<R: RpcClient> Indexer<R> {
         event: &SorobanEvent,
         schema_version: i32,
     ) -> Result<u64, anyhow::Error> {
-        // Issue #266: bloom filter pre-filter
+        // Issue #615: session-level bloom filter pre-filter (reset on new ledger)
+        if self.session_bloom.check_and_set(
+            &event.tx_hash,
+            &event.contract_id,
+            &event.event_type,
+            event.ledger,
+        ) {
+            return Ok(0);
+        }
+
+        // Issue #266: persistent bloom filter pre-filter
         if let Some(ref bloom) = self.bloom_filter {
             if bloom.check(&event.tx_hash, &event.contract_id, &event.event_type) {
                 return Ok(0);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod abi;
+pub mod anonymization;
 pub mod codegen;
 pub mod event_compression;
 pub mod ledger_hashes;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -87,6 +87,20 @@ pub fn record_invalid_contract_id() {
     m::counter!("soroban_pulse_events_invalid_contract_id_total").increment(1);
 }
 
+/// Record a passed XDR validation (issue #616)
+pub fn record_xdr_validation_pass() {
+    m::counter!("soroban_pulse_xdr_validation_pass_total").increment(1);
+}
+
+/// Record a failed XDR validation with a field label (issue #616)
+pub fn record_xdr_validation_fail(field: &str) {
+    m::counter!(
+        "soroban_pulse_xdr_validation_fail_total",
+        "field" => field.to_string()
+    )
+    .increment(1);
+}
+
 /// Record an archive integrity failure (issue #371)
 pub fn record_archive_integrity_failure() {
     m::counter!("soroban_pulse_archive_integrity_failures_total").increment(1);
@@ -295,6 +309,52 @@ pub fn record_content_dedup_hit() {
 /// Record that an event fingerprint was computed and stored (Issue #582).
 pub fn record_fingerprint_stored() {
     m::counter!("soroban_pulse_fingerprints_stored_total").increment(1);
+}
+
+/// Record a schema validation pass (issue #617)
+pub fn record_schema_validation_pass(contract_id: &str) {
+    m::counter!(
+        "soroban_pulse_schema_validation_pass_total",
+        "contract_id" => contract_id.to_string()
+    )
+    .increment(1);
+}
+
+/// Record a schema validation failure (issue #617)
+pub fn record_schema_validation_fail(contract_id: &str) {
+    m::counter!(
+        "soroban_pulse_schema_validation_fail_total",
+        "contract_id" => contract_id.to_string()
+    )
+    .increment(1);
+}
+
+/// Record an anonymization operation (issue #618)
+pub fn record_anonymization_applied(rule_name: &str) {
+    m::counter!(
+        "soroban_pulse_anonymization_applied_total",
+        "rule" => rule_name.to_string()
+    )
+    .increment(1);
+}
+
+/// Record a PII detection hit (issue #618)
+pub fn record_pii_detected(field: &str) {
+    m::counter!(
+        "soroban_pulse_pii_detected_total",
+        "field" => field.to_string()
+    )
+    .increment(1);
+}
+
+/// Record a session-level bloom filter dedup hit (issue #615)
+pub fn record_session_bloom_hit() {
+    m::counter!("soroban_pulse_session_bloom_hits_total").increment(1);
+}
+
+/// Record a session bloom filter reset on new ledger (issue #615)
+pub fn record_session_bloom_reset() {
+    m::counter!("soroban_pulse_session_bloom_resets_total").increment(1);
 }
 
 /// Record contract history query duration

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -102,6 +102,8 @@ pub struct AppState {
     pub sse_ring_buffer: std::sync::Arc<crate::sse_ring_buffer::SseRingBuffer>,
     /// TTL-bounded query result cache for materialized-view backed queries.
     pub query_result_cache: std::sync::Arc<moka::future::Cache<String, serde_json::Value>>,
+    /// Issue #618: Anonymization rules configuration.
+    pub anonymization_config: Option<Arc<crate::anonymization::AnonymizationConfig>>,
 }
 
 /// OpenAPI spec — all paths are documented via #[utoipa::path] on handlers.
@@ -150,6 +152,7 @@ pub struct AppState {
         handlers::get_contract_schema,
         handlers::delete_contract_schema,
         handlers::validate_event_data_against_schema,
+        handlers::list_contract_schemas,
         handlers::start_mask_events,
         handlers::get_mask_job_status,
         handlers::get_timeseries,
@@ -159,6 +162,10 @@ pub struct AppState {
         handlers::check_contract_exists,
         handlers::get_config,
         handlers::reload_config,
+        handlers::get_anonymization_config,
+        handlers::upsert_anonymization_rule,
+        handlers::delete_anonymization_rule,
+        handlers::scan_event_for_pii,
     ),
     components(schemas(
         crate::models::Event,
@@ -380,6 +387,7 @@ pub fn create_router_with_tx_and_tenant_map(
         abi_cache,
         sse_ring_buffer,
         query_result_cache,
+        anonymization_config: None,
     };
 
     // Spawn cache invalidation task: subscribe to the broadcast channel and
@@ -414,6 +422,7 @@ pub fn create_router_with_tx_and_tenant_map(
         .route("/admin/indexer/resume", axum::routing::post(handlers::resume_indexer))
         .route("/admin/contracts/{contract_id}/schema", axum::routing::post(handlers::register_contract_schema).get(handlers::get_contract_schema).delete(handlers::delete_contract_schema))
         .route("/admin/contracts/{contract_id}/validate", axum::routing::post(handlers::validate_event_data_against_schema))
+        .route("/admin/schemas", axum::routing::get(handlers::list_contract_schemas))
         .route_layer(axum::middleware::from_fn_with_state(
             Arc::clone(&admin_auth_state),
             middleware::admin_auth_middleware,
@@ -459,6 +468,10 @@ pub fn create_router_with_tx_and_tenant_map(
         .route("/contracts/exists", get(handlers::check_contract_exists))
         .route("/config", get(handlers::get_config))
         .route("/admin/config/reload", axum::routing::post(handlers::reload_config))
+        .route("/config/anonymization", axum::routing::get(handlers::get_anonymization_config))
+        .route("/config/anonymization/rules", axum::routing::post(handlers::upsert_anonymization_rule))
+        .route("/config/anonymization/rules/{name}", axum::routing::delete(handlers::delete_anonymization_rule))
+        .route("/config/anonymization/scan", axum::routing::post(handlers::scan_event_for_pii))
         .route("/contracts/{contract_id}/summary", get(handlers::get_contract_summary))
         .route("/contracts/{contract_id}/event-counts", get(handlers::get_contract_event_counts))
         .route("/admin/replay", axum::routing::post(handlers::replay_events))
@@ -473,6 +486,7 @@ pub fn create_router_with_tx_and_tenant_map(
         .route("/admin/indexer/resume", axum::routing::post(handlers::resume_indexer))
         .route("/admin/contracts/{contract_id}/schema", axum::routing::post(handlers::register_contract_schema).get(handlers::get_contract_schema).delete(handlers::delete_contract_schema))
         .route("/admin/contracts/{contract_id}/validate", axum::routing::post(handlers::validate_event_data_against_schema))
+        .route("/admin/schemas", axum::routing::get(handlers::list_contract_schemas))
         .route("/notifications/email/bounce", axum::routing::post(handlers::email_bounce_webhook))
         .route("/subscriptions", axum::routing::post(subscriptions::create_subscription))
         .route("/subscriptions/{id}", get(subscriptions::get_subscription).delete(subscriptions::cancel_subscription))

--- a/src/schema_validator.rs
+++ b/src/schema_validator.rs
@@ -1,13 +1,36 @@
-use jsonschema::{Draft, JSONSchema, error::ValidationError};
+//! Issue #617: JSON Schema validation for Soroban event data.
+//!
+//! Compiles and caches JSON Draft-7 schemas per contract. Schemas are stored in the
+//! `contract_schemas` table and loaded at startup. Each schema update increments a
+//! `version` counter (via DB trigger) so consumers can detect stale cached copies.
+//!
+//! ## Integration points
+//! - `register_schema` / `get_schema` / `delete_schema` / `list_schemas` — CRUD.
+//! - `validate_event_data` — called by the indexer to gate event storage.
+//! - `record_validation_metrics` — persists pass/fail counts to `schema_validation_metrics`.
+
+use jsonschema::{Draft, JSONSchema};
+use serde::Serialize;
 use serde_json::Value;
 use sqlx::PgPool;
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::RwLock;
 use tracing::{debug, warn};
-use crate::error::ValidationErrorDetail;
 
-/// Schema validator that caches compiled JSON schemas per contract
+use crate::error::ValidationErrorDetail;
+use crate::metrics;
+
+/// Summary returned when listing all registered schemas.
+#[derive(Debug, Serialize)]
+pub struct SchemaInfo {
+    pub contract_id: String,
+    pub version: i32,
+    pub description: Option<String>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+/// Schema validator that caches compiled JSON schemas per contract.
 #[derive(Clone)]
 pub struct SchemaValidator {
     pool: PgPool,
@@ -22,7 +45,7 @@ impl SchemaValidator {
         }
     }
 
-    /// Load all schemas from the database into the cache
+    /// Load all schemas from the database into the in-memory cache.
     pub async fn load_schemas(&self) -> Result<(), sqlx::Error> {
         let schemas: Vec<(String, Value)> =
             sqlx::query_as("SELECT contract_id, schema FROM contract_schemas")
@@ -44,49 +67,38 @@ impl SchemaValidator {
                 }
             }
         }
-
         Ok(())
     }
 
-    /// Register a new schema for a contract
+    /// Register (or replace) a JSON Schema for a contract.
+    ///
+    /// The `version` column is incremented automatically by the DB trigger on UPDATE.
     pub async fn register_schema(
         &self,
         contract_id: &str,
         schema: &Value,
     ) -> Result<(), anyhow::Error> {
-        // Validate that the schema itself is valid
-        let compiled = JSONSchema::options()
-            .with_draft(Draft::Draft7)
-            .compile(schema)
-            .map_err(|e| anyhow::anyhow!("Invalid JSON Schema: {}", e))?;
-
-        // Store in database
-        sqlx::query(
-            r#"
-            INSERT INTO contract_schemas (contract_id, schema, updated_at)
-            VALUES ($1, $2, NOW())
-            ON CONFLICT (contract_id)
-            DO UPDATE SET schema = EXCLUDED.schema, updated_at = NOW()
-            "#,
-        )
-        .bind(contract_id)
-        .bind(schema)
-        .execute(&self.pool)
-        .await?;
-
-        // Update cache
-        let mut cache = self.cache.write().await;
-        cache.insert(contract_id.to_string(), Arc::new(compiled));
-
-        debug!(contract_id = %contract_id, "Registered schema for contract");
-        Ok(())
+        register_schema_with_desc(self, contract_id, schema, None).await
     }
 
-    /// Validate event data against the registered schema for a contract
+    /// Register a schema with an optional human-readable description.
+    pub async fn register_schema_described(
+        &self,
+        contract_id: &str,
+        schema: &Value,
+        description: Option<&str>,
+    ) -> Result<(), anyhow::Error> {
+        register_schema_with_desc(self, contract_id, schema, description).await
+    }
+
+    /// Validate event data against the registered schema for a contract.
+    ///
     /// Returns:
-    /// - None if no schema is registered for this contract
-    /// - Some((true, vec![])) if validation passes
-    /// - Some((false, errors)) if validation fails with error details
+    /// - `None` — no schema is registered for this contract (event is accepted).
+    /// - `Some((true, []))` — validation passed.
+    /// - `Some((false, errors))` — validation failed with structured error details.
+    ///
+    /// Increments Prometheus counters (`schema_validation_pass/fail_total`) on every call.
     pub async fn validate_event_data(
         &self,
         contract_id: &str,
@@ -106,36 +118,79 @@ impl SchemaValidator {
                         message: e.to_string(),
                     })
                     .collect();
-                
+
                 let error_messages: Vec<String> = error_details
                     .iter()
                     .map(|e| format!("{} at {}", e.message, e.instance_path))
                     .collect();
-                
+
                 warn!(
                     contract_id = %contract_id,
                     errors = ?error_messages,
                     "Event data failed schema validation"
                 );
-                
+
+                metrics::record_schema_validation_fail(contract_id);
                 return Some((false, error_details));
             }
         }
 
+        metrics::record_schema_validation_pass(contract_id);
         Some((is_valid, vec![]))
     }
 
-    /// Get the schema for a contract
+    /// Retrieve the full schema JSON and its current version for a contract.
     pub async fn get_schema(&self, contract_id: &str) -> Option<Value> {
-        sqlx::query_scalar::<_, Value>("SELECT schema FROM contract_schemas WHERE contract_id = $1")
-            .bind(contract_id)
-            .fetch_optional(&self.pool)
-            .await
-            .ok()
-            .flatten()
+        sqlx::query_scalar::<_, Value>(
+            "SELECT schema FROM contract_schemas WHERE contract_id = $1",
+        )
+        .bind(contract_id)
+        .fetch_optional(&self.pool)
+        .await
+        .ok()
+        .flatten()
     }
 
-    /// Delete a schema for a contract
+    /// Retrieve schema metadata (without the full schema body) for a contract.
+    pub async fn get_schema_info(&self, contract_id: &str) -> Option<SchemaInfo> {
+        sqlx::query_as::<_, (String, i32, Option<String>, chrono::DateTime<chrono::Utc>)>(
+            "SELECT contract_id, version, description, updated_at \
+             FROM contract_schemas WHERE contract_id = $1",
+        )
+        .bind(contract_id)
+        .fetch_optional(&self.pool)
+        .await
+        .ok()
+        .flatten()
+        .map(|(cid, version, desc, updated_at)| SchemaInfo {
+            contract_id: cid,
+            version,
+            description: desc,
+            updated_at,
+        })
+    }
+
+    /// List all registered schemas (metadata only, no schema body).
+    pub async fn list_schemas(&self) -> Result<Vec<SchemaInfo>, sqlx::Error> {
+        let rows = sqlx::query_as::<_, (String, i32, Option<String>, chrono::DateTime<chrono::Utc>)>(
+            "SELECT contract_id, version, description, updated_at \
+             FROM contract_schemas ORDER BY contract_id",
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|(contract_id, version, description, updated_at)| SchemaInfo {
+                contract_id,
+                version,
+                description,
+                updated_at,
+            })
+            .collect())
+    }
+
+    /// Delete the schema for a contract and evict it from the cache.
     pub async fn delete_schema(&self, contract_id: &str) -> Result<bool, sqlx::Error> {
         let result = sqlx::query("DELETE FROM contract_schemas WHERE contract_id = $1")
             .bind(contract_id)
@@ -151,4 +206,67 @@ impl SchemaValidator {
             Ok(false)
         }
     }
+
+    /// Persist cumulative pass/fail counters to `schema_validation_metrics`.
+    ///
+    /// Called periodically to keep the DB table in sync with the in-process counters.
+    /// Uses `ON CONFLICT DO UPDATE` so the row is upserted atomically.
+    pub async fn record_validation_metrics(
+        pool: &PgPool,
+        contract_id: &str,
+        pass_delta: i64,
+        fail_delta: i64,
+    ) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"
+            INSERT INTO schema_validation_metrics (contract_id, pass_count, fail_count, last_checked)
+            VALUES ($1, $2, $3, NOW())
+            ON CONFLICT (contract_id) DO UPDATE
+                SET pass_count   = schema_validation_metrics.pass_count + EXCLUDED.pass_count,
+                    fail_count   = schema_validation_metrics.fail_count + EXCLUDED.fail_count,
+                    last_checked = NOW()
+            "#,
+        )
+        .bind(contract_id)
+        .bind(pass_delta)
+        .bind(fail_delta)
+        .execute(pool)
+        .await?;
+        Ok(())
+    }
+}
+
+/// Internal helper shared by `register_schema` and `register_schema_described`.
+async fn register_schema_with_desc(
+    sv: &SchemaValidator,
+    contract_id: &str,
+    schema: &Value,
+    description: Option<&str>,
+) -> Result<(), anyhow::Error> {
+    let compiled = JSONSchema::options()
+        .with_draft(Draft::Draft7)
+        .compile(schema)
+        .map_err(|e| anyhow::anyhow!("Invalid JSON Schema: {}", e))?;
+
+    sqlx::query(
+        r#"
+        INSERT INTO contract_schemas (contract_id, schema, description, updated_at)
+        VALUES ($1, $2, $3, NOW())
+        ON CONFLICT (contract_id)
+        DO UPDATE SET schema = EXCLUDED.schema,
+                      description = COALESCE(EXCLUDED.description, contract_schemas.description),
+                      updated_at = NOW()
+        "#,
+    )
+    .bind(contract_id)
+    .bind(schema)
+    .bind(description)
+    .execute(&sv.pool)
+    .await?;
+
+    let mut cache = sv.cache.write().await;
+    cache.insert(contract_id.to_string(), Arc::new(compiled));
+
+    debug!(contract_id = %contract_id, "Registered schema for contract");
+    Ok(())
 }

--- a/src/xdr_validation.rs
+++ b/src/xdr_validation.rs
@@ -1,42 +1,99 @@
 //! Issue #267: XDR validation for Soroban event data using the `stellar-xdr` crate.
 //! Issue #370: Contract ID Strkey format validation.
+//! Issue #616: Full validation module covering contract IDs, tx hashes, and ScVal types,
+//!             with custom error types, pass/fail counters, and API doc annotations.
 //!
-//! Validates `event_data.value` and each element of `event_data.topic` as `ScVal`
-//! (Soroban Contract Value). Also validates contract_id conforms to Stellar Strkey format.
-//! Events that fail validation are logged at WARN and counted in metrics.
+//! ## Validation rules
+//!
+//! | Field           | Rule                                                       |
+//! |-----------------|-------------------------------------------------------------|
+//! | `contract_id`   | C-type Strkey: starts with `C`, 56 chars, base32 (A-Z 2-7)|
+//! | `tx_hash`       | 64 lowercase hex characters (SHA-256 of the XDR envelope)  |
+//! | `event_data.value` | Valid `ScVal` JSON when non-null                        |
+//! | `event_data.topic` | Every element is a valid `ScVal` JSON                   |
 
 use serde_json::Value;
 use stellar_xdr::curr::ScVal;
+use thiserror::Error;
 use tracing::warn;
 
 use crate::metrics;
 
+/// Structured error returned when an individual Stellar type fails validation.
+#[derive(Debug, Error, PartialEq)]
+pub enum XdrValidationError {
+    #[error("contract_id '{0}' is not a valid Stellar C-type Strkey (expected 56 base32 chars starting with 'C')")]
+    InvalidContractId(String),
+
+    #[error("tx_hash '{0}' is not valid (expected 64 lowercase hex chars)")]
+    InvalidTxHash(String),
+
+    #[error("event_data.value is not a valid ScVal")]
+    InvalidScValue,
+
+    #[error("event_data.topic[{index}] is not a valid ScVal")]
+    InvalidTopicElement { index: usize },
+}
+
 /// Validate that a JSON value can be deserialized as a `ScVal`.
-/// Returns `true` if valid, `false` otherwise.
 fn is_valid_sc_val(v: &Value) -> bool {
     serde_json::from_value::<ScVal>(v.clone()).is_ok()
 }
 
-/// Validate that a contract_id is a valid Stellar Strkey (C-type, 56 chars, base32).
-/// Returns `true` if valid, `false` otherwise.
+/// Validate that a `contract_id` is a valid Stellar Strkey (C-type).
+///
+/// Rules:
+/// - Exactly 56 characters
+/// - Starts with `'C'`
+/// - All characters are valid base32 (`A–Z`, `2–7`)
 pub fn validate_contract_id(contract_id: &str) -> bool {
-    // C-type Strkey: starts with 'C', 56 characters total, base32 encoded
     if contract_id.len() != 56 {
         return false;
     }
     if !contract_id.starts_with('C') {
         return false;
     }
-    // Verify all characters are valid base32 (A-Z, 2-7)
-    contract_id.chars().all(|c| {
-        (c >= 'A' && c <= 'Z') || (c >= '2' && c <= '7')
-    })
+    contract_id
+        .chars()
+        .all(|c| matches!(c, 'A'..='Z' | '2'..='7'))
 }
 
-/// Validate the contract_id, `event_data.value` and `event_data.topic` fields of a Soroban event.
+/// Validate that a `tx_hash` conforms to the Stellar transaction hash format.
 ///
-/// Returns `true` if the event passes all validations, `false` if it should be skipped.
+/// Rules:
+/// - Exactly 64 characters
+/// - All characters are ASCII hex digits (`0–9`, `a–f`, `A–F`)
+pub fn validate_tx_hash(tx_hash: &str) -> bool {
+    if tx_hash.len() != 64 {
+        return false;
+    }
+    tx_hash.chars().all(|c| c.is_ascii_hexdigit())
+}
+
+/// Validate a `contract_id` and return a typed error on failure.
+pub fn validate_contract_id_strict(contract_id: &str) -> Result<(), XdrValidationError> {
+    if validate_contract_id(contract_id) {
+        Ok(())
+    } else {
+        Err(XdrValidationError::InvalidContractId(contract_id.to_string()))
+    }
+}
+
+/// Validate a `tx_hash` and return a typed error on failure.
+pub fn validate_tx_hash_strict(tx_hash: &str) -> Result<(), XdrValidationError> {
+    if validate_tx_hash(tx_hash) {
+        Ok(())
+    } else {
+        Err(XdrValidationError::InvalidTxHash(tx_hash.to_string()))
+    }
+}
+
+/// Validate the `contract_id`, `tx_hash`, `event_data.value`, and `event_data.topic`
+/// fields of a Soroban event.
+///
+/// Returns `true` if all validations pass, `false` if the event should be skipped.
 /// On failure, logs a WARN and increments appropriate metrics.
+/// On success, increments the XDR-valid counter.
 pub fn validate_xdr(
     tx_hash: &str,
     contract_id: &str,
@@ -44,7 +101,7 @@ pub fn validate_xdr(
     value: &Value,
     topic: Option<&Vec<Value>>,
 ) -> bool {
-    // Validate contract_id format first
+    // Validate contract_id format
     if !validate_contract_id(contract_id) {
         warn!(
             tx_hash = %tx_hash,
@@ -53,6 +110,20 @@ pub fn validate_xdr(
             "contract_id failed Strkey validation, skipping event",
         );
         metrics::record_invalid_contract_id();
+        metrics::record_xdr_validation_fail("contract_id");
+        return false;
+    }
+
+    // Validate tx_hash format
+    if !validate_tx_hash(tx_hash) {
+        warn!(
+            tx_hash = %tx_hash,
+            contract_id = %contract_id,
+            ledger = ledger,
+            "tx_hash failed hex validation, skipping event",
+        );
+        metrics::record_xdr_invalid();
+        metrics::record_xdr_validation_fail("tx_hash");
         return false;
     }
 
@@ -66,6 +137,7 @@ pub fn validate_xdr(
             "event_data.value failed XDR/ScVal validation, skipping event",
         );
         metrics::record_xdr_invalid();
+        metrics::record_xdr_validation_fail("sc_value");
         return false;
     }
 
@@ -82,11 +154,13 @@ pub fn validate_xdr(
                     i,
                 );
                 metrics::record_xdr_invalid();
+                metrics::record_xdr_validation_fail("sc_topic");
                 return false;
             }
         }
     }
 
+    metrics::record_xdr_validation_pass();
     true
 }
 
@@ -95,8 +169,13 @@ mod tests {
     use super::*;
     use serde_json::json;
 
+    const VALID_CONTRACT_ID: &str =
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+    const VALID_TX_HASH: &str =
+        "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
+
     fn call(value: Value, topic: Option<Vec<Value>>) -> bool {
-        validate_xdr("txhash", "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF", 100, &value, topic.as_ref())
+        validate_xdr(VALID_TX_HASH, VALID_CONTRACT_ID, 100, &value, topic.as_ref())
     }
 
     #[test]
@@ -106,7 +185,6 @@ mod tests {
 
     #[test]
     fn valid_sc_val_void_passes() {
-        // ScVal::Void serializes as {"void": null} in stellar-xdr serde
         let v = json!({"void": null});
         assert!(call(v, None));
     }
@@ -119,7 +197,6 @@ mod tests {
 
     #[test]
     fn invalid_value_fails() {
-        // A plain string is not a valid ScVal
         let v = json!("not_a_scval");
         assert!(!call(v, None));
     }
@@ -151,34 +228,96 @@ mod tests {
 
     #[test]
     fn valid_c_type_strkey() {
-        assert!(validate_contract_id("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"));
+        assert!(validate_contract_id(VALID_CONTRACT_ID));
     }
 
     #[test]
     fn invalid_strkey_wrong_type() {
-        // G-type (account) instead of C-type (contract)
-        assert!(!validate_contract_id("GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"));
+        assert!(!validate_contract_id(
+            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+        ));
     }
 
     #[test]
     fn invalid_strkey_wrong_length() {
-        assert!(!validate_contract_id("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"));
+        assert!(!validate_contract_id(
+            "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+        ));
     }
 
     #[test]
     fn invalid_strkey_invalid_chars() {
-        assert!(!validate_contract_id("CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@WHF"));
+        assert!(!validate_contract_id(
+            "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA@WHF"
+        ));
     }
 
     #[test]
     fn invalid_strkey_lowercase() {
-        assert!(!validate_contract_id("caaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaawhf"));
+        assert!(!validate_contract_id(
+            "caaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaawhf"
+        ));
     }
 
     #[test]
     fn contract_id_validation_rejects_invalid_format() {
         let v = Value::Null;
-        // Invalid contract ID should fail validation
-        assert!(!validate_xdr("txhash", "INVALID", 100, &v, None));
+        assert!(!validate_xdr(VALID_TX_HASH, "INVALID", 100, &v, None));
+    }
+
+    // tx_hash validation tests
+
+    #[test]
+    fn valid_tx_hash_passes() {
+        assert!(validate_tx_hash(VALID_TX_HASH));
+    }
+
+    #[test]
+    fn tx_hash_uppercase_hex_passes() {
+        let hash = "A".repeat(64);
+        assert!(validate_tx_hash(&hash));
+    }
+
+    #[test]
+    fn tx_hash_wrong_length_fails() {
+        assert!(!validate_tx_hash(&"a".repeat(63)));
+        assert!(!validate_tx_hash(&"a".repeat(65)));
+        assert!(!validate_tx_hash(""));
+    }
+
+    #[test]
+    fn tx_hash_non_hex_fails() {
+        let bad = format!("{}z{}", "a".repeat(32), "a".repeat(31));
+        assert!(!validate_tx_hash(&bad));
+    }
+
+    #[test]
+    fn validate_xdr_rejects_bad_tx_hash() {
+        let v = Value::Null;
+        assert!(!validate_xdr("INVALID_HASH", VALID_CONTRACT_ID, 100, &v, None));
+    }
+
+    // Strict helpers
+
+    #[test]
+    fn strict_contract_id_ok() {
+        assert!(validate_contract_id_strict(VALID_CONTRACT_ID).is_ok());
+    }
+
+    #[test]
+    fn strict_contract_id_err() {
+        let err = validate_contract_id_strict("BAD").unwrap_err();
+        assert!(matches!(err, XdrValidationError::InvalidContractId(_)));
+    }
+
+    #[test]
+    fn strict_tx_hash_ok() {
+        assert!(validate_tx_hash_strict(VALID_TX_HASH).is_ok());
+    }
+
+    #[test]
+    fn strict_tx_hash_err() {
+        let err = validate_tx_hash_strict("bad").unwrap_err();
+        assert!(matches!(err, XdrValidationError::InvalidTxHash(_)));
     }
 }


### PR DESCRIPTION
… XDR validation (#615 #616 #617 #618)

Issue closes #617 — Event data schema validation
- Add schema versioning: version column auto-incremented via DB trigger on contract_schemas
- Add schema description field for human-readable annotation
- Add list_contract_schemas endpoint (GET /v1/admin/schemas) returning metadata for all registered schemas
- Add schema_validation_metrics table for persistent pass/fail counts
- Add schema validation Prometheus metrics (schema_validation_pass/fail_total per contract_id)
- Register_schema now returns current version in response body
- Migration: 20260630000002_schema_versioning_and_metrics.sql

Issue closes #618 — Event data anonymization pipeline
- New anonymization.rs module with regex-based PII detection and redaction
- Built-in patterns: email, phone, SSN, IPv4, credit card — configurable via DB
- AnonymizationConfig struct: loads rules from DB, falls back to defaults when table is empty
- Background worker (run_anonymization_worker) processes un-anonymized events in batches
- audit_anonymization writes every redaction to audit_logs with applied rules
- New endpoints: GET/POST /v1/config/anonymization, POST /v1/config/anonymization/rules, DELETE /v1/config/anonymization/rules/{name}, POST /v1/config/anonymization/scan (dry-run)
- Metrics: pii_detected_total (per field), anonymization_applied_total (per rule)
- Migration: 20260630000003_anonymization_rules.sql with default rules seeded

Issue closes #615 — Event deduplication across RPC polls (Bloom filter)
- Add SessionBloomFilter: per-poll-cycle Bloom filter that auto-resets on new ledger detection
- Session filter runs before the persistent EventBloomFilter — catches intra-batch duplicates from overlapping RPC cursor responses within the same ledger
- Metrics: session_bloom_hits_total, session_bloom_resets_total
- ON CONFLICT DO NOTHING already enforced at DB level as authoritative guard

Issue closes #616 — XDR validation for Stellar types
- Add validate_tx_hash to xdr_validation.rs (64-char hex) with XdrValidationError type
- Add XdrValidationError enum: InvalidContractId, InvalidTxHash, InvalidScValue, InvalidTopicElement
- Add validate_contract_id_strict / validate_tx_hash_strict returning typed errors
- validate_xdr now also validates tx_hash format before ScVal checks
- Add xdr_validation_pass_total counter (incremented on every fully valid event)
- Add xdr_validation_fail_total{field} counter (contract_id / tx_hash / sc_value / sc_topic)
- Validation rules documented in module-level doc table

## Summary

<!-- A clear, concise description of what this PR does. -->

## Related Issue

Closes #<!-- issue number -->

## Changes

<!-- List the key changes made. -->

- 

## Testing

<!-- Describe how you tested this. -->

- [ ] `cargo test` passes
- [ ] `cargo clippy` reports no warnings
- [ ] Manually tested locally

## Notes

<!-- Anything reviewers should pay special attention to, or N/A. -->
