### PR TITLE
feat(deny): add cargo-deny configuration and CI integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,28 @@ jobs:
           components: rustfmt
       - run: cargo fmt --check
 
+  deny:
+    name: cargo-deny
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check advisories
+          arguments: --all-features
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check bans
+          arguments: --all-features
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check licenses
+          arguments: --all-features
+      - uses: EmbarkStudios/cargo-deny-action@v2
+        with:
+          command: check sources
+          arguments: --all-features
+
   check-migrations:
     name: Check Migrations
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help build test test-db lint fmt run docker-up docker-down migrate clean gen-openapi gen-postman
+.PHONY: help build test test-db lint fmt run docker-up docker-down migrate clean gen-openapi gen-postman deny
 
 help: ## Show available targets
 	@grep -E '^[a-zA-Z_-]+:.*##' $(MAKEFILE_LIST) | awk 'BEGIN {FS = ":.*##"}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
@@ -23,6 +23,12 @@ lint: ## Run clippy with warnings as errors
 
 fmt: ## Format source code
 	cargo fmt
+
+deny: ## Run cargo-deny checks (advisories, bans, licenses, sources)
+	cargo deny check advisories
+	cargo deny check bans
+	cargo deny check licenses
+	cargo deny check sources
 
 run: ## Start the development server
 	cargo run

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,129 @@
+# cargo-deny configuration for SorobanPulse
+# https://embarkstudios.github.io/cargo-deny/
+
+# =====================================================================
+# Advisories - Check for known security vulnerabilities
+# =====================================================================
+[advisories]
+# Treat advisory database as the source of truth
+version = 2
+# Ignore advisories for specific crates (if any)
+ignore = []
+# Yanked crate versions are treated as vulnerabilities
+yanked = "warn"
+# Ignore individual advisories by RUSTSEC ID
+# ignore = [
+#     { id = "RUSTSEC-0000-0000", reason = "not applicable" }
+# ]
+
+# =====================================================================
+# Bans - Check for banned dependencies
+# =====================================================================
+[bans]
+# Multiple versions of the same crate are allowed (set to "deny" to enforce single version)
+multiple-versions = "warn"
+# List of crates that are not allowed to be used
+deny = [
+    # Security-sensitive crates that should not be used directly
+    # { name = "openssl", wrappers = ["openssl-sys"] },
+    # { name = "reqwest", wrappers = [] },
+]
+
+# List of crates that are allowed to have multiple versions
+skip = [
+    # Add crates here if they need to have multiple versions
+    # { name = "some-crate", version = ">=1.0, <2.0" },
+]
+
+# List of crates that are allowed to be skipped from checking
+allow-wildcard-dependencies = false
+
+# Allow specific crates to have wildcard version requirements
+# allow-wildcard-dependencies = [
+#     { name = "some-crate", allow = ["*"] },
+# ]
+
+# =====================================================================
+# Licenses - Check for allowed licenses
+# =====================================================================
+[licenses]
+# How to handle unlicensed crates
+unlicensed = "deny"
+# List of allowed licenses
+allow = [
+    "MIT",
+    "Apache-2.0",
+    "Apache-2.0 WITH LLVM-exception",
+    "BSD-2-Clause",
+    "BSD-3-Clause",
+    "ISC",
+    "Unicode-DFS-2016",
+    "Unicode-3.0",
+    "Zlib",
+    "0BSD",
+    "BSL-1.0",
+    "CC0-1.0",
+    "Zlib",
+]
+# Confidence threshold for license detection
+confidence-threshold = 0.8
+# Allow crates with specific licenses
+# allow = [
+#     { name = "some-crate", license = "MIT" },
+# ]
+# Deny crates with specific licenses
+# deny = [
+#     { name = "some-crate", license = "GPL-3.0" },
+# ]
+
+# =====================================================================
+# Sources - Check for crate sources
+# =====================================================================
+[sources]
+# How to handle crates with unknown sources
+unknown-registry = "warn"
+unknown-git = "warn"
+# List of allowed sources
+allow-registry = [
+    "https://github.com/rust-lang/crates.io-index",
+    "https://github.com/rust-lang/crates.io",
+]
+allow-git = [
+    # Add allowed git sources here
+    # "https://github.com/some-org/some-repo",
+]
+
+# =====================================================================
+# Targets - Check for specific targets
+# =====================================================================
+[targets]
+# List of targets to check
+# targets = [
+#     { triple = "x86_64-unknown-linux-gnu", features = [] },
+#     { triple = "aarch64-unknown-linux-gnu", features = [] },
+# ]
+
+# =====================================================================
+# Yanked - Check for yanked crates
+# =====================================================================
+[yanked]
+# How to handle yanked crate versions
+warn = ["*"]
+
+# =====================================================================
+# All - Global settings
+# =====================================================================
+[all]
+# Maximum number of advisories to report (0 = unlimited)
+# max-advisories = 0
+# Maximum number of bans to report (0 = unlimited)
+# max-bans = 0
+
+# =====================================================================
+# Features - Feature configuration
+# =====================================================================
+[features]
+# List of features to enable for all crates
+# enable = ["some-feature"]
+# List of features to disable for all crates
+# disable = ["some-feature"]

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -9,6 +9,9 @@ pre-commit:
     clippy:
       run: cargo clippy -- -D warnings
       glob: "*.rs"
+    deny:
+      run: cargo deny check
+      glob: "Cargo.toml"
     gen-openapi:
       run: cargo run --bin gen_openapi > openapi.json && cp openapi.json docs/openapi.json && git add openapi.json docs/openapi.json
       glob: "*.rs"


### PR DESCRIPTION
This PR adds comprehensive cargo-deny configuration and CI integration including:

- Add deny.toml configuration for license, advisory, ban, and source checks
- Add cargo-deny CI workflow with advisory, ban, license, and source checks
- Add cargo-deny pre-commit hook to lefthook.yml
- Add deny target to Makefile for local development
- Configure allowed licenses: MIT, Apache-2.0, BSD, ISC, Unicode
- Configure advisory database checking for known vulnerabilities

Closes #640
Closes #641
Closes #638
Closes #639