### PR TITLE
feat: Infrastructure as Code & Terraform expansion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -366,3 +366,32 @@ jobs:
         run: npm install -g @stoplight/spectral-cli@6.11.1
       - name: Validate OpenAPI spec
         run: spectral lint openapi.json --ruleset https://unpkg.com/@stoplight/spectral-openapi/dist/ruleset.js
+
+  terraform-validate:
+    name: Terraform Validate
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: terraform
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: "~> 1.6"
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive -diff
+
+      - name: Terraform Init (backend=false)
+        run: terraform init -backend=false
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Install TFLint
+        run: |
+          curl -s https://raw.githubusercontent.com/terraform-linters/tflint/master/install_linux.sh | bash
+
+      - name: TFLint
+        run: tflint --init && tflint --recursive

--- a/scripts/terraform-init.sh
+++ b/scripts/terraform-init.sh
@@ -1,0 +1,130 @@
+#!/usr/bin/env bash
+# =============================================================================
+# Terraform State Bootstrap Script (Issue #833)
+#
+# Creates the S3 bucket and DynamoDB table required by the Terraform backend
+# before the first `terraform init`.
+#
+# Usage:
+#   ./scripts/terraform-init.sh [ENVIRONMENT]
+#
+# Arguments:
+#   ENVIRONMENT   dev | staging | production (default: staging)
+#
+# Prerequisites:
+#   - AWS CLI configured with appropriate credentials
+#   - Sufficient IAM permissions to create S3 buckets and DynamoDB tables
+# =============================================================================
+
+set -euo pipefail
+
+ENVIRONMENT="${1:-staging}"
+PROJECT="soroban-pulse"
+REGION="${AWS_REGION:-us-east-1}"
+
+BUCKET_NAME="${PROJECT}-terraform-state"
+TABLE_NAME="${PROJECT}-terraform-locks"
+
+echo "=== Terraform State Bootstrap ==="
+echo "Environment : ${ENVIRONMENT}"
+echo "Region      : ${REGION}"
+echo "S3 Bucket   : ${BUCKET_NAME}"
+echo "DynamoDB    : ${TABLE_NAME}"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Validate environment
+# ---------------------------------------------------------------------------
+if [[ ! "${ENVIRONMENT}" =~ ^(dev|staging|production)$ ]]; then
+  echo "ERROR: ENVIRONMENT must be 'dev', 'staging', or 'production'."
+  exit 1
+fi
+
+# ---------------------------------------------------------------------------
+# Create S3 bucket for Terraform state
+# ---------------------------------------------------------------------------
+echo "--- Creating S3 state bucket (if not exists) ---"
+
+if aws s3api head-bucket --bucket "${BUCKET_NAME}" 2>/dev/null; then
+  echo "Bucket '${BUCKET_NAME}' already exists — skipping creation."
+else
+  aws s3api create-bucket \
+    --bucket "${BUCKET_NAME}" \
+    --region "${REGION}" \
+    $([ "${REGION}" != "us-east-1" ] && echo "--create-bucket-configuration LocationConstraint=${REGION}")
+
+  echo "Bucket '${BUCKET_NAME}' created."
+fi
+
+# Enable versioning (idempotent)
+echo "Enabling bucket versioning..."
+aws s3api put-bucket-versioning \
+  --bucket "${BUCKET_NAME}" \
+  --versioning-configuration Status=Enabled
+
+# Enable server-side encryption (idempotent)
+echo "Enabling bucket encryption (AES-256)..."
+aws s3api put-bucket-encryption \
+  --bucket "${BUCKET_NAME}" \
+  --server-side-encryption-configuration '{
+    "Rules": [
+      {
+        "ApplyServerSideEncryptionByDefault": {
+          "SSEAlgorithm": "aws:kms"
+        },
+        "BucketKeyEnabled": true
+      }
+    ]
+  }'
+
+# Block public access (idempotent)
+echo "Blocking public access..."
+aws s3api put-public-access-block \
+  --bucket "${BUCKET_NAME}" \
+  --public-access-block-configuration \
+    BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true
+
+# ---------------------------------------------------------------------------
+# Create DynamoDB table for state locking
+# ---------------------------------------------------------------------------
+echo ""
+echo "--- Creating DynamoDB lock table (if not exists) ---"
+
+if aws dynamodb describe-table --table-name "${TABLE_NAME}" --region "${REGION}" 2>/dev/null; then
+  echo "Table '${TABLE_NAME}' already exists — skipping creation."
+else
+  aws dynamodb create-table \
+    --table-name "${TABLE_NAME}" \
+    --attribute-definitions AttributeName=LockID,AttributeType=S \
+    --key-schema AttributeName=LockID,KeyType=HASH \
+    --billing-mode PAY_PER_REQUEST \
+    --region "${REGION}" \
+    --tags Key=Project,Value="${PROJECT}" Key=ManagedBy,Value=Terraform Key=Purpose,Value=state-locking
+
+  echo "Waiting for table to become ACTIVE..."
+  aws dynamodb wait table-exists --table-name "${TABLE_NAME}" --region "${REGION}"
+  echo "Table '${TABLE_NAME}' created and active."
+fi
+
+# ---------------------------------------------------------------------------
+# Enable point-in-time recovery on the lock table
+# ---------------------------------------------------------------------------
+echo "Enabling point-in-time recovery on lock table..."
+aws dynamodb update-continuous-backups \
+  --table-name "${TABLE_NAME}" \
+  --region "${REGION}" \
+  --point-in-time-recovery-specification PointInTimeRecoveryEnabled=true 2>/dev/null || true
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Bootstrap Complete ==="
+echo ""
+echo "You can now run:"
+echo "  cd terraform"
+echo "  terraform init"
+echo "  terraform plan -var-file=environments/${ENVIRONMENT}/terraform.tfvars"
+echo ""
+echo "State will be stored in: s3://${BUCKET_NAME}/${PROJECT}/terraform.tfstate"
+echo "Locks managed via DynamoDB table: ${TABLE_NAME}"

--- a/terraform/environments/dev/terraform.tfvars.example
+++ b/terraform/environments/dev/terraform.tfvars.example
@@ -1,0 +1,76 @@
+# =============================================================================
+# Dev Environment — terraform.tfvars.example
+# SorobanPulse (Issue #833)
+#
+# Copy to terraform.tfvars and fill in real values before applying.
+# NEVER commit terraform.tfvars — it may contain sensitive data.
+#
+# Minimal configuration for local development and experimentation.
+# Uses the smallest instance types and disables HA features to reduce cost.
+# =============================================================================
+
+aws_region   = "us-east-1"
+environment  = "dev"
+project_name = "soroban-pulse"
+
+# ---------------------------------------------------------------------------
+# Networking — single AZ to minimize cost
+# ---------------------------------------------------------------------------
+vpc_cidr             = "10.2.0.0/16"
+availability_zones   = ["us-east-1a", "us-east-1b"]
+public_subnet_cidrs  = ["10.2.1.0/24", "10.2.2.0/24"]
+private_subnet_cidrs = ["10.2.11.0/24", "10.2.12.0/24"]
+enable_nat_gateway   = true
+single_nat_gateway   = true
+
+# ---------------------------------------------------------------------------
+# RDS — minimal instance for dev
+# ---------------------------------------------------------------------------
+db_instance_class               = "db.t3.micro"
+db_engine_version               = "16.3"
+db_name                         = "soroban_pulse_dev"
+db_username                     = "soroban_admin"
+db_allocated_storage            = 20
+db_max_allocated_storage        = 50
+db_backup_retention_period      = 1
+db_multi_az                     = false
+db_deletion_protection          = false
+db_apply_immediately            = true
+db_skip_final_snapshot          = true
+db_performance_insights_enabled = false
+db_monitoring_interval          = 0
+
+# ---------------------------------------------------------------------------
+# ALB
+# ---------------------------------------------------------------------------
+alb_internal            = false
+alb_access_logs_enabled = false
+alb_idle_timeout        = 60
+health_check_path       = "/healthz/ready"
+health_check_interval   = 30
+health_check_threshold  = 2
+app_port                = 3000
+app_container_count     = 1
+
+# Replace with a real ACM certificate ARN before applying:
+# certificate_arn = "arn:aws:acm:us-east-1:ACCOUNT_ID:certificate/CERT_ID"
+
+# ---------------------------------------------------------------------------
+# ECS Fargate — minimal for dev
+# ---------------------------------------------------------------------------
+ecs_task_cpu    = 256
+ecs_task_memory = 512
+
+# ---------------------------------------------------------------------------
+# Backup — short retention for dev
+# ---------------------------------------------------------------------------
+backup_retention_days = 7
+
+# ---------------------------------------------------------------------------
+# Monitoring — relaxed thresholds for dev
+# ---------------------------------------------------------------------------
+rds_cpu_alarm_threshold     = 95
+rds_storage_alarm_threshold = 1073741824  # 1 GiB
+alb_5xx_alarm_threshold     = 50
+alb_latency_alarm_threshold = 5.0
+log_retention_days          = 7

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,10 +1,12 @@
 # =============================================================================
-# Root Module — SorobanPulse Infrastructure (Issue #650)
+# Root Module — SorobanPulse Infrastructure (Issue #650, #833)
 #
 # Wires together:
 #   - VPC + subnets + NAT gateway
 #   - RDS PostgreSQL
 #   - Application Load Balancer
+#   - ECS Fargate service
+#   - Automated backup storage
 #   - Monitoring / CloudWatch alarms
 # =============================================================================
 
@@ -78,6 +80,58 @@ module "alb" {
   health_check_interval  = var.health_check_interval
   health_check_threshold = var.health_check_threshold
   app_port               = var.app_port
+}
+
+# ---------------------------------------------------------------------------
+# ECS Fargate Service (Issue #833)
+# ---------------------------------------------------------------------------
+
+module "ecs" {
+  source = "./modules/ecs"
+
+  name_prefix        = local.name_prefix
+  aws_region         = var.aws_region
+  container_image    = var.ecs_container_image
+  task_cpu           = var.ecs_task_cpu
+  task_memory        = var.ecs_task_memory
+  desired_count      = var.app_container_count
+  app_port           = var.app_port
+  health_check_path  = var.health_check_path
+  private_subnet_ids = module.vpc.private_subnet_ids
+  security_group_ids = [module.vpc.app_security_group_id]
+  target_group_arn   = module.alb.target_group_arn
+  secret_arns        = [module.rds.db_secret_arn]
+  log_retention_days = var.log_retention_days
+
+  environment_variables = [
+    {
+      name  = "PORT"
+      value = tostring(var.app_port)
+    },
+    {
+      name  = "ENVIRONMENT"
+      value = var.environment
+    }
+  ]
+
+  secret_environment_variables = [
+    {
+      name      = "DATABASE_URL"
+      valueFrom = module.rds.db_secret_arn
+    }
+  ]
+}
+
+# ---------------------------------------------------------------------------
+# Automated Backup Storage (Issue #833)
+# ---------------------------------------------------------------------------
+
+module "backup" {
+  source = "./modules/backup"
+
+  name_prefix    = local.name_prefix
+  retention_days = var.backup_retention_days
+  force_destroy  = var.backup_force_destroy
 }
 
 # ---------------------------------------------------------------------------

--- a/terraform/modules/backup/main.tf
+++ b/terraform/modules/backup/main.tf
@@ -1,0 +1,173 @@
+# =============================================================================
+# Module: backup — Automated Backup Storage (Issue #833)
+#
+# Creates:
+#   - S3 bucket for database and application backups
+#   - Lifecycle rules for tiered storage and expiration
+#   - Bucket versioning for point-in-time recovery
+#   - Server-side encryption (AES-256)
+#   - Bucket policy blocking public access
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# S3 Bucket
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket" "backups" {
+  bucket        = "${var.name_prefix}-backups"
+  force_destroy = var.force_destroy
+
+  tags = {
+    Name    = "${var.name_prefix}-backups"
+    Purpose = "Automated backup storage"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Block Public Access
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket_public_access_block" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# ---------------------------------------------------------------------------
+# Versioning
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket_versioning" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Server-Side Encryption
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "aws:kms"
+    }
+    bucket_key_enabled = true
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Lifecycle Rules
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket_lifecycle_configuration" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  # Move current backups to Infrequent Access after 30 days
+  rule {
+    id     = "transition-to-ia"
+    status = "Enabled"
+
+    filter {
+      prefix = "db/"
+    }
+
+    transition {
+      days          = 30
+      storage_class = "STANDARD_IA"
+    }
+  }
+
+  # Move older backups to Glacier after 90 days
+  rule {
+    id     = "transition-to-glacier"
+    status = "Enabled"
+
+    filter {
+      prefix = "db/"
+    }
+
+    transition {
+      days          = 90
+      storage_class = "GLACIER"
+    }
+  }
+
+  # Expire backups after the retention period
+  rule {
+    id     = "expire-old-backups"
+    status = "Enabled"
+
+    filter {
+      prefix = "db/"
+    }
+
+    expiration {
+      days = var.retention_days
+    }
+  }
+
+  # Clean up incomplete multipart uploads
+  rule {
+    id     = "abort-incomplete-uploads"
+    status = "Enabled"
+
+    filter {
+      prefix = ""
+    }
+
+    abort_incomplete_multipart_upload {
+      days_after_initiation = 7
+    }
+  }
+
+  # Expire old versions of objects
+  rule {
+    id     = "expire-old-versions"
+    status = "Enabled"
+
+    filter {
+      prefix = ""
+    }
+
+    noncurrent_version_expiration {
+      noncurrent_days = var.version_retention_days
+    }
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Bucket Policy — enforce encryption in transit
+# ---------------------------------------------------------------------------
+
+resource "aws_s3_bucket_policy" "backups" {
+  bucket = aws_s3_bucket.backups.id
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Sid       = "DenyUnencryptedTransport"
+        Effect    = "Deny"
+        Principal = "*"
+        Action    = "s3:*"
+        Resource = [
+          aws_s3_bucket.backups.arn,
+          "${aws_s3_bucket.backups.arn}/*"
+        ]
+        Condition = {
+          Bool = {
+            "aws:SecureTransport" = "false"
+          }
+        }
+      }
+    ]
+  })
+}

--- a/terraform/modules/backup/outputs.tf
+++ b/terraform/modules/backup/outputs.tf
@@ -1,0 +1,18 @@
+# =============================================================================
+# Module: backup — Outputs (Issue #833)
+# =============================================================================
+
+output "bucket_id" {
+  description = "ID (name) of the backup S3 bucket."
+  value       = aws_s3_bucket.backups.id
+}
+
+output "bucket_arn" {
+  description = "ARN of the backup S3 bucket."
+  value       = aws_s3_bucket.backups.arn
+}
+
+output "bucket_domain_name" {
+  description = "Regional domain name of the backup S3 bucket."
+  value       = aws_s3_bucket.backups.bucket_regional_domain_name
+}

--- a/terraform/modules/backup/variables.tf
+++ b/terraform/modules/backup/variables.tf
@@ -1,0 +1,26 @@
+# =============================================================================
+# Module: backup — Variables (Issue #833)
+# =============================================================================
+
+variable "name_prefix" {
+  description = "Prefix applied to every resource name."
+  type        = string
+}
+
+variable "retention_days" {
+  description = "Number of days to retain backups before expiration."
+  type        = number
+  default     = 90
+}
+
+variable "version_retention_days" {
+  description = "Number of days to retain non-current object versions."
+  type        = number
+  default     = 30
+}
+
+variable "force_destroy" {
+  description = "Allow the bucket to be destroyed even if it contains objects. Set to false in production."
+  type        = bool
+  default     = false
+}

--- a/terraform/modules/ecs/main.tf
+++ b/terraform/modules/ecs/main.tf
@@ -1,0 +1,193 @@
+# =============================================================================
+# Module: ecs — ECS Fargate Service (Issue #833)
+#
+# Creates:
+#   - ECS Cluster
+#   - ECS Task Definition (Fargate)
+#   - ECS Service (connected to ALB target group)
+#   - IAM roles for task execution and task runtime
+#   - CloudWatch Log Group for container logs
+# =============================================================================
+
+# ---------------------------------------------------------------------------
+# ECS Cluster
+# ---------------------------------------------------------------------------
+
+resource "aws_ecs_cluster" "main" {
+  name = "${var.name_prefix}-cluster"
+
+  setting {
+    name  = "containerInsights"
+    value = var.container_insights ? "enabled" : "disabled"
+  }
+
+  tags = {
+    Name = "${var.name_prefix}-cluster"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# CloudWatch Log Group for ECS Tasks
+# ---------------------------------------------------------------------------
+
+resource "aws_cloudwatch_log_group" "ecs" {
+  name              = "/ecs/${var.name_prefix}"
+  retention_in_days = var.log_retention_days
+
+  tags = {
+    Name = "${var.name_prefix}-ecs-logs"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# IAM — Task Execution Role (pulls images, writes logs)
+# ---------------------------------------------------------------------------
+
+data "aws_iam_policy_document" "ecs_assume" {
+  statement {
+    actions = ["sts:AssumeRole"]
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role" "execution" {
+  name               = "${var.name_prefix}-ecs-exec"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+
+  tags = {
+    Name = "${var.name_prefix}-ecs-exec"
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "execution" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+# Allow the execution role to read secrets from Secrets Manager (for DB creds)
+data "aws_iam_policy_document" "secrets_read" {
+  statement {
+    actions   = ["secretsmanager:GetSecretValue"]
+    resources = var.secret_arns
+  }
+}
+
+resource "aws_iam_role_policy" "secrets_read" {
+  count  = length(var.secret_arns) > 0 ? 1 : 0
+  name   = "${var.name_prefix}-secrets-read"
+  role   = aws_iam_role.execution.id
+  policy = data.aws_iam_policy_document.secrets_read.json
+}
+
+# ---------------------------------------------------------------------------
+# IAM — Task Role (app-level permissions at runtime)
+# ---------------------------------------------------------------------------
+
+resource "aws_iam_role" "task" {
+  name               = "${var.name_prefix}-ecs-task"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume.json
+
+  tags = {
+    Name = "${var.name_prefix}-ecs-task"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# Task Definition
+# ---------------------------------------------------------------------------
+
+resource "aws_ecs_task_definition" "app" {
+  family                   = "${var.name_prefix}-app"
+  requires_compatibilities = ["FARGATE"]
+  network_mode             = "awsvpc"
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.execution.arn
+  task_role_arn            = aws_iam_role.task.arn
+
+  container_definitions = jsonencode([
+    {
+      name      = "app"
+      image     = var.container_image
+      essential = true
+
+      portMappings = [
+        {
+          containerPort = var.app_port
+          protocol      = "tcp"
+        }
+      ]
+
+      environment = var.environment_variables
+
+      secrets = var.secret_environment_variables
+
+      logConfiguration = {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-group"         = aws_cloudwatch_log_group.ecs.name
+          "awslogs-region"        = var.aws_region
+          "awslogs-stream-prefix" = "app"
+        }
+      }
+
+      healthCheck = {
+        command     = ["CMD-SHELL", "curl -f http://localhost:${var.app_port}${var.health_check_path} || exit 1"]
+        interval    = 30
+        timeout     = 5
+        retries     = 3
+        startPeriod = 60
+      }
+    }
+  ])
+
+  tags = {
+    Name = "${var.name_prefix}-app"
+  }
+}
+
+# ---------------------------------------------------------------------------
+# ECS Service
+# ---------------------------------------------------------------------------
+
+resource "aws_ecs_service" "app" {
+  name            = "${var.name_prefix}-app"
+  cluster         = aws_ecs_cluster.main.id
+  task_definition = aws_ecs_task_definition.app.arn
+  desired_count   = var.desired_count
+  launch_type     = "FARGATE"
+
+  network_configuration {
+    subnets          = var.private_subnet_ids
+    security_groups  = var.security_group_ids
+    assign_public_ip = false
+  }
+
+  load_balancer {
+    target_group_arn = var.target_group_arn
+    container_name   = "app"
+    container_port   = var.app_port
+  }
+
+  deployment_circuit_breaker {
+    enable   = true
+    rollback = true
+  }
+
+  deployment_maximum_percent         = 200
+  deployment_minimum_healthy_percent = 100
+
+  # Allow the service to stabilise before marking as complete
+  health_check_grace_period_seconds = 120
+
+  tags = {
+    Name = "${var.name_prefix}-app"
+  }
+
+  lifecycle {
+    ignore_changes = [desired_count]
+  }
+}

--- a/terraform/modules/ecs/outputs.tf
+++ b/terraform/modules/ecs/outputs.tf
@@ -1,0 +1,48 @@
+# =============================================================================
+# Module: ecs — Outputs (Issue #833)
+# =============================================================================
+
+output "cluster_id" {
+  description = "ID of the ECS cluster."
+  value       = aws_ecs_cluster.main.id
+}
+
+output "cluster_arn" {
+  description = "ARN of the ECS cluster."
+  value       = aws_ecs_cluster.main.arn
+}
+
+output "cluster_name" {
+  description = "Name of the ECS cluster."
+  value       = aws_ecs_cluster.main.name
+}
+
+output "service_name" {
+  description = "Name of the ECS service."
+  value       = aws_ecs_service.app.name
+}
+
+output "service_id" {
+  description = "ID of the ECS service."
+  value       = aws_ecs_service.app.id
+}
+
+output "task_definition_arn" {
+  description = "ARN of the current task definition."
+  value       = aws_ecs_task_definition.app.arn
+}
+
+output "task_execution_role_arn" {
+  description = "ARN of the ECS task execution IAM role."
+  value       = aws_iam_role.execution.arn
+}
+
+output "task_role_arn" {
+  description = "ARN of the ECS task IAM role."
+  value       = aws_iam_role.task.arn
+}
+
+output "log_group_name" {
+  description = "CloudWatch log group name for ECS task logs."
+  value       = aws_cloudwatch_log_group.ecs.name
+}

--- a/terraform/modules/ecs/variables.tf
+++ b/terraform/modules/ecs/variables.tf
@@ -1,0 +1,100 @@
+# =============================================================================
+# Module: ecs — Variables (Issue #833)
+# =============================================================================
+
+variable "name_prefix" {
+  description = "Prefix applied to every resource name."
+  type        = string
+}
+
+variable "aws_region" {
+  description = "AWS region for CloudWatch log configuration."
+  type        = string
+}
+
+variable "container_image" {
+  description = "Docker image URI for the application container."
+  type        = string
+  default     = "ghcr.io/soroban-pulse/sorobanpulse:latest"
+}
+
+variable "task_cpu" {
+  description = "CPU units for the Fargate task (256 = 0.25 vCPU)."
+  type        = number
+  default     = 512
+}
+
+variable "task_memory" {
+  description = "Memory in MiB for the Fargate task."
+  type        = number
+  default     = 1024
+}
+
+variable "desired_count" {
+  description = "Desired number of running task instances."
+  type        = number
+  default     = 2
+}
+
+variable "app_port" {
+  description = "Port the application container listens on."
+  type        = number
+  default     = 3000
+}
+
+variable "health_check_path" {
+  description = "HTTP path for container health checks."
+  type        = string
+  default     = "/healthz/ready"
+}
+
+variable "private_subnet_ids" {
+  description = "IDs of private subnets where tasks are launched."
+  type        = list(string)
+}
+
+variable "security_group_ids" {
+  description = "Security group IDs to attach to the ECS tasks."
+  type        = list(string)
+}
+
+variable "target_group_arn" {
+  description = "ARN of the ALB target group to register tasks with."
+  type        = string
+}
+
+variable "secret_arns" {
+  description = "ARNs of Secrets Manager secrets the execution role may read."
+  type        = list(string)
+  default     = []
+}
+
+variable "environment_variables" {
+  description = "Environment variables passed to the container."
+  type = list(object({
+    name  = string
+    value = string
+  }))
+  default = []
+}
+
+variable "secret_environment_variables" {
+  description = "Secret environment variables (references to Secrets Manager or SSM)."
+  type = list(object({
+    name      = string
+    valueFrom = string
+  }))
+  default = []
+}
+
+variable "container_insights" {
+  description = "Enable CloudWatch Container Insights on the ECS cluster."
+  type        = bool
+  default     = true
+}
+
+variable "log_retention_days" {
+  description = "CloudWatch log retention period in days for ECS task logs."
+  type        = number
+  default     = 30
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,5 +1,5 @@
 # =============================================================================
-# Root Outputs — SorobanPulse Terraform (Issue #650)
+# Root Outputs — SorobanPulse Terraform (Issue #650, #833)
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -69,6 +69,39 @@ output "alb_arn" {
 output "target_group_arn" {
   description = "ARN of the ALB target group."
   value       = module.alb.target_group_arn
+}
+
+# ---------------------------------------------------------------------------
+# ECS (Issue #833)
+# ---------------------------------------------------------------------------
+
+output "ecs_cluster_name" {
+  description = "Name of the ECS Fargate cluster."
+  value       = module.ecs.cluster_name
+}
+
+output "ecs_service_name" {
+  description = "Name of the ECS service running the application."
+  value       = module.ecs.service_name
+}
+
+output "ecs_task_definition_arn" {
+  description = "ARN of the current ECS task definition."
+  value       = module.ecs.task_definition_arn
+}
+
+# ---------------------------------------------------------------------------
+# Backup (Issue #833)
+# ---------------------------------------------------------------------------
+
+output "backup_bucket_id" {
+  description = "Name of the S3 bucket used for automated backups."
+  value       = module.backup.bucket_id
+}
+
+output "backup_bucket_arn" {
+  description = "ARN of the S3 backup bucket."
+  value       = module.backup.bucket_arn
 }
 
 # ---------------------------------------------------------------------------

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,5 +1,5 @@
 # =============================================================================
-# Input Variables — SorobanPulse Terraform (Issue #650)
+# Input Variables — SorobanPulse Terraform (Issue #650, #833)
 # =============================================================================
 
 # ---------------------------------------------------------------------------
@@ -13,11 +13,11 @@ variable "aws_region" {
 }
 
 variable "environment" {
-  description = "Deployment environment: staging | production."
+  description = "Deployment environment: dev | staging | production."
   type        = string
   validation {
-    condition     = contains(["staging", "production"], var.environment)
-    error_message = "environment must be 'staging' or 'production'."
+    condition     = contains(["dev", "staging", "production"], var.environment)
+    error_message = "environment must be 'dev', 'staging', or 'production'."
   }
 }
 
@@ -209,6 +209,44 @@ variable "app_container_count" {
   description = "Desired number of running application containers."
   type        = number
   default     = 2
+}
+
+# ---------------------------------------------------------------------------
+# ECS Fargate (Issue #833)
+# ---------------------------------------------------------------------------
+
+variable "ecs_task_cpu" {
+  description = "CPU units for the Fargate task (256 = 0.25 vCPU)."
+  type        = number
+  default     = 512
+}
+
+variable "ecs_task_memory" {
+  description = "Memory in MiB for the Fargate task."
+  type        = number
+  default     = 1024
+}
+
+variable "ecs_container_image" {
+  description = "Docker image URI for the application container."
+  type        = string
+  default     = "ghcr.io/soroban-pulse/sorobanpulse:latest"
+}
+
+# ---------------------------------------------------------------------------
+# Backup (Issue #833)
+# ---------------------------------------------------------------------------
+
+variable "backup_retention_days" {
+  description = "Number of days to retain S3 backups before expiration."
+  type        = number
+  default     = 90
+}
+
+variable "backup_force_destroy" {
+  description = "Allow the backup bucket to be destroyed even with objects inside."
+  type        = bool
+  default     = false
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/terraform_validation_tests.rs
+++ b/tests/terraform_validation_tests.rs
@@ -1,0 +1,473 @@
+// =============================================================================
+// Terraform Validation Tests (Issue #833)
+//
+// Validates Terraform configuration file structure and completeness by reading
+// .tf files as text. These tests do NOT require Terraform to be installed.
+// =============================================================================
+
+use std::fs;
+use std::path::Path;
+
+/// Root terraform directory relative to the project root.
+const TERRAFORM_DIR: &str = "terraform";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/// Read a Terraform file relative to the project root and return its contents.
+fn read_tf_file(relative_path: &str) -> String {
+    let path = Path::new(TERRAFORM_DIR).join(relative_path);
+    fs::read_to_string(&path).unwrap_or_else(|e| {
+        panic!(
+            "Failed to read Terraform file '{}': {}",
+            path.display(),
+            e
+        )
+    })
+}
+
+/// Assert that a file exists within the terraform directory.
+fn assert_tf_file_exists(relative_path: &str) {
+    let path = Path::new(TERRAFORM_DIR).join(relative_path);
+    assert!(
+        path.exists(),
+        "Expected Terraform file does not exist: {}",
+        path.display()
+    );
+}
+
+/// Assert that file content contains a specific pattern.
+fn assert_contains(content: &str, pattern: &str, file_name: &str) {
+    assert!(
+        content.contains(pattern),
+        "File '{}' should contain '{}' but it was not found.\nContent:\n{}",
+        file_name,
+        pattern,
+        &content[..content.len().min(2000)]
+    );
+}
+
+// =============================================================================
+// Root Configuration Tests
+// =============================================================================
+
+#[test]
+fn root_main_tf_exists_and_has_required_modules() {
+    assert_tf_file_exists("main.tf");
+    let content = read_tf_file("main.tf");
+
+    // All expected module blocks must be present
+    assert_contains(&content, "module \"vpc\"", "main.tf");
+    assert_contains(&content, "module \"rds\"", "main.tf");
+    assert_contains(&content, "module \"alb\"", "main.tf");
+    assert_contains(&content, "module \"monitoring\"", "main.tf");
+    assert_contains(&content, "module \"ecs\"", "main.tf");
+    assert_contains(&content, "module \"backup\"", "main.tf");
+}
+
+#[test]
+fn root_main_tf_wires_module_sources_correctly() {
+    let content = read_tf_file("main.tf");
+
+    assert_contains(&content, "source = \"./modules/vpc\"", "main.tf");
+    assert_contains(&content, "source = \"./modules/rds\"", "main.tf");
+    assert_contains(&content, "source = \"./modules/alb\"", "main.tf");
+    assert_contains(&content, "source = \"./modules/monitoring\"", "main.tf");
+    assert_contains(&content, "source = \"./modules/ecs\"", "main.tf");
+    assert_contains(&content, "source = \"./modules/backup\"", "main.tf");
+}
+
+#[test]
+fn root_variables_tf_exists_and_has_required_variables() {
+    assert_tf_file_exists("variables.tf");
+    let content = read_tf_file("variables.tf");
+
+    let required_vars = [
+        "aws_region",
+        "environment",
+        "project_name",
+        "vpc_cidr",
+        "availability_zones",
+        "public_subnet_cidrs",
+        "private_subnet_cidrs",
+        "db_instance_class",
+        "db_name",
+        "certificate_arn",
+        "app_port",
+        "app_container_count",
+        "ecs_task_cpu",
+        "ecs_task_memory",
+        "backup_retention_days",
+        "log_retention_days",
+    ];
+
+    for var_name in &required_vars {
+        let pattern = format!("variable \"{}\"", var_name);
+        assert_contains(&content, &pattern, "variables.tf");
+    }
+}
+
+#[test]
+fn root_variables_tf_environment_allows_dev() {
+    let content = read_tf_file("variables.tf");
+
+    // The environment variable validation should allow "dev"
+    assert_contains(&content, "\"dev\"", "variables.tf");
+    assert_contains(&content, "\"staging\"", "variables.tf");
+    assert_contains(&content, "\"production\"", "variables.tf");
+}
+
+#[test]
+fn root_outputs_tf_exists_and_has_required_outputs() {
+    assert_tf_file_exists("outputs.tf");
+    let content = read_tf_file("outputs.tf");
+
+    let required_outputs = [
+        "vpc_id",
+        "public_subnet_ids",
+        "private_subnet_ids",
+        "db_instance_id",
+        "db_endpoint",
+        "db_name",
+        "alb_dns_name",
+        "alb_arn",
+        "target_group_arn",
+        "ecs_cluster_name",
+        "ecs_service_name",
+        "backup_bucket_id",
+        "backup_bucket_arn",
+        "log_group_name",
+        "sns_alarm_topic_arn",
+    ];
+
+    for output_name in &required_outputs {
+        let pattern = format!("output \"{}\"", output_name);
+        assert_contains(&content, &pattern, "outputs.tf");
+    }
+}
+
+#[test]
+fn providers_tf_exists_and_has_backend_config() {
+    assert_tf_file_exists("providers.tf");
+    let content = read_tf_file("providers.tf");
+
+    assert_contains(&content, "backend \"s3\"", "providers.tf");
+    assert_contains(&content, "dynamodb_table", "providers.tf");
+    assert_contains(&content, "encrypt", "providers.tf");
+    assert_contains(&content, "provider \"aws\"", "providers.tf");
+    assert_contains(&content, "required_version", "providers.tf");
+}
+
+// =============================================================================
+// Module Structure Tests
+// =============================================================================
+
+#[test]
+fn all_modules_have_required_files() {
+    let modules = ["vpc", "rds", "alb", "monitoring", "ecs", "backup"];
+
+    for module in &modules {
+        let required_files = ["main.tf", "variables.tf", "outputs.tf"];
+        for file in &required_files {
+            let path = format!("modules/{}/{}", module, file);
+            assert_tf_file_exists(&path);
+        }
+    }
+}
+
+// =============================================================================
+// ECS Module Tests
+// =============================================================================
+
+#[test]
+fn ecs_module_has_cluster_resource() {
+    let content = read_tf_file("modules/ecs/main.tf");
+    assert_contains(&content, "aws_ecs_cluster", "modules/ecs/main.tf");
+}
+
+#[test]
+fn ecs_module_has_task_definition() {
+    let content = read_tf_file("modules/ecs/main.tf");
+    assert_contains(
+        &content,
+        "aws_ecs_task_definition",
+        "modules/ecs/main.tf",
+    );
+    assert_contains(&content, "FARGATE", "modules/ecs/main.tf");
+    assert_contains(&content, "awsvpc", "modules/ecs/main.tf");
+}
+
+#[test]
+fn ecs_module_has_service() {
+    let content = read_tf_file("modules/ecs/main.tf");
+    assert_contains(&content, "aws_ecs_service", "modules/ecs/main.tf");
+    assert_contains(&content, "load_balancer", "modules/ecs/main.tf");
+}
+
+#[test]
+fn ecs_module_has_iam_roles() {
+    let content = read_tf_file("modules/ecs/main.tf");
+    assert_contains(&content, "aws_iam_role", "modules/ecs/main.tf");
+    assert_contains(
+        &content,
+        "ecs-tasks.amazonaws.com",
+        "modules/ecs/main.tf",
+    );
+}
+
+#[test]
+fn ecs_module_has_required_variables() {
+    let content = read_tf_file("modules/ecs/variables.tf");
+
+    let required_vars = [
+        "name_prefix",
+        "aws_region",
+        "container_image",
+        "task_cpu",
+        "task_memory",
+        "desired_count",
+        "app_port",
+        "private_subnet_ids",
+        "security_group_ids",
+        "target_group_arn",
+    ];
+
+    for var_name in &required_vars {
+        let pattern = format!("variable \"{}\"", var_name);
+        assert_contains(&content, &pattern, "modules/ecs/variables.tf");
+    }
+}
+
+#[test]
+fn ecs_module_has_required_outputs() {
+    let content = read_tf_file("modules/ecs/outputs.tf");
+
+    let required_outputs = [
+        "cluster_id",
+        "cluster_arn",
+        "service_name",
+        "task_definition_arn",
+        "task_execution_role_arn",
+        "task_role_arn",
+    ];
+
+    for output_name in &required_outputs {
+        let pattern = format!("output \"{}\"", output_name);
+        assert_contains(&content, &pattern, "modules/ecs/outputs.tf");
+    }
+}
+
+// =============================================================================
+// Backup Module Tests
+// =============================================================================
+
+#[test]
+fn backup_module_has_s3_bucket() {
+    let content = read_tf_file("modules/backup/main.tf");
+    assert_contains(&content, "aws_s3_bucket", "modules/backup/main.tf");
+}
+
+#[test]
+fn backup_module_has_lifecycle_rules() {
+    let content = read_tf_file("modules/backup/main.tf");
+    assert_contains(
+        &content,
+        "aws_s3_bucket_lifecycle_configuration",
+        "modules/backup/main.tf",
+    );
+    assert_contains(&content, "STANDARD_IA", "modules/backup/main.tf");
+    assert_contains(&content, "GLACIER", "modules/backup/main.tf");
+}
+
+#[test]
+fn backup_module_has_encryption() {
+    let content = read_tf_file("modules/backup/main.tf");
+    assert_contains(
+        &content,
+        "aws_s3_bucket_server_side_encryption_configuration",
+        "modules/backup/main.tf",
+    );
+}
+
+#[test]
+fn backup_module_has_versioning() {
+    let content = read_tf_file("modules/backup/main.tf");
+    assert_contains(
+        &content,
+        "aws_s3_bucket_versioning",
+        "modules/backup/main.tf",
+    );
+}
+
+#[test]
+fn backup_module_blocks_public_access() {
+    let content = read_tf_file("modules/backup/main.tf");
+    assert_contains(
+        &content,
+        "aws_s3_bucket_public_access_block",
+        "modules/backup/main.tf",
+    );
+}
+
+#[test]
+fn backup_module_has_required_variables() {
+    let content = read_tf_file("modules/backup/variables.tf");
+
+    let required_vars = ["name_prefix", "retention_days", "force_destroy"];
+
+    for var_name in &required_vars {
+        let pattern = format!("variable \"{}\"", var_name);
+        assert_contains(&content, &pattern, "modules/backup/variables.tf");
+    }
+}
+
+#[test]
+fn backup_module_has_required_outputs() {
+    let content = read_tf_file("modules/backup/outputs.tf");
+
+    let required_outputs = ["bucket_id", "bucket_arn"];
+
+    for output_name in &required_outputs {
+        let pattern = format!("output \"{}\"", output_name);
+        assert_contains(&content, &pattern, "modules/backup/outputs.tf");
+    }
+}
+
+// =============================================================================
+// Environment Configuration Tests
+// =============================================================================
+
+#[test]
+fn dev_environment_exists() {
+    assert_tf_file_exists("environments/dev/terraform.tfvars.example");
+}
+
+#[test]
+fn staging_environment_exists() {
+    assert_tf_file_exists("environments/staging/terraform.tfvars.example");
+}
+
+#[test]
+fn production_environment_exists() {
+    assert_tf_file_exists("environments/production/terraform.tfvars.example");
+}
+
+#[test]
+fn dev_environment_has_correct_environment_value() {
+    let content = read_tf_file("environments/dev/terraform.tfvars.example");
+    assert_contains(
+        &content,
+        "environment  = \"dev\"",
+        "environments/dev/terraform.tfvars.example",
+    );
+}
+
+#[test]
+fn all_environments_have_core_variables() {
+    let environments = ["dev", "staging", "production"];
+
+    for env in &environments {
+        let path = format!("environments/{}/terraform.tfvars.example", env);
+        let content = read_tf_file(&path);
+
+        assert_contains(&content, "aws_region", &path);
+        assert_contains(&content, "environment", &path);
+        assert_contains(&content, "project_name", &path);
+        assert_contains(&content, "vpc_cidr", &path);
+        assert_contains(&content, "db_instance_class", &path);
+        assert_contains(&content, "app_port", &path);
+    }
+}
+
+// =============================================================================
+// State Management Tests
+// =============================================================================
+
+#[test]
+fn terraform_init_script_exists() {
+    let path = Path::new("scripts/terraform-init.sh");
+    assert!(
+        path.exists(),
+        "Terraform bootstrap script should exist at scripts/terraform-init.sh"
+    );
+}
+
+#[test]
+fn terraform_init_script_creates_s3_bucket() {
+    let content =
+        fs::read_to_string("scripts/terraform-init.sh").expect("Failed to read terraform-init.sh");
+
+    assert_contains(&content, "s3api create-bucket", "terraform-init.sh");
+    assert_contains(&content, "put-bucket-versioning", "terraform-init.sh");
+    assert_contains(&content, "put-bucket-encryption", "terraform-init.sh");
+}
+
+#[test]
+fn terraform_init_script_creates_dynamodb_table() {
+    let content =
+        fs::read_to_string("scripts/terraform-init.sh").expect("Failed to read terraform-init.sh");
+
+    assert_contains(&content, "dynamodb create-table", "terraform-init.sh");
+    assert_contains(&content, "LockID", "terraform-init.sh");
+}
+
+#[test]
+fn terraform_init_script_validates_environment() {
+    let content =
+        fs::read_to_string("scripts/terraform-init.sh").expect("Failed to read terraform-init.sh");
+
+    // Script should validate that environment is one of the allowed values
+    assert_contains(&content, "dev", "terraform-init.sh");
+    assert_contains(&content, "staging", "terraform-init.sh");
+    assert_contains(&content, "production", "terraform-init.sh");
+}
+
+// =============================================================================
+// Cross-Module Wiring Tests
+// =============================================================================
+
+#[test]
+fn main_tf_passes_vpc_outputs_to_downstream_modules() {
+    let content = read_tf_file("main.tf");
+
+    // ECS should receive private subnets from VPC
+    assert_contains(&content, "module.vpc.private_subnet_ids", "main.tf");
+
+    // ECS should receive app security group from VPC
+    assert_contains(&content, "module.vpc.app_security_group_id", "main.tf");
+
+    // ALB should receive public subnets from VPC
+    assert_contains(&content, "module.vpc.public_subnet_ids", "main.tf");
+}
+
+#[test]
+fn main_tf_connects_ecs_to_alb_target_group() {
+    let content = read_tf_file("main.tf");
+
+    // ECS module should receive the ALB target group ARN
+    assert_contains(&content, "module.alb.target_group_arn", "main.tf");
+}
+
+#[test]
+fn main_tf_passes_rds_secret_to_ecs() {
+    let content = read_tf_file("main.tf");
+
+    // ECS should receive the RDS secret ARN for database credentials
+    assert_contains(&content, "module.rds.db_secret_arn", "main.tf");
+}
+
+// =============================================================================
+// CI Integration Tests
+// =============================================================================
+
+#[test]
+fn ci_workflow_includes_terraform_validation() {
+    let content = fs::read_to_string(".github/workflows/ci.yml")
+        .expect("Failed to read CI workflow file");
+
+    assert_contains(&content, "terraform-validate", "ci.yml");
+    assert_contains(&content, "terraform fmt", "ci.yml");
+    assert_contains(&content, "terraform validate", "ci.yml");
+    assert_contains(&content, "tflint", "ci.yml");
+}


### PR DESCRIPTION
## Summary

Closes #833

Expands the Terraform Infrastructure as Code foundation with modular ECS Fargate and S3 backup modules, multi-environment support (dev/staging/production), state management tooling, and CI-integrated validation.

- **ECS Fargate module** (`terraform/modules/ecs/`): Cluster, task definition, service, IAM execution/task roles, CloudWatch log group -- wired to the existing ALB target group (which already uses `target_type = "ip"` for Fargate)
- **S3 backup module** (`terraform/modules/backup/`): Automated backup bucket with versioning, KMS encryption, public access block, lifecycle rules (Standard -> IA -> Glacier -> expire), and TLS-only bucket policy
- **Dev environment** (`terraform/environments/dev/`): Minimal-cost tfvars with `db.t3.micro`, single NAT, relaxed alarm thresholds
- **Environment validation**: Updated `variables.tf` to allow `"dev"` in the environment validation rule
- **Root module wiring**: `main.tf` and `outputs.tf` updated to integrate ECS and backup modules with cross-module references (VPC subnets, ALB target group, RDS secrets)
- **State management bootstrap**: `scripts/terraform-init.sh` creates the S3 state bucket (versioned, encrypted, public-access-blocked) and DynamoDB lock table with point-in-time recovery
- **CI validation job**: New `terraform-validate` job in `.github/workflows/ci.yml` runs `terraform fmt -check`, `terraform validate`, and `tflint`
- **Validation tests**: `tests/terraform_validation_tests.rs` -- 30+ Rust tests that verify `.tf` file structure, required blocks, module wiring, and environment completeness without requiring Terraform to be installed

### Files changed

| File | Change |
|------|--------|
| `terraform/environments/dev/terraform.tfvars.example` | New -- dev environment |
| `terraform/modules/ecs/{main,variables,outputs}.tf` | New -- ECS Fargate module |
| `terraform/modules/backup/{main,variables,outputs}.tf` | New -- S3 backup module |
| `terraform/main.tf` | Updated -- wire ECS and backup modules |
| `terraform/variables.tf` | Updated -- add "dev" to env validation, add ECS/backup vars |
| `terraform/outputs.tf` | Updated -- add ECS and backup outputs |
| `.github/workflows/ci.yml` | Updated -- add terraform-validate job |
| `scripts/terraform-init.sh` | New -- state bootstrap script |
| `tests/terraform_validation_tests.rs` | New -- Terraform config validation tests |

## Test plan

- [ ] `cargo test --test terraform_validation_tests` passes (validates .tf file structure)
- [ ] Terraform validate CI job runs successfully on PR
- [ ] `terraform init -backend=false && terraform validate` passes locally
- [ ] `terraform fmt -check -recursive` shows no formatting issues
- [ ] Review ECS module wiring with ALB target group and RDS secrets
- [ ] Review backup module lifecycle rules and encryption settings
- [ ] Verify dev/staging/production tfvars have appropriate resource sizing

🤖 Generated with [Claude Code](https://claude.com/claude-code)