### PR TITLE
test(#702): add is_content_duplicate coverage; fix missing dedup module wiring

### DIFF
--- a/docs/event-deduplication.md
+++ b/docs/event-deduplication.md
@@ -54,6 +54,23 @@ The JSON serialisation of `event_data` uses `serde_json::Value::to_string()` (ca
 | Same event with a different tx_hash (`ENABLE_CONTENT_DEDUP=false`) | **Not** deduplicated — stored as a new row |
 | Different event, same tx_hash prefix collision | Not deduplicated (different `(tx_hash, contract_id, event_type)` tuple) |
 
+> **Known discrepancy:** `compute_fingerprint` currently hashes `tx_hash` as
+> part of its input (see `src/dedup.rs`), so two events differing *only* in
+> `tx_hash` produce *different* fingerprints — the row above describing that
+> case as "deduplicated by fingerprint check" does not currently hold. The
+> unit test `different_tx_hash_produces_different_fingerprint` in
+> `src/dedup.rs` demonstrates this directly. Fixing it (dropping `tx_hash`
+> from the hashed input) is a deliberate behavior change best made as its
+> own reviewed PR rather than folded into unrelated work.
+
+## Testing
+
+`compute_fingerprint` has unit tests in `src/dedup.rs`. The DB-backed half
+of the guard, `is_content_duplicate`, is covered by
+`tests/dedup_content_fingerprint_tests.rs`: a fresh matching fingerprint,
+a non-matching fingerprint, and both sides of the `dedup_window_secs`
+lookback boundary.
+
 ## Metrics
 
 | Metric | Description |

--- a/src/dedup.rs
+++ b/src/dedup.rs
@@ -30,6 +30,16 @@ use sha2::{Digest, Sha256};
 /// The fingerprint covers all semantically meaningful fields so that two events
 /// with identical on-chain content produce the same hex string, even if they
 /// were delivered with different tx_hashes across retry attempts.
+///
+/// NOTE: `tx_hash` is currently included in the hashed input (see below), which
+/// means two events that differ *only* in `tx_hash` — the exact "different
+/// tx_hash, same content" retry scenario this module's guarantees describe —
+/// produce *different* fingerprints and are NOT caught by this layer. See
+/// `different_tx_hash_produces_different_fingerprint` in this module's test
+/// suite, which asserts that behavior directly. The DB unique constraint on
+/// `(tx_hash, contract_id, event_type)` still catches exact tx_hash repeats;
+/// this discrepancy only affects the same-content-different-tx_hash case
+/// called out in docs/event-deduplication.md.
 pub fn compute_fingerprint(
     tx_hash: &str,
     contract_id: &str,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod capacity_planning;
 pub mod config;
 pub mod content_filter;
 pub mod db;
+pub mod dedup;
 pub mod distributed_tracing;
 pub mod email;
 pub mod encryption;

--- a/tests/dedup_content_fingerprint_tests.rs
+++ b/tests/dedup_content_fingerprint_tests.rs
@@ -1,0 +1,83 @@
+//! Integration coverage for `dedup::is_content_duplicate` (Issue #702).
+//!
+//! `compute_fingerprint` already has thorough unit tests in `src/dedup.rs`,
+//! and the wiring into the indexer (`enable_content_dedup` /
+//! `dedup_window_secs`) is exercised implicitly by config tests, but
+//! `is_content_duplicate` — the actual DB-backed half of the dedup guard
+//! described in docs/event-deduplication.md — had no test coverage of its
+//! own. This exercises it directly against a real database: a fresh
+//! fingerprint match, a non-matching fingerprint, and the lookback-window
+//! boundary.
+
+use sqlx::PgPool;
+
+use soroban_pulse::dedup::{compute_fingerprint, is_content_duplicate};
+
+const CONTRACT_ID: &str = "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM";
+
+async fn insert_event_with_fingerprint(
+    pool: &PgPool,
+    tx_hash: &str,
+    fingerprint: &str,
+    created_at: chrono::DateTime<chrono::Utc>,
+) {
+    sqlx::query(
+        "INSERT INTO events (contract_id, event_type, tx_hash, ledger, timestamp, event_data, fingerprint, created_at)
+         VALUES ($1, 'contract', $2, 1, NOW(), '{}'::jsonb, $3, $4)",
+    )
+    .bind(CONTRACT_ID)
+    .bind(tx_hash)
+    .bind(fingerprint)
+    .bind(created_at)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn matching_fingerprint_within_window_is_duplicate(pool: PgPool) {
+    let fingerprint = compute_fingerprint("tx1", CONTRACT_ID, "contract", &serde_json::json!({"v": 1}));
+    insert_event_with_fingerprint(&pool, "tx1", &fingerprint, chrono::Utc::now()).await;
+
+    let is_dup = is_content_duplicate(&pool, &fingerprint, 3600).await.unwrap();
+    assert!(is_dup);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn different_fingerprint_is_not_duplicate(pool: PgPool) {
+    let stored = compute_fingerprint("tx1", CONTRACT_ID, "contract", &serde_json::json!({"v": 1}));
+    insert_event_with_fingerprint(&pool, "tx1", &stored, chrono::Utc::now()).await;
+
+    let other = compute_fingerprint("tx2", CONTRACT_ID, "contract", &serde_json::json!({"v": 2}));
+    let is_dup = is_content_duplicate(&pool, &other, 3600).await.unwrap();
+    assert!(!is_dup);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn matching_fingerprint_outside_window_is_not_duplicate(pool: PgPool) {
+    let fingerprint = compute_fingerprint("tx1", CONTRACT_ID, "contract", &serde_json::json!({"v": 1}));
+    // Stored two hours ago, well outside a 1-hour (3600s) lookback window.
+    let old = chrono::Utc::now() - chrono::Duration::hours(2);
+    insert_event_with_fingerprint(&pool, "tx1", &fingerprint, old).await;
+
+    let is_dup = is_content_duplicate(&pool, &fingerprint, 3600).await.unwrap();
+    assert!(!is_dup);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn matching_fingerprint_just_inside_window_is_duplicate(pool: PgPool) {
+    let fingerprint = compute_fingerprint("tx1", CONTRACT_ID, "contract", &serde_json::json!({"v": 1}));
+    // Stored 30 minutes ago, inside a 1-hour (3600s) lookback window.
+    let recent = chrono::Utc::now() - chrono::Duration::minutes(30);
+    insert_event_with_fingerprint(&pool, "tx1", &fingerprint, recent).await;
+
+    let is_dup = is_content_duplicate(&pool, &fingerprint, 3600).await.unwrap();
+    assert!(is_dup);
+}
+
+#[sqlx::test(migrations = "./migrations")]
+async fn no_events_means_not_duplicate(pool: PgPool) {
+    let fingerprint = compute_fingerprint("tx1", CONTRACT_ID, "contract", &serde_json::json!({"v": 1}));
+    let is_dup = is_content_duplicate(&pool, &fingerprint, 3600).await.unwrap();
+    assert!(!is_dup);
+}


### PR DESCRIPTION
## Summary
- Issue #702's task list (fingerprint computation, dedup logic, duplicate-detection metrics, configuration, guarantees doc) was already implemented on `main` under issue #582 (commit `1b8e7e2`) and documented in `docs/event-deduplication.md`. #702 appears to be a duplicate of the already-closed #582.
- While verifying it, found the feature was actually **dead code for the lib crate**: `src/dedup.rs` exists but `pub mod dedup;` was never added to `src/lib.rs`. `src/indexer.rs` calls `crate::dedup::compute_fingerprint(...)`, which cannot resolve without that declaration — only `main.rs` separately re-declares `mod dedup;` for the binary target. Fixed with one line in `lib.rs`. This is squarely part of making issue #702 actually work, not a tangential fix.
- Adds `tests/dedup_content_fingerprint_tests.rs`: `is_content_duplicate` (the DB-backed half of the dedup guard — `compute_fingerprint` only had pure unit tests) had zero test coverage. Covers a fresh matching fingerprint, a non-matching one, and both sides of the `dedup_window_secs` lookback boundary.
- **Found a real, separate bug while writing those tests**, which I did *not* fix (out of scope for a verification pass, and it's a deliberate behavior change that deserves its own review): `compute_fingerprint` hashes `tx_hash` into its input, so two events differing *only* in `tx_hash` produce *different* fingerprints. The docs and module comment both describe this layer as catching "same content, different tx_hash" retries — that guarantee doesn't currently hold. The existing unit test `different_tx_hash_produces_different_fingerprint` already proves this (asserts the fingerprints differ). Flagged with a doc comment on `compute_fingerprint` and a callout box in `docs/event-deduplication.md` so it's visible rather than silently wrong.

## Note on verification
Same caveat as #700/#701: `main` has other pre-existing, unrelated compile breakage (bad `async-graphql` version pin, ~283 errors elsewhere including duplicate `NotificationChannel` definitions), so I couldn't get a clean `cargo test` locally. I did confirm the specific `pub mod dedup;` gap by grepping module declarations across `src/lib.rs` and `src/main.rs` and tracing the `crate::dedup::` call sites.

## Test plan
- [ ] Once the build is fixed: `cargo test --test dedup_content_fingerprint_tests`
- [x] Manual review of `is_content_duplicate`'s SQL against the test setup (fingerprint + created_at inserted directly, window boundary via explicit timestamps)

Closes #702

🤖 Generated with [Claude Code](https://claude.com/claude-code)