### PR TITLE
docs: expand operational guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,13 @@ migrations/
 
 See [docs/schema.md](docs/schema.md) for a detailed description of the database schema, indexes, constraints, and an ER diagram.
 
+## Documentation
+
+- [Subscription best practices](docs/subscription-best-practices.md) covers filter optimization, delivery frequency, retry/backoff guidance, common patterns, and anti-patterns.
+- [Contract event schemas](docs/contract-event-schemas.md) documents Stellar contract event patterns, XDR encoding, event data types, examples, and validation rules.
+- [Multi-deployment architecture](docs/multi-deployment-architecture.md) covers geo-redundancy, failover, cross-region sync, multi-cloud deployment, and consistency trade-offs.
+- [Data retention policy](docs/data-retention.md) explains default retention periods, archival, GDPR procedures, deletion workflows, and audit trail retention.
+
 ## Setup
 
 ### 1. Prerequisites

--- a/docs/contract-event-schemas.md
+++ b/docs/contract-event-schemas.md
@@ -182,6 +182,18 @@ GET /v1/events?event_type=contract
 - Events exceeding this limit are logged and skipped
 - The `soroban_pulse_events_oversized_total` counter tracks skipped events
 
+## Schema Validation Rules
+
+Use these rules when publishing or validating decoded contract events:
+
+- `contract_id` must be a valid Stellar contract strkey starting with `C`.
+- `tx_hash` and `ledger_hash`, when present, must be lowercase hex strings.
+- `ledger` must be a positive integer and `ledger_closed_at` must be an RFC 3339 timestamp.
+- `topic` must contain base64-encoded XDR `ScVal` segments, with `topic[0]` as a symbol for filterable contract events.
+- Numeric Soroban values larger than JavaScript's safe integer range must be serialized as strings.
+- `event_type` must be one of `contract`, `system`, or `diagnostic`.
+- `value` must be valid JSON and stay within `MAX_EVENT_DATA_BYTES`.
+
 ## Versioning
 
 The event schema is tied to the Soroban protocol version. Breaking changes are announced in `CHANGELOG.md` and the `schema_version` column in the database tracks the protocol version in effect when each event was stored.

--- a/docs/data-retention.md
+++ b/docs/data-retention.md
@@ -234,6 +234,12 @@ psql "$DATABASE_URL" -c "DROP SCHEMA public CASCADE; CREATE SCHEMA public;"
 
 Revoke database credentials and destroy any object-store archives according to your organisation's data disposal policy.
 
+## Audit Trail Retention
+
+Keep admin audit logs for at least 365 days, or longer when required by your compliance program. Audit records should include the actor, action, target resource, request identifier, timestamp, and outcome, but should not store full secrets or unnecessary payload data.
+
+Audit logs should be immutable to normal application users. Export them to append-only object storage or a SIEM before database purge jobs run, and restrict deletion permissions to break-glass administrators. When responding to GDPR erasure requests, retain audit entries needed to prove compliance while redacting direct personal identifiers where legally required.
+
 ## Related Documentation
 
 - [Encryption at rest setup guide](encryption.md)

--- a/docs/multi-deployment-architecture.md
+++ b/docs/multi-deployment-architecture.md
@@ -210,3 +210,18 @@ curl https://region-b.pulse.example.com/healthz/ready
 curl https://region-a.pulse.example.com/v1/metrics | grep soroban_pulse_indexer_is_leader
 curl https://region-b.pulse.example.com/v1/metrics | grep soroban_pulse_indexer_is_leader
 ```
+
+## Data Consistency
+
+SorobanPulse should use a single writable PostgreSQL primary per network. Cross-region replicas are eventually consistent and can lag behind the primary, so route admin operations, subscription changes, webhook registration, and replay jobs to the primary region.
+
+For read traffic, choose a consistency mode per workload:
+
+| Workload | Recommended routing | Consistency expectation |
+|---|---|---|
+| Dashboard analytics | Nearest healthy replica | Eventual consistency is acceptable |
+| Alerting and webhook delivery | Primary region | Avoid missed or duplicated delivery decisions |
+| Replay/backfill jobs | Primary region | Reads the latest checkpoint and writes deterministic output |
+| Public event search | Replica with lag checks | Reject or reroute when replica lag exceeds the SLA |
+
+Use idempotent consumers and ledger checkpoints to handle duplicate reads after failover. After promotion, verify the new primary has replayed all WAL up to the last known `indexer_checkpoints` row before enabling webhook delivery.

--- a/docs/subscription-best-practices.md
+++ b/docs/subscription-best-practices.md
@@ -263,6 +263,14 @@ HAVING COUNT(*) > 10;
 
 When a webhook endpoint is persistently unavailable, consider temporarily disabling it via `PATCH /v1/webhooks/:id` and re-enabling it once the endpoint recovers. This prevents your retry queue from building up.
 
+## Anti-Patterns to Avoid
+
+- Subscribing to every contract and filtering in the consumer when a contract or topic filter is available.
+- Performing long-running work before returning `200 OK` from a webhook handler.
+- Creating duplicate subscriptions for the same contract, topic set, and destination.
+- Ignoring `Retry-After` on REST polling clients after `429` or `503` responses.
+- Reconnecting SSE clients in tight loops without jitter or `Last-Event-ID`.
+
 ## Related Documentation
 
 - [Webhook verification](webhook-verification.md)


### PR DESCRIPTION
Summary:
- Add discoverability links for operational documentation in README.
- Document missing subscription anti-patterns, contract schema validation rules, multi-deployment consistency guidance, and audit trail retention.

Closes: #726
Closes: #727
Closes: #728
Closes: #729

Validation:
- git diff --check
- cargo fmt --check not run: cargo is not installed in this environment
- make lint/cargo clippy not run: cargo is not installed in this environment