### PR TITLE
feat: financial accuracy testing, locale/timezone testing, codegen helpers, VS Code extension (#718 #719 #720 #721)

### DIFF
--- a/src/distributed_tracing.rs
+++ b/src/distributed_tracing.rs
@@ -69,7 +69,7 @@ impl TracingConfig {
 ///
 /// W3C Trace Context format: `traceparent: version-trace_id-parent_id-trace_flags`
 /// Example: `00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`
-pub fn extract_trace_context(headers: &http::HeaderMap) -> Option<TraceContext> {
+pub fn extract_trace_context(headers: &axum::http::HeaderMap) -> Option<TraceContext> {
     // Try W3C traceparent first
     if let Some(traceparent) = headers.get("traceparent") {
         if let Ok(s) = traceparent.to_str() {

--- a/src/financial_accuracy.rs
+++ b/src/financial_accuracy.rs
@@ -189,7 +189,7 @@ impl EventValidator for AmountRangeValidator {
             }
         }
 
-        ValidationRest::with_findings(findings)
+        ValidationResult::with_findings(findings)
     }
 }
 

--- a/src/timezone_locale.rs
+++ b/src/timezone_locale.rs
@@ -55,7 +55,8 @@ impl TimezoneConfig {
     /// US Pacific (PST/PDT): UTC-8 standard, UTC-7 DST (Mar–Nov).
     pub fn us_pacific() -> Self {
         Self {
-            name: "America/Los_Angeles".to_string(         offset_seconds: -8 * 3600,
+            name: "America/Los_Angeles".to_string(),
+            offset_seconds: -8 * 3600,
             dst_offset_seconds: 3600,
             dst_start_month: Some(3),
             dst_end_month: Some(11),
@@ -170,7 +171,8 @@ impl Locale {
     pub fn from_str(s: &str) -> Option<Self> {
         match s.to_lowercase().as_str() {
             "en-us" | "en_us" => Some(Self::EnUs),
-            "en-gb" | "en_gb" => Some(       "de" | "de-de" => Some(Self::De),
+            "en-gb" | "en_gb" => Some(Self::EnGb),
+            "de" | "de-de" => Some(Self::De),
             "ja" | "ja-jp" => Some(Self::Ja),
             "fr" | "fr-fr" => Some(Self::Fr),
             "ng" | "en-ng" => Some(Self::Ng),
@@ -298,7 +300,7 @@ pub enum DstTransitionKind {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DstTransition {
-    pub tine: String,
+    pub timezone: String,
     pub kind: DstTransitionKind,
     pub utc_at: DateTime<Utc>,
     pub offset_before_seconds: i32,
@@ -368,7 +370,7 @@ pub struct TimezoneHandlingDoc {
 }
 
 impl TimezoneHandlingDoc {
-    pub fn generate() -Self {
+    pub fn generate() -> Self {
         Self {
             storage_format: "All timestamps stored as UTC (DateTime<Utc>) in PostgreSQL TIMESTAMPTZ columns.",
             api_input_format: "ISO 8601 / RFC 3339 strings accepted; bare naive datetimes interpreted as UTC.",

--- a/tests/timezone_locale_tests.rs
+++ b/tests/timezone_locale_tests.rs
@@ -8,7 +8,6 @@ use soroban_pulse::timezone_locale::{
     convert_to_all_timezones, detect_dst_transition, format_datetime_for_locale,
     format_number_for_locale, parse_timestamp_lenient, scan_for_dst_transitions,
     validate_timestamp_range, DstTransitionKind, Locale, TimezoneConfig, TimezoneHandlingDoc,
-    SumVerificationConfig,
 };
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Implements all four Stellar Wave issues assigned to this contributor.

---

## Issue #718 — Add financial accuracy testing

**File:** `src/financial_accuracy.rs`, `tests/financial_accuracy_tests.rs`

- `DataValidationFramework` — runs pluggable validators (`RequiredFieldsValidator`, `AmountRangeValidator`, `LedgerSequenceValidator`, `TimestampValidator`) against raw event JSON
- `EventCountReconciler` — compares DB count vs. external source with configurable tolerance
- `SumVerifier` — verifies total sums across event batches using JSON pointer paths
- `AccuracyReport` — aggregated pass/fail report with severity breakdown
- `run_accuracy_check()` — high-level runner that wires all components together
- **24 tests** covering all tasks

**Bug fix:** `ValidationRest::with_findings` → `ValidationResult::with_findings` (typo)

Closes #718

---

## Issue #719 — Add locale and timezone testing

**File:** `src/timezone_locale.rs`, `tests/timezone_locale_tests.rs`

- `TimezoneConfig` — named timezone structs with DST-aware offset calculation (UTC, US/Eastern, US/Pacific, Europe/Berlin, Asia/Tokyo, Africa/Lagos)
- `Locale` enum — en-US, en-GB, de, ja, fr, en-NG with locale-specific date/number formatting
- `convert_to_all_timezones()` — batch conversion across multiple zones
- `detect_dst_transition()` / `scan_for_dst_transitions()` — detect spring-forward / fall-back crossings
- `TimezoneHandlingDoc` — documents the project's timezone strategy
- **45 tests** covering all tasks

**Bug fixes:**
- `us_pacific()`: broken struct constructor (missing closing paren + comma)
- `Locale::from_str`: broken `en-gb` match arm
- `DstTransition`: `tine` field typo → `timezone`
- `TimezoneHandlingDoc::generate()`: missing `>` in return type arrow
- Removed unused `SumVerificationConfig` import from test file

Closes #719

---

## Issue #720 — Create code generation helpers for subscriptions

**Files:** `src/codegen/` (mod.rs, subscription.rs, filter.rs, webhook.rs, tests.rs), `src/bin/gen_subscription_scaffold.rs`, `docs/codegen.md`

- Generates complete subscription handler + SQL migration + webhook delivery code from a name and channel type (webhook/email/sms)
- Optional `--with-filter` flag generates content filter config module
- Optional `--with-tests` flag generates test scaffold
- `--dry-run` flag previews to stdout without writing
- Templates use `{{PASCAL}}`/`{{SNAKE}}`/`{{CHANNEL}}` substitution — no external template engine dependency
- Full documentation in `docs/codegen.md`

Closes #720

---

## Issue #721 — Add VS Code extension for API exploration

**Files:** `vscode-extension/src/` (extension.ts, apiExplorer.ts, requestTester.ts, apiData.ts, types.ts), `vscode-extension/package.json`

- Activity bar panel with collapsible endpoint tree grouped by category
- Filter/search box to narrow endpoints by name or method
- Request tester webview: select endpoint, fill params, send request, view response
- Copy URL command for quick cURL usage
- Configurable base URL, API key, admin key, and request timeout via VS Code settings
- Ready for `vsce package` and marketplace publishing

Closes #721

---

## Testing

- Issue #718: 24 unit tests in `tests/financial_accuracy_tests.rs`
- Issue #719: 45 unit tests in `tests/timezone_locale_tests.rs`
- Issue #720: Tests embedded in `src/codegen/tests.rs` and `src/codegen/mod.rs`
- Issue #721: TypeScript extension (compile with `npm run compile` in `vscode-extension/`)