### PR TITLE
feat(#700): add POST /v1/replay/with-transform endpoint

### DIFF
--- a/docs/lua-transformation.md
+++ b/docs/lua-transformation.md
@@ -358,6 +358,108 @@ curl -X POST https://your-host/v1/admin/lua/preview \
 
 ---
 
+## Replay With Transform Endpoint
+
+Re-run already-indexed events through a Lua transformation and, optionally,
+redeliver the transformed events through the normal downstream pipeline
+(webhooks, SSE, email, etc.) — exactly as if they had just been indexed. This
+is useful for backfilling a new derived field, correcting a past enrichment
+bug, or testing a transformation against real historical data before wiring
+it up as the indexer's permanent `EVENT_TRANSFORM_SCRIPT`.
+
+### `POST /v1/replay/with-transform`
+
+**Request body:**
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `transformation_script` | string | **Required.** The body of an implicit `function transform_event(event) ... end` — write just the statements, e.g. `"return event"`. Return the (optionally modified) `event` table to keep it, or `nil` to skip it. |
+| `from_ledger` / `to_ledger` | integer | Ledger range to replay. Either this or `from_timestamp` is required. |
+| `from_timestamp` / `to_timestamp` | string (ISO 8601) | Timestamp range to replay, as an alternative to the ledger range. |
+| `contract_id` | string | Restrict replay to a single contract. |
+| `dry_run` | bool | When `true` (default `false`), run the script and report results without redelivering any events. |
+| `limit` | integer | Max events to replay (default 100, max 1000). |
+
+Note the script convention here differs from the `EVENT_TRANSFORM_SCRIPT` file
+and the `/v1/admin/lua/preview` endpoint above, which both require a full
+script that *defines* `transform_event`. This endpoint wraps whatever you
+send as the function body, so short scripts don't need the boilerplate.
+
+**Response:**
+
+```json
+{
+  "replay_id": "8f14e45f-ceea-4c8a-b81e-1234567890ab",
+  "status": "completed",
+  "dry_run": false,
+  "total_events": 3,
+  "transformed_events": 2,
+  "skipped_events": 1,
+  "error_events": 0,
+  "preview": [
+    {
+      "event_id": "11111111-1111-1111-1111-111111111111",
+      "original": { "contractId": "CABC...", "value": { "amount": 100 } },
+      "transformed": { "contractId": "CABC...", "value": { "amount": 100, "amount_xlm": 0.00001 } },
+      "error": null
+    }
+  ]
+}
+```
+
+`status` is `"dry_run"` when the request had `dry_run: true`, otherwise
+`"completed"`. `preview` always lists the original/transformed pair for every
+event considered, regardless of `dry_run`, so you can inspect exactly what
+the script did.
+
+### Examples
+
+Add a human-readable amount alongside the raw stroop value, for the last
+1,000 ledgers, without delivering anything (dry run):
+
+```bash
+curl -X POST https://your-host/v1/replay/with-transform \
+  -H "Content-Type: application/json" \
+  -d '{
+    "from_ledger": 100000,
+    "to_ledger": 101000,
+    "dry_run": true,
+    "transformation_script": "if event.value.amount then event.value.amount_xlm = event.value.amount / 10000000 end return event"
+  }'
+```
+
+Backfill a `contract_label` field for one contract and redeliver the
+transformed events to subscribers:
+
+```bash
+curl -X POST https://your-host/v1/replay/with-transform \
+  -H "Content-Type: application/json" \
+  -d '{
+    "from_timestamp": "2026-01-01T00:00:00Z",
+    "to_timestamp": "2026-01-02T00:00:00Z",
+    "contract_id": "CABC...",
+    "transformation_script": "event.value.contract_label = \"DEX Contract\" return event"
+  }'
+```
+
+Drop diagnostic events entirely while replaying a ledger range (script
+returns `nil` for events to skip):
+
+```bash
+curl -X POST https://your-host/v1/replay/with-transform \
+  -H "Content-Type: application/json" \
+  -d '{
+    "from_ledger": 50000,
+    "to_ledger": 50500,
+    "transformation_script": "if event.event_type == \"diagnostic\" then return nil end return event"
+  }'
+```
+
+See `examples/replay_with_transform_normalize.lua` for a longer example in
+the same bare-body convention.
+
+---
+
 ## Future Enhancements
 
 Potential future improvements:

--- a/examples/replay_with_transform_normalize.lua
+++ b/examples/replay_with_transform_normalize.lua
@@ -1,0 +1,28 @@
+-- Example transformation body for POST /v1/replay/with-transform
+--
+-- Unlike EVENT_TRANSFORM_SCRIPT files and /v1/admin/lua/preview, the
+-- replay-with-transform endpoint wraps whatever you send in
+-- `transformation_script` as the body of an implicit
+-- `function transform_event(event) ... end` — so this file is the function
+-- *body* only, not a standalone script defining the function itself.
+--
+-- Usage: send this file's contents (or an inline excerpt) as the
+-- `transformation_script` field of a POST /v1/replay/with-transform request.
+
+-- Drop diagnostic events entirely.
+if event.event_type == "diagnostic" then
+    return nil
+end
+
+-- Add a human-readable XLM amount alongside the raw stroop value.
+if event.value and event.value.amount then
+    event.value.amount_xlm = event.value.amount / 10000000
+end
+
+-- Tag the event so it's obvious downstream that this row went through a
+-- replay pass rather than the original indexer.
+if event.value then
+    event.value.replayed = true
+end
+
+return event

--- a/src/handlers.rs
+++ b/src/handlers.rs
@@ -5415,6 +5415,172 @@ pub async fn lua_preview(
     Ok(Json(models::LuaPreviewResponse { results }))
 }
 
+/// Replay already-indexed events through a Lua transformation script (Issue #700).
+///
+/// Fetches events matching the ledger and/or timestamp window (and optional
+/// `contract_id` filter), runs each one through `transformation_script`, and
+/// reports per-event results. In `dry_run` mode nothing is redelivered — the
+/// endpoint only reports what the script *would* do. Otherwise, transformed
+/// events (script returned a table, not `nil`) are broadcast on the same
+/// channel newly-indexed events use, so they flow through the normal
+/// downstream pipeline (webhooks, SSE, email, etc.) exactly like a live event.
+#[utoipa::path(
+    post,
+    path = "/v1/replay/with-transform",
+    tag = "admin",
+    request_body = models::ReplayWithTransformRequest,
+    responses(
+        (status = 200, description = "Replay completed or previewed", body = models::ReplayWithTransformResponse),
+        (status = 400, description = "Invalid request or transformation script"),
+    )
+)]
+pub async fn replay_with_transform(
+    State(state): State<AppState>,
+    Json(request): Json<models::ReplayWithTransformRequest>,
+) -> Result<Json<models::ReplayWithTransformResponse>, AppError> {
+    if request.transformation_script.trim().is_empty() {
+        return Err(AppError::Validation(
+            "transformation_script must not be empty".to_string(),
+        ));
+    }
+    if request.from_ledger.is_none() && request.from_timestamp.is_none() {
+        return Err(AppError::Validation(
+            "either from_ledger or from_timestamp is required".to_string(),
+        ));
+    }
+    if let (Some(from), Some(to)) = (request.from_ledger, request.to_ledger) {
+        if from > to {
+            return Err(AppError::Validation(
+                "from_ledger must be <= to_ledger".to_string(),
+            ));
+        }
+    }
+    if let (Some(from), Some(to)) = (request.from_timestamp, request.to_timestamp) {
+        if from > to {
+            return Err(AppError::Validation(
+                "from_timestamp must be <= to_timestamp".to_string(),
+            ));
+        }
+    }
+
+    let wrapped_script =
+        crate::lua_transform::LuaTransformer::wrap_script_body(&request.transformation_script);
+    crate::lua_transform::LuaTransformer::validate_syntax(&wrapped_script)
+        .map_err(|e| AppError::Validation(format!("invalid transformation script: {e}")))?;
+
+    let limit = request.limit.unwrap_or(100).clamp(1, 1000);
+
+    let mut query = QueryBuilder::<sqlx::Postgres>::new(
+        "SELECT id, contract_id, event_type, tx_hash, ledger, timestamp, event_data \
+         FROM events WHERE ",
+    );
+    let mut needs_and = false;
+    if let Some(from_ledger) = request.from_ledger {
+        query.push("ledger >= ");
+        query.push_bind(from_ledger);
+        needs_and = true;
+    }
+    if let Some(to_ledger) = request.to_ledger {
+        if needs_and {
+            query.push(" AND ");
+        }
+        query.push("ledger <= ");
+        query.push_bind(to_ledger);
+        needs_and = true;
+    }
+    if let Some(from_timestamp) = request.from_timestamp {
+        if needs_and {
+            query.push(" AND ");
+        }
+        query.push("timestamp >= ");
+        query.push_bind(from_timestamp);
+        needs_and = true;
+    }
+    if let Some(to_timestamp) = request.to_timestamp {
+        if needs_and {
+            query.push(" AND ");
+        }
+        query.push("timestamp <= ");
+        query.push_bind(to_timestamp);
+        needs_and = true;
+    }
+    if let Some(ref contract_id) = request.contract_id {
+        if needs_and {
+            query.push(" AND ");
+        }
+        query.push("contract_id = ");
+        query.push_bind(contract_id);
+    }
+    query.push(" ORDER BY ledger ASC LIMIT ");
+    query.push_bind(limit);
+
+    let rows = query.build().fetch_all(&state.pool).await?;
+
+    let ids: Vec<uuid::Uuid> = rows
+        .iter()
+        .map(|r| r.try_get::<uuid::Uuid, _>("id"))
+        .collect::<Result<_, _>>()?;
+    let events: Vec<crate::models::SorobanEvent> = rows
+        .iter()
+        .map(|r| -> Result<_, sqlx::Error> {
+            let timestamp: DateTime<Utc> = r.try_get("timestamp")?;
+            Ok(crate::models::SorobanEvent {
+                id: None,
+                contract_id: r.try_get("contract_id")?,
+                event_type: r.try_get("event_type")?,
+                tx_hash: r.try_get("tx_hash")?,
+                ledger: r.try_get::<i64, _>("ledger")? as u64,
+                ledger_closed_at: timestamp.to_rfc3339(),
+                ledger_hash: None,
+                in_successful_call: true,
+                value: r.try_get("event_data")?,
+                topic: None,
+                tenant_id: None,
+            })
+        })
+        .collect::<Result<_, _>>()?;
+
+    let total_events = events.len() as i64;
+    let timeout_ms = state.config.event_transform_timeout_ms;
+    let mut preview =
+        crate::lua_transform::LuaTransformer::preview_events(wrapped_script, events, timeout_ms)
+            .await;
+    for (item, id) in preview.iter_mut().zip(ids.iter()) {
+        item.event_id = *id;
+    }
+
+    let transformed_events = preview.iter().filter(|i| i.transformed.is_some()).count() as i64;
+    let error_events = preview.iter().filter(|i| i.error.is_some()).count() as i64;
+    let skipped_events = total_events - transformed_events - error_events;
+
+    if !request.dry_run {
+        for item in preview.iter() {
+            if let Some(ref transformed) = item.transformed {
+                if let Ok(event) =
+                    serde_json::from_value::<crate::models::SorobanEvent>(transformed.clone())
+                {
+                    let _ = state.event_tx.send(event);
+                }
+            }
+        }
+    }
+
+    Ok(Json(models::ReplayWithTransformResponse {
+        replay_id: uuid::Uuid::new_v4(),
+        status: if request.dry_run {
+            "dry_run".to_string()
+        } else {
+            "completed".to_string()
+        },
+        dry_run: request.dry_run,
+        total_events,
+        transformed_events,
+        skipped_events,
+        error_events,
+        preview,
+    }))
+}
+
 pub async fn replay_events(
     State(state): State<AppState>,
     Json(request): Json<models::ReplayRequest>,
@@ -14731,6 +14897,8 @@ mod ops_tests {
         assert!(v.get("entries").is_some());
         assert!(v.get("count").is_some());
     }
+}
+
 // ── Issue #696: SLI / SLO admin reporting endpoint ──────────────────────────
 
 /// Return the current SLI / SLO aggregate report.

--- a/src/lua_transform.rs
+++ b/src/lua_transform.rs
@@ -363,6 +363,25 @@ impl LuaTransformer {
             .context("failed to compile preview script")?;
         Self::transform_sync(&lua, event)
     }
+
+    /// Wrap a bare script body into an implicit `transform_event` function
+    /// definition, so callers of the replay-with-transform endpoint can pass
+    /// a short expression (e.g. `"return event"`) instead of a full script
+    /// that defines `transform_event` itself.
+    pub fn wrap_script_body(body: &str) -> String {
+        format!("function transform_event(event)\n{body}\nend")
+    }
+
+    /// Check that a (already-wrapped) script compiles as valid Lua, without
+    /// executing it. Used to reject malformed scripts with a 400 before any
+    /// events are touched.
+    pub fn validate_syntax(script: &str) -> Result<(), String> {
+        let lua = Lua::new();
+        lua.load(script)
+            .into_function()
+            .map(|_| ())
+            .map_err(|e| e.to_string())
+    }
 }
 
 #[cfg(test)]

--- a/src/models.rs
+++ b/src/models.rs
@@ -507,6 +507,47 @@ pub struct ReplayRequest {
     pub to_ledger: u64,
 }
 
+/// Request body for POST /v1/replay/with-transform (Issue #700).
+///
+/// Replays already-indexed events matching the given ledger or timestamp
+/// window through a Lua transformation script. Either `from_ledger` or
+/// `from_timestamp` is required.
+#[derive(Debug, Deserialize, utoipa::ToSchema)]
+pub struct ReplayWithTransformRequest {
+    pub from_ledger: Option<i64>,
+    pub to_ledger: Option<i64>,
+    pub from_timestamp: Option<DateTime<Utc>>,
+    pub to_timestamp: Option<DateTime<Utc>>,
+    /// Restrict replay to a single contract.
+    pub contract_id: Option<String>,
+    /// Lua expression or statements evaluated as the body of an implicit
+    /// `function transform_event(event) ... end`. Return the (optionally
+    /// modified) `event` table to keep it, or `nil` to skip it.
+    pub transformation_script: String,
+    /// When true, run the transformation and report results without
+    /// redelivering any events. Defaults to false.
+    #[serde(default)]
+    pub dry_run: bool,
+    /// Max events to replay (default 100, max 1000).
+    pub limit: Option<i64>,
+}
+
+/// Response body for POST /v1/replay/with-transform.
+#[derive(Debug, Serialize, utoipa::ToSchema)]
+pub struct ReplayWithTransformResponse {
+    pub replay_id: Uuid,
+    /// "dry_run" or "completed".
+    pub status: String,
+    pub dry_run: bool,
+    pub total_events: i64,
+    pub transformed_events: i64,
+    pub skipped_events: i64,
+    pub error_events: i64,
+    /// Original/transformed event pairs. Always populated (bounded by
+    /// `limit`) so callers can inspect the effect of the script.
+    pub preview: Vec<LuaPreviewItem>,
+}
+
 /// Request body for the batch tx-hash lookup endpoint.
 #[derive(Debug, Deserialize, utoipa::ToSchema)]
 pub struct BatchTxRequest {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -142,6 +142,7 @@ pub struct AppState {
         handlers::ws_stream_events,
         handlers::get_contracts,
         handlers::replay_events,
+        handlers::replay_with_transform,
         handlers::start_reencrypt,
         handlers::register_contract_abi,
         handlers::get_contract_abi,
@@ -500,6 +501,7 @@ pub fn create_router_with_tx_and_tenant_map(
         .route("/contracts/{contract_id}/summary", get(handlers::get_contract_summary))
         .route("/contracts/{contract_id}/event-counts", get(handlers::get_contract_event_counts))
         .route("/admin/replay", axum::routing::post(handlers::replay_events))
+        .route("/replay/with-transform", axum::routing::post(handlers::replay_with_transform))
         .route("/admin/reencrypt", axum::routing::post(handlers::start_reencrypt))
         .route("/admin/mask-events", axum::routing::post(handlers::start_mask_events))
         .route("/admin/mask-events/{job_id}", get(handlers::get_mask_job_status))


### PR DESCRIPTION
## Summary
- Adds `POST /v1/replay/with-transform`: replays already-indexed events (by ledger and/or timestamp window, optionally filtered by `contract_id`) through a Lua transformation script.
- Scripts are the bare *body* of an implicit `function transform_event(event) ... end` (e.g. `"return event"`), wrapped and syntax-checked (400 before touching the DB) via new `LuaTransformer::wrap_script_body` / `validate_syntax` helpers. Execution reuses the existing, already-tested `LuaTransformer::preview_events` (same timeout/instruction/memory limits as `/v1/admin/lua/preview`).
- `dry_run: true` reports per-event results without redelivering anything. Otherwise, transformed events are broadcast on the same channel the indexer uses for newly-indexed events, so they flow through the normal downstream pipeline (webhooks, SSE, email, etc.).
- Adds a "Replay With Transform Endpoint" section + curl examples to `docs/lua-transformation.md`, and an example script `examples/replay_with_transform_normalize.lua`.
- Also fixes an unrelated but fatal bug: `mod ops_tests` in `handlers.rs` (added by #801) was left unclosed, swallowing `get_slo_report`/`record_slo_sample` and breaking compilation of the whole crate. One-line fix (added the missing `}`).

This matches the integration test spec already on `main` in `tests/event_replay_transform_tests.rs` (added by 24682f7 for issue #580, ahead of the implementation).

## Note on verification
I was not able to get a clean `cargo check`/`cargo test` in my environment: independent of this change, `main`'s `Cargo.toml` pins `async-graphql = "0.12"`, a version that was never published to crates.io, and once that's worked around locally the crate has ~283 pre-existing, unrelated compile errors (e.g. `NotificationChannel` defined three times in `models.rs` from colliding merges, a missing `chrono::Timelike` import in `rate_limiter.rs`). None of that is touched by this PR. I wrote and reviewed this change carefully by hand against `tests/event_replay_transform_tests.rs` and existing handler conventions (`lua_preview`, `replay_events`, the RSS feed handler's `QueryBuilder` pattern), but flagging that it hasn't been compiled in CI-equivalent conditions.

## Test plan
- [ ] Once the build is fixed, run `cargo test --test event_replay_transform_tests`
- [x] Manual review against the 8 cases in `tests/event_replay_transform_tests.rs` (200 on success, 400 on empty/missing fields and invalid script, `dry_run` echoed, `preview` populated, `replay_id`/`status` present, timestamp and contract_id filters accepted)

Closes #700

🤖 Generated with [Claude Code](https://claude.com/claude-code)