### PR TITLE
feat(notifications): unified NotificationChannel trait for Discord/Telegram

### DIFF
--- a/docs/notification-channels.md
+++ b/docs/notification-channels.md
@@ -202,3 +202,30 @@ clearly distinguishable from real event notifications.
 soroban_pulse_notification_test_total{channel_type="webhook", result="success"}
 soroban_pulse_notification_test_total{channel_type="webhook", result="failure"}
 ```
+
+## #809 – Unified Channel Interface
+
+To reduce the cost of adding and maintaining chat-style channels, `src/notification_channel.rs`
+defines a common `NotificationChannel` trait:
+
+```rust
+#[async_trait::async_trait]
+pub trait NotificationChannel: Send + Sync {
+    fn channel_name(&self) -> &'static str;
+
+    async fn send_event_notification(
+        &self,
+        event: &SorobanEvent,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>>;
+}
+```
+
+`DiscordClient` and `TelegramClient` implement this trait, so callers that only need to
+deliver a plain event notification can hold a `&dyn NotificationChannel` instead of a
+concrete client type. Channel-specific behavior (thread replies, inline buttons, webhook
+setup, etc.) remains on each client's own methods — the trait only standardizes the shared
+"send an event" path.
+
+To add a new chat-style channel: implement `channel_name()` and `send_event_notification()`
+for your client type in `notification_channel.rs`, delegating to the client's own
+notification method as the Discord and Telegram implementations do.

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,6 +59,7 @@ mod github;
 mod discord;
 mod slack;
 mod telegram;
+mod notification_channel;
 mod integration_handlers;
 mod retry_policy;
 mod sms;

--- a/src/notification_channel.rs
+++ b/src/notification_channel.rs
@@ -1,0 +1,52 @@
+/// Unified Notification Channel Interface (Issue #809)
+///
+/// A minimal common contract that notification channels (Discord, Telegram,
+/// Slack, etc.) can implement so callers can send an event notification
+/// without knowing which concrete channel they're talking to. Existing
+/// channel-specific methods (e.g. thread replies, buttons) remain available
+/// directly on each client; this trait covers the shared "send an event"
+/// path described in `docs/notification-channels.md`.
+use crate::discord::DiscordClient;
+use crate::models::SorobanEvent;
+use crate::telegram::TelegramClient;
+
+#[async_trait::async_trait]
+pub trait NotificationChannel: Send + Sync {
+    /// Short, stable identifier for this channel (e.g. "discord", "telegram").
+    fn channel_name(&self) -> &'static str;
+
+    /// Send a notification for `event` through this channel, returning a
+    /// provider-specific message identifier on success.
+    async fn send_event_notification(
+        &self,
+        event: &SorobanEvent,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>>;
+}
+
+#[async_trait::async_trait]
+impl NotificationChannel for DiscordClient {
+    fn channel_name(&self) -> &'static str {
+        "discord"
+    }
+
+    async fn send_event_notification(
+        &self,
+        event: &SorobanEvent,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        DiscordClient::send_event_notification(self, event, None).await
+    }
+}
+
+#[async_trait::async_trait]
+impl NotificationChannel for TelegramClient {
+    fn channel_name(&self) -> &'static str {
+        "telegram"
+    }
+
+    async fn send_event_notification(
+        &self,
+        event: &SorobanEvent,
+    ) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        TelegramClient::send_event_notification(self, event).await
+    }
+}


### PR DESCRIPTION
## Summary
- Add a `NotificationChannel` trait (`src/notification_channel.rs`) defining a common `channel_name()` + `send_event_notification()` contract for chat-style channels.
- Implement it for `DiscordClient` and `TelegramClient`, delegating to their existing `send_event_notification` methods so callers can hold a `&dyn NotificationChannel` instead of a concrete client type.
- Document the interface and the pattern for adding a new channel in `docs/notification-channels.md` (`#809 – Unified Channel Interface` section).

This is a first, minimal step toward the broader channel-architecture simplification tracked in #809: it standardizes the shared "send an event" path without touching each channel's existing thread/button/webhook-specific methods.

Closes #809

## Validation performed
- Manual review of trait/impl signatures against the existing `DiscordClient::send_event_notification` and `TelegramClient::send_event_notification` method signatures for parameter/return-type compatibility.
- Note: `cargo build` on `main` currently fails with ~291 pre-existing compile errors across unrelated files (e.g. `adaptive_pool.rs`, `slo_tracker.rs`, `handlers.rs`, missing `DATABASE_URL` for `sqlx::query!` macros), which blocks compiling the `soroban-pulse` lib crate the binary depends on and prevented running a full `cargo build`/`clippy` pass end-to-end. These failures are pre-existing and out of scope for this change.