### PR TITLE
feat(#695): Create custom Grafana dashboard panels for event flow vis…

### DIFF
--- a/docs/grafana-dashboard.json
+++ b/docs/grafana-dashboard.json
@@ -39,6 +39,18 @@
       "id": "gauge",
       "name": "Gauge",
       "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "heatmap",
+      "name": "Heatmap",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "bargauge",
+      "name": "Bar gauge",
+      "version": ""
     }
   ],
   "annotations": {
@@ -57,7 +69,9 @@
       }
     ]
   },
-  "description": "Soroban Pulse operational metrics dashboard",
+  "description": "Soroban Pulse operational metrics dashboard with event flow visualization, lag heatmaps, contract popularity, and webhook delivery monitoring",
+  "theme": "dark",
+  "style": "dark",
   "editable": true,
   "fiscalYearStartMonth": 0,
   "graphTooltip": 1,
@@ -803,6 +817,459 @@
           "refId": "A"
         }
       ]
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 200,
+      "title": "Event Flow & Notifications",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#37872D",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 50
+              },
+              {
+                "color": "#E02F44",
+                "value": 200
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 0,
+        "y": 53
+      },
+      "id": 201,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name",
+        "trendDisplayMode": "arrow"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(soroban_pulse_events_indexed_total{instance=~\"$instance\"}[1m]) * 60",
+          "legendFormat": "Events/min",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "rate(soroban_pulse_events_indexed_total{instance=~\"$instance\"}[1m] offset 5m) * 60",
+          "legendFormat": "Events/min (prev)",
+          "refId": "B"
+        }
+      ],
+      "title": "Event Rate (events/min)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#37872D",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 0
+              },
+              {
+                "color": "#E02F44",
+                "value": 10
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 6,
+        "y": 53
+      },
+      "id": 202,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name",
+        "trendDisplayMode": "arrow"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "soroban_pulse_indexer_lag_ledgers{instance=~\"$instance\"}",
+          "legendFormat": "Current Lag",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "soroban_pulse_indexer_lag_ledgers{instance=~\"$instance\"} offset 5m",
+          "legendFormat": "Lag (5m ago)",
+          "refId": "B"
+        }
+      ],
+      "title": "Current Indexer Lag",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#E02F44",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 80
+              },
+              {
+                "color": "#37872D",
+                "value": 95
+              }
+            ]
+          },
+          "unit": "percent"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 12,
+        "y": 53
+      },
+      "id": 203,
+      "options": {
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": true,
+        "showThresholdMarkers": true,
+        "text": {}
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "(sum(rate(soroban_pulse_webhook_delivery_success_total{instance=~\"$instance\"}[5m])) / (sum(rate(soroban_pulse_webhook_delivery_success_total{instance=~\"$instance\"}[5m])) + sum(rate(soroban_pulse_webhook_failures_total{instance=~\"$instance\"}[5m])) + 0.001)) * 100",
+          "legendFormat": "Webhook Success Rate",
+          "refId": "A"
+        }
+      ],
+      "title": "Webhook Delivery Success Rate",
+      "type": "gauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "max": 100,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#37872D",
+                "value": null
+              },
+              {
+                "color": "#EAB839",
+                "value": 50
+              },
+              {
+                "color": "#E02F44",
+                "value": 100
+              }
+            ]
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 6,
+        "x": 18,
+        "y": 53
+      },
+      "id": 204,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "area",
+        "justifyMode": "center",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "value_and_name",
+        "trendDisplayMode": "arrow"
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(soroban_pulse_notification_delivery_success_total{instance=~\"$instance\"}[5m])) * 60",
+          "legendFormat": "Deliveries/min",
+          "refId": "A"
+        },
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(soroban_pulse_notification_delivery_success_total{instance=~\"$instance\"}[5m] offset 5m)) * 60",
+          "legendFormat": "Deliveries/min (prev)",
+          "refId": "B"
+        }
+      ],
+      "title": "Notification Delivery Rate",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "unit": "short"
+        }
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 63
+      },
+      "id": 205,
+      "options": {
+        "calculate": false,
+        "calculation": {},
+        "cellGap": 2,
+        "cellValues": {},
+        "color": {
+          "exponent": 0.5,
+          "fill": "#5794F2",
+          "max": 50,
+          "min": 0,
+          "mode": "scheme",
+          "reverse": false,
+          "scale": "exponential",
+          "scheme": "Spectral",
+          "steps": 64
+        },
+        "exemplars": {
+          "color": "rgba(255,0,255,0.7)"
+        },
+        "filterValues": {
+          "le": 1e-9
+        },
+        "legend": {
+          "show": true
+        },
+        "rowsFrame": {
+          "layout": "auto"
+        },
+        "showValue": "never",
+        "tooltip": {
+          "show": true,
+          "yHistogram": true
+        },
+        "yAxis": {
+          "axisPlacement": "left",
+          "reverse": false,
+          "unit": "short"
+        }
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "sum(rate(soroban_pulse_indexer_lag_observation_ledgers_bucket{instance=~\"$instance\"}[5m])) by (le)",
+          "format": "heatmap",
+          "legendFormat": "{{le}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Lag Distribution Heatmap",
+      "type": "heatmap"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "${DS_PROMETHEUS}"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            }
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 63
+      },
+      "id": 206,
+      "options": {
+        "displayMode": "gradient",
+        "minVizHeight": 16,
+        "minVizWidth": 8,
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true,
+        "text": {
+          "titleSize": 14,
+          "valueSize": 12
+        }
+      },
+      "pluginVersion": "9.0.0",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "expr": "topk(10, soroban_pulse_contract_event_count{instance=~\"$instance\"})",
+          "legendFormat": "{{contract_id}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Contract Popularity Top-10",
+      "type": "bargauge"
     }
   ],
   "refresh": "30s",

--- a/src/indexer.rs
+++ b/src/indexer.rs
@@ -582,6 +582,7 @@ impl<R: RpcClient> Indexer<R> {
                             }
                             let lag = result.latest_ledger - current_ledger;
                             metrics::update_indexer_lag(lag);
+                            metrics::record_indexer_lag_observation(lag);
 
                             // Warn if lag exceeds threshold
                             if lag > self.config.indexer_lag_warn_threshold {
@@ -600,6 +601,7 @@ impl<R: RpcClient> Indexer<R> {
                             }
                             let lag = latest.saturating_sub(current_ledger);
                             metrics::update_indexer_lag(lag);
+                            metrics::record_indexer_lag_observation(lag);
                         }
                         sleep(Duration::from_millis(self.config.indexer_poll_interval_ms)).await;
                     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -568,6 +568,35 @@ pub fn update_notification_rate_per_minute(channel: &str, rate: f64) {
     .set(rate);
 }
 
+/// #695: Record a successful notification delivery attempt.
+pub fn record_notification_delivery_success() {
+    m::counter!("soroban_pulse_notification_delivery_success_total").increment(1);
+}
+
+/// #695: Record a failed notification delivery attempt.
+pub fn record_notification_delivery_failure() {
+    m::counter!("soroban_pulse_notification_delivery_failure_total").increment(1);
+}
+
+/// #695: Record a successful webhook delivery.
+pub fn record_webhook_delivery_success() {
+    m::counter!("soroban_pulse_webhook_delivery_success_total").increment(1);
+}
+
+/// #695: Update the per-contract event count gauge (used for top-10 contract popularity panel).
+pub fn update_contract_event_count(contract_id: &str, count: i64) {
+    m::gauge!(
+        "soroban_pulse_contract_event_count",
+        "contract_id" => contract_id.to_string()
+    )
+    .set(count as f64);
+}
+
+/// #695: Record an observation of indexer lag for heatmap distribution.
+pub fn record_indexer_lag_observation(lag: u64) {
+    m::histogram!("soroban_pulse_indexer_lag_observation_ledgers").record(lag as f64);
+}
+
 // ── Issue #607: Contract ABI cache metrics ───────────────────────────────────
 
 pub fn record_abi_cache_hit(contract_id: &str) {
@@ -875,6 +904,40 @@ mod tests {
 
         // This should not panic
         update_db_pool_metrics(&pool);
+        assert!(true);
+    }
+
+    // ── Issue #695: new custom dashboard panel metrics ───────────────────
+
+    #[test]
+    fn test_record_webhook_delivery_success() {
+        record_webhook_delivery_success();
+        assert!(true);
+    }
+
+    #[test]
+    fn test_record_notification_delivery_success() {
+        record_notification_delivery_success();
+        assert!(true);
+    }
+
+    #[test]
+    fn test_record_notification_delivery_failure() {
+        record_notification_delivery_failure();
+        assert!(true);
+    }
+
+    #[test]
+    fn test_update_contract_event_count() {
+        update_contract_event_count("CABCDEF12345678901234567890123456789012345678901234567", 42);
+        update_contract_event_count("CABCDEF12345678901234567890123456789012345678901234567", 0);
+        assert!(true);
+    }
+
+    #[test]
+    fn test_record_indexer_lag_observation() {
+        record_indexer_lag_observation(0);
+        record_indexer_lag_observation(1000);
         assert!(true);
     }
 

--- a/src/stats_refresh.rs
+++ b/src/stats_refresh.rs
@@ -171,6 +171,29 @@ pub async fn check_staleness(pool: &PgPool) {
     }
 }
 
+/// Update the per-contract event count Prometheus gauges for the Grafana
+/// "Contract Popularity Top-10" panel (#695). Reads from `events_contract_summary`.
+pub async fn update_contract_event_count_metrics(pool: &PgPool) {
+    let mut conn = match pool.acquire().await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(error = %e, "Failed to acquire DB connection for contract metrics");
+            return;
+        }
+    };
+
+    let rows: Vec<(String, i64)> = sqlx::query_as(
+        "SELECT contract_id, event_count FROM events_contract_summary ORDER BY event_count DESC LIMIT 20",
+    )
+    .fetch_all(&mut *conn)
+    .await
+    .unwrap_or_default();
+
+    for (contract_id, count) in rows {
+        crate::metrics::update_contract_event_count(&contract_id, count);
+    }
+}
+
 /// Run EXPLAIN on a representative events query and record estimated row count.
 pub async fn analyze_query_plans(pool: &PgPool) {
     let queries: &[(&str, &str)] = &[
@@ -221,12 +244,14 @@ pub fn spawn(pool: PgPool, interval_secs: u64, mut shutdown: watch::Receiver<boo
         refresh_all(&pool).await;
         check_staleness(&pool).await;
         analyze_query_plans(&pool).await;
+        update_contract_event_count_metrics(&pool).await;
         loop {
             tokio::select! {
                 _ = tokio::time::sleep(interval) => {
                     refresh_all(&pool).await;
                     check_staleness(&pool).await;
                     analyze_query_plans(&pool).await;
+                    update_contract_event_count_metrics(&pool).await;
                 }
                 _ = shutdown.changed() => {
                     info!("Stats refresh task shutting down");

--- a/src/webhook.rs
+++ b/src/webhook.rs
@@ -194,6 +194,7 @@ pub async fn deliver_with_retry_policy(
                             priority = %event.event_type,
                             "Webhook delivered successfully"
                         );
+                        crate::metrics::record_webhook_delivery_success();
                         Ok(())
                     }
                     Ok(resp) => {
@@ -304,6 +305,7 @@ pub async fn deliver_with_failover(
             match req.send().await {
                 Ok(resp) if resp.status().is_success() => {
                     info!(url = %url, attempt = attempt, "Webhook delivered (primary)");
+                    crate::metrics::record_webhook_delivery_success();
                     Ok(())
                 }
                 Ok(resp) => Err(format!("HTTP {}", resp.status())),
@@ -342,6 +344,7 @@ pub async fn deliver_with_failover(
                 match req.send().await {
                     Ok(resp) if resp.status().is_success() => {
                         info!(url = %url, attempt = attempt, "Webhook delivered (failover)");
+                        crate::metrics::record_webhook_delivery_success();
                         Ok(())
                     }
                     Ok(resp) => Err(format!("HTTP {}", resp.status())),


### PR DESCRIPTION
…ualization

- Add event rate panel with trend arrows (stat panel with sparkline + comparison query)
- Add lag distribution heatmap using histogram buckets
- Add contract popularity top-10 bargauge panel
- Add webhook delivery success rate gauge panel
- Add notification delivery rate stat panel with trend arrows
- Implement custom color themes with dark mode and per-panel threshold colors
- Add new Prometheus metrics: record_webhook_delivery_success, record_notification_delivery_success/failure, update_contract_event_count, record_indexer_lag_observation
- Wire new metrics into webhook delivery, indexer lag tracking, and stats refresh loop

Closes #695

## Summary

<!-- A clear, concise description of what this PR does. -->

## Related Issue

Closes #<!-- issue number -->

## Changes

<!-- List the key changes made. -->

- 

## Testing

<!-- Describe how you tested this. -->

- [ ] `cargo test` passes
- [ ] `cargo clippy` reports no warnings
- [ ] Manually tested locally

## Notes

<!-- Anything reviewers should pay special attention to, or N/A. -->
